### PR TITLE
Cleanup test project files a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ ReleaseAot
 *.aps
 *.ipch
 *.sdf
+*.opensdf
 *.suo
 *.user
 *.userprops

--- a/build_win32/MipsTest.vcxproj
+++ b/build_win32/MipsTest.vcxproj
@@ -199,7 +199,6 @@
     <ClInclude Include="..\Source\MipsExecutor.h" />
     <ClInclude Include="..\Source\MIPSInstructionFactory.h" />
     <ClInclude Include="..\Source\MipsJitter.h" />
-    <ClInclude Include="..\Source\MIPSModule.h" />
     <ClInclude Include="..\Source\MIPSReflection.h" />
     <ClInclude Include="..\Source\MIPSTags.h" />
     <ClInclude Include="..\tools\MipsTest\Add64Test.h" />

--- a/build_win32/MipsTest.vcxproj.filters
+++ b/build_win32/MipsTest.vcxproj.filters
@@ -138,9 +138,6 @@
     <ClInclude Include="..\Source\MipsJitter.h">
       <Filter>Source Files\Play Core</Filter>
     </ClInclude>
-    <ClInclude Include="..\Source\MIPSModule.h">
-      <Filter>Source Files\Play Core</Filter>
-    </ClInclude>
     <ClInclude Include="..\Source\MIPSReflection.h">
       <Filter>Source Files\Play Core</Filter>
     </ClInclude>

--- a/build_win32/VuTest.vcxproj
+++ b/build_win32/VuTest.vcxproj
@@ -196,7 +196,6 @@
     <ClInclude Include="..\Source\MipsExecutor.h" />
     <ClInclude Include="..\Source\MIPSInstructionFactory.h" />
     <ClInclude Include="..\Source\MipsJitter.h" />
-    <ClInclude Include="..\Source\MIPSModule.h" />
     <ClInclude Include="..\Source\MIPSReflection.h" />
     <ClInclude Include="..\Source\MIPSTags.h" />
     <ClInclude Include="..\Source\VuBasicBlock.h" />

--- a/build_win32/VuTest.vcxproj.filters
+++ b/build_win32/VuTest.vcxproj.filters
@@ -126,9 +126,6 @@
     <ClInclude Include="..\Source\MipsJitter.h">
       <Filter>Source Files\Play Core</Filter>
     </ClInclude>
-    <ClInclude Include="..\Source\MIPSModule.h">
-      <Filter>Source Files\Play Core</Filter>
-    </ClInclude>
     <ClInclude Include="..\Source\MIPSReflection.h">
       <Filter>Source Files\Play Core</Filter>
     </ClInclude>


### PR DESCRIPTION
This fixes the test projects being dirty every time you build, and also ignores another project.

By the way, I would recommend having some instructions on how to setup the build.  It seems like a bit of a pain.  It's great when users are able to easily build the project because they can provide test results and even debugging results for games you don't own.  Just my opinion.

-[Unknown]