### PR TITLE
Fixes for Budokai 1 to boot further

### DIFF
--- a/Source/PS2OS.cpp
+++ b/Source/PS2OS.cpp
@@ -1385,13 +1385,28 @@ void CPS2OS::sc_AddDmacHandler()
 	//0  -> At the start
 	//n  -> After handler 'n'
 
-	if(next != 0)
-	{
-		assert(0);
-	}
-
 	uint32 id = m_dmacHandlers.Allocate();
 	if(id == 0xFFFFFFFF)
+	{
+		m_ee.m_State.nGPR[SC_RETURN].nD0 = -1;
+		return;
+	}
+
+	switch (next)
+	{
+	case -1:
+	{
+		id = m_dmacHandlers.End();
+		break;
+	}
+	default:
+	{
+		id = next + m_dmacHandlers.Begin();
+		break;
+	}
+	}
+
+	if (id > 127)
 	{
 		m_ee.m_State.nGPR[SC_RETURN].nD0 = -1;
 		return;


### PR DESCRIPTION
This implements more features of AddDmacHandler so that Budokai 1 boots further.