### PR TITLE
Add support for CSO compressed files

### DIFF
--- a/Source/CsoImageStream.cpp
+++ b/Source/CsoImageStream.cpp
@@ -19,7 +19,7 @@ struct CsoHeader
 	uint8 reserved[2];
 };
 
-CCsoImageStream::CCsoImageStream(CStream *baseStream)
+CCsoImageStream::CCsoImageStream(CStream* baseStream)
 	: m_baseStream(baseStream), m_readBuffer(nullptr), m_zlibBuffer(nullptr), m_index(nullptr), m_position(0)
 {
 	if(baseStream == nullptr)
@@ -128,10 +128,10 @@ bool CCsoImageStream::IsEOF()
 	return m_position >= GetTotalSize();
 }
 
-uint64 CCsoImageStream::Read(void *buffer, uint64 size)
+uint64 CCsoImageStream::Read(void* buffer, uint64 size)
 {
 	uint64 remaining = size;
-	uint8 *dest = reinterpret_cast<uint8 *>(buffer);
+	uint8* dest = reinterpret_cast<uint8*>(buffer);
 
 	// We read only one frame at a time for now.
 	while(remaining > 0 && !IsEOF())
@@ -145,7 +145,7 @@ uint64 CCsoImageStream::Read(void *buffer, uint64 size)
 	return size - remaining;
 }
 
-uint64 CCsoImageStream::Write(const void *buffer, uint64 size)
+uint64 CCsoImageStream::Write(const void* buffer, uint64 size)
 {
 	throw std::exception("Unable to write to CSO, read only.");
 }
@@ -155,7 +155,7 @@ uint64 CCsoImageStream::GetTotalSize() const
 	return m_totalSize;
 }
 
-uint32 CCsoImageStream::ReadFromNextFrame(uint8 *dest, uint64 maxBytes)
+uint32 CCsoImageStream::ReadFromNextFrame(uint8* dest, uint64 maxBytes)
 {
 	assert(!IsEOF());
 
@@ -227,7 +227,7 @@ void CCsoImageStream::DecompressFrame(uint32 frame, uint64 readBufferSize)
 	m_zlibBufferFrame = frame;
 }
 
-uint64 CCsoImageStream::ReadBaseAt(uint64 pos, uint8 *dest, uint64 bytes)
+uint64 CCsoImageStream::ReadBaseAt(uint64 pos, uint8* dest, uint64 bytes)
 {
 	m_baseStream->Seek(pos, Framework::STREAM_SEEK_SET);
 	return m_baseStream->Read(dest, bytes);

--- a/Source/CsoImageStream.cpp
+++ b/Source/CsoImageStream.cpp
@@ -1,0 +1,234 @@
+#include <algorithm>
+#include <assert.h>
+#include "CsoImageStream.h"
+#include "zlib.h"
+
+typedef uint32 uint32_le;
+typedef uint64 uint64_le;
+
+static const uint32 CSO_READ_BUFFER_SIZE = 256 * 1024;
+
+struct CsoHeader
+{
+	uint8 magic[4];
+	uint32_le header_size;
+	uint64_le total_bytes;
+	uint32_le frame_size;
+	uint8 ver;
+	uint8 align;
+	uint8 reserved[2];
+};
+
+CCsoImageStream::CCsoImageStream(CStream *baseStream)
+	: m_baseStream(baseStream), m_readBuffer(nullptr), m_zlibBuffer(nullptr), m_index(nullptr), m_position(0)
+{
+	if(baseStream == nullptr)
+	{
+		throw std::runtime_error("Null base stream supplied.");
+	}
+
+	ReadFileHeader();
+	InitializeBuffers();
+}
+
+CCsoImageStream::~CCsoImageStream()
+{
+	delete [] m_readBuffer;
+	delete [] m_zlibBuffer;
+	delete [] m_index;
+}
+
+void CCsoImageStream::ReadFileHeader()
+{
+	CsoHeader hdr = {};
+
+	m_baseStream->Seek(0, Framework::STREAM_SEEK_SET);
+	if(m_baseStream->Read(&hdr, sizeof(CsoHeader)) != sizeof(CsoHeader))
+	{
+		throw std::runtime_error("Could not read full CSO header.");
+	}
+
+	if(hdr.magic[0] != 'C' || hdr.magic[1] != 'I' || hdr.magic[2] != 'S' || hdr.magic[3] != 'O')
+	{
+		throw std::runtime_error("Not a valid CSO file.");
+	}
+	if(hdr.ver > 1)
+	{
+		throw std::runtime_error("Only CSOv1 supported right now.");
+	}
+
+	m_frameSize = hdr.frame_size;
+	if((m_frameSize & (m_frameSize - 1)) != 0)
+	{
+		throw std::runtime_error("CSO frame size must be a power of two.");
+	}
+	if(m_frameSize < 0x800)
+	{
+		throw std::runtime_error("CSO frame size must be at least one sector.");
+	}
+
+	// Determine the translation from bytes to frame.
+	m_frameShift = 0;
+	for(uint32 i = m_frameSize; i > 1; i >>= 1)
+	{
+		++m_frameShift;
+	}
+
+	m_indexShift = hdr.align;
+	m_totalSize = hdr.total_bytes;
+}
+
+void CCsoImageStream::InitializeBuffers()
+{
+	uint32 numFrames = static_cast<uint32>((m_totalSize + m_frameSize - 1) / m_frameSize);
+
+	// We might read a bit of alignment too, so be prepared.
+	if(m_frameSize + (1 << m_indexShift) < CSO_READ_BUFFER_SIZE)
+	{
+		m_readBuffer = new uint8[CSO_READ_BUFFER_SIZE];
+	}
+	else
+	{
+		m_readBuffer = new uint8[m_frameSize + (1 << m_indexShift)];
+	}
+	m_zlibBuffer = new uint8[m_frameSize + (1 << m_indexShift)];
+	m_zlibBufferFrame = numFrames;
+
+	const uint32 indexSize = numFrames + 1;
+	m_index = new uint32[indexSize];
+	if(m_baseStream->Read(m_index, sizeof(uint32) * indexSize) != sizeof(uint32) * indexSize)
+	{
+		throw std::runtime_error("Unable to read CSO index.");
+	}
+}
+
+void CCsoImageStream::Seek(int64 position, Framework::STREAM_SEEK_DIRECTION origin)
+{
+	switch (origin)
+	{
+	case Framework::STREAM_SEEK_CUR:
+		m_position += position;
+		break;
+	case Framework::STREAM_SEEK_SET:
+		m_position = position;
+		break;
+	case Framework::STREAM_SEEK_END:
+		m_position = GetTotalSize() + position;
+		break;
+	}
+}
+
+uint64 CCsoImageStream::Tell()
+{
+	return m_position;
+}
+
+bool CCsoImageStream::IsEOF()
+{
+	return m_position >= GetTotalSize();
+}
+
+uint64 CCsoImageStream::Read(void *buffer, uint64 size)
+{
+	uint64 remaining = size;
+	uint8 *dest = reinterpret_cast<uint8 *>(buffer);
+
+	// We read only one frame at a time for now.
+	while(remaining > 0 && !IsEOF())
+	{
+		uint32 bytes = ReadFromNextFrame(dest, remaining);
+		remaining -= bytes;
+		m_position += bytes;
+		dest += bytes;
+	}
+
+	return size - remaining;
+}
+
+uint64 CCsoImageStream::Write(const void *buffer, uint64 size)
+{
+	throw std::exception("Unable to write to CSO, read only.");
+}
+
+uint64 CCsoImageStream::GetTotalSize() const
+{
+	return m_totalSize;
+}
+
+uint32 CCsoImageStream::ReadFromNextFrame(uint8 *dest, uint64 maxBytes)
+{
+	assert(!IsEOF());
+
+	const uint32 frame = static_cast<uint32>(m_position >> m_frameShift);
+	const uint32 offset = static_cast<uint32>(m_position - (frame << m_frameShift));
+	// This is how many bytes we will actually be reading from this frame.
+	const uint32 bytes = static_cast<uint32>(std::min(maxBytes, static_cast<uint64>(m_frameSize - offset)));
+
+	// Grab the index data for the frame we're about to read.
+	const bool compressed = (m_index[frame + 0] & 0x80000000) == 0;
+	const uint32 index0 = m_index[frame + 0] & 0x7FFFFFFF;
+	const uint32 index1 = m_index[frame + 1] & 0x7FFFFFFF;
+
+	// Calculate where the compressed payload is (if compressed.)
+	const uint64 frameRawPos = static_cast<uint64>(index0) << m_indexShift;
+	const uint64 frameRawSize = (index1 - index0) << m_indexShift;
+
+	if(!compressed)
+	{
+		// Just read directly, easy.
+		if(ReadBaseAt(frameRawPos + offset, dest, bytes) != bytes)
+		{
+			throw std::exception("Unable to read uncompressed bytes from CSO.");
+		}
+	}
+	else
+	{
+		// We don't need to decompress if we already did this same frame last time.
+		if(m_zlibBufferFrame != frame)
+		{
+			// This might be less bytes than frameRawSize in case of padding on the last frame.
+			// This is because the index positions must be aligned.
+			const uint64 readRawBytes = ReadBaseAt(frameRawPos, m_readBuffer, frameRawSize);
+			DecompressFrame(frame, readRawBytes);
+		}
+
+		// Now we just copy the offset data from the cache.
+		memcpy(dest, m_zlibBuffer + offset, bytes);
+	}
+
+	return bytes;
+}
+
+void CCsoImageStream::DecompressFrame(uint32 frame, uint64 readBufferSize)
+{
+	z_stream z;
+	z.zalloc = Z_NULL;
+	z.zfree = Z_NULL;
+	z.opaque = Z_NULL;
+	if(inflateInit2(&z, -15) != Z_OK)
+	{
+		throw std::exception("Unable to initialize zlib for CSO decompression.");
+	}
+
+	z.next_in = m_readBuffer;
+	z.avail_in = static_cast<uint32>(readBufferSize);
+	z.next_out = m_zlibBuffer;
+	z.avail_out = m_frameSize;
+
+	int status = inflate(&z, Z_FINISH);
+	if(status != Z_STREAM_END || z.total_out != m_frameSize)
+	{
+		inflateEnd(&z);
+		throw std::exception("Unable to decompress CSO frame using zlib.");
+	}
+	inflateEnd(&z);
+
+	// Our buffer now contains this frame.
+	m_zlibBufferFrame = frame;
+}
+
+uint64 CCsoImageStream::ReadBaseAt(uint64 pos, uint8 *dest, uint64 bytes)
+{
+	m_baseStream->Seek(pos, Framework::STREAM_SEEK_SET);
+	return m_baseStream->Read(dest, bytes);
+}

--- a/Source/CsoImageStream.h
+++ b/Source/CsoImageStream.h
@@ -6,31 +6,31 @@
 class CCsoImageStream : public Framework::CStream
 {
 public:
-	                    CCsoImageStream(Framework::CStream *baseStream);
+	                    CCsoImageStream(Framework::CStream* baseStream);
 	virtual             ~CCsoImageStream();
 
 	virtual void        Seek(int64 pos, Framework::STREAM_SEEK_DIRECTION whence);
 	virtual uint64      Tell();
 	virtual bool        IsEOF();
-	virtual uint64      Read(void *dest, uint64 bytes);
-	virtual uint64      Write(const void *src, uint64 bytes);
+	virtual uint64      Read(void* dest, uint64 bytes);
+	virtual uint64      Write(const void* src, uint64 bytes);
 
 private:
 	void                ReadFileHeader();
 	void                InitializeBuffers();
 	uint64              GetTotalSize() const;
-	uint32              ReadFromNextFrame(uint8 *dest, uint64 maxBytes);
-	uint64              ReadBaseAt(uint64 pos, uint8 *dest, uint64 bytes);
+	uint32              ReadFromNextFrame(uint8* dest, uint64 maxBytes);
+	uint64              ReadBaseAt(uint64 pos, uint8* dest, uint64 bytes);
 	void                DecompressFrame(uint32 frame, uint64 readBufferSize);
 
-	Framework::CStream  *m_baseStream;
+	Framework::CStream* m_baseStream;
 	uint32              m_frameSize;
 	uint8               m_frameShift;
 	uint8               m_indexShift;
-	uint8               *m_readBuffer;
-	uint8               *m_zlibBuffer;
+	uint8*              m_readBuffer;
+	uint8*              m_zlibBuffer;
 	uint32              m_zlibBufferFrame;
-	uint32              *m_index;
+	uint32*             m_index;
 	uint64              m_totalSize;
 	uint64              m_position;
 };

--- a/Source/CsoImageStream.h
+++ b/Source/CsoImageStream.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Types.h"
+#include "Stream.h"
+
+class CCsoImageStream : public Framework::CStream
+{
+public:
+	                    CCsoImageStream(Framework::CStream *baseStream);
+	virtual             ~CCsoImageStream();
+
+	virtual void        Seek(int64 pos, Framework::STREAM_SEEK_DIRECTION whence);
+	virtual uint64      Tell();
+	virtual bool        IsEOF();
+	virtual uint64      Read(void *dest, uint64 bytes);
+	virtual uint64      Write(const void *src, uint64 bytes);
+
+private:
+	void                ReadFileHeader();
+	void                InitializeBuffers();
+	uint64              GetTotalSize() const;
+	uint32              ReadFromNextFrame(uint8 *dest, uint64 maxBytes);
+	uint64              ReadBaseAt(uint64 pos, uint8 *dest, uint64 bytes);
+	void                DecompressFrame(uint32 frame, uint64 readBufferSize);
+
+	Framework::CStream  *m_baseStream;
+	uint32              m_frameSize;
+	uint8               m_frameShift;
+	uint8               m_indexShift;
+	uint8               *m_readBuffer;
+	uint8               *m_zlibBuffer;
+	uint32              m_zlibBufferFrame;
+	uint32              *m_index;
+	uint64              m_totalSize;
+	uint64              m_position;
+};

--- a/Source/CsoImageStream.h
+++ b/Source/CsoImageStream.h
@@ -6,31 +6,31 @@
 class CCsoImageStream : public Framework::CStream
 {
 public:
-	                    CCsoImageStream(Framework::CStream* baseStream);
-	virtual             ~CCsoImageStream();
+						CCsoImageStream(Framework::CStream* baseStream);
+	virtual				~CCsoImageStream();
 
-	virtual void        Seek(int64 pos, Framework::STREAM_SEEK_DIRECTION whence);
-	virtual uint64      Tell();
-	virtual bool        IsEOF();
-	virtual uint64      Read(void* dest, uint64 bytes);
-	virtual uint64      Write(const void* src, uint64 bytes);
+	virtual void		Seek(int64 pos, Framework::STREAM_SEEK_DIRECTION whence) override;
+	virtual uint64		Tell() override;
+	virtual bool		IsEOF() override;
+	virtual uint64		Read(void* dest, uint64 bytes) override;
+	virtual uint64		Write(const void* src, uint64 bytes) override;
 
 private:
-	void                ReadFileHeader();
-	void                InitializeBuffers();
-	uint64              GetTotalSize() const;
-	uint32              ReadFromNextFrame(uint8* dest, uint64 maxBytes);
-	uint64              ReadBaseAt(uint64 pos, uint8* dest, uint64 bytes);
-	void                DecompressFrame(uint32 frame, uint64 readBufferSize);
+	void				ReadFileHeader();
+	void				InitializeBuffers();
+	uint64				GetTotalSize() const;
+	uint32				ReadFromNextFrame(uint8* dest, uint64 maxBytes);
+	uint64				ReadBaseAt(uint64 pos, uint8* dest, uint64 bytes);
+	void				DecompressFrame(uint32 frame, uint64 readBufferSize);
 
-	Framework::CStream* m_baseStream;
-	uint32              m_frameSize;
-	uint8               m_frameShift;
-	uint8               m_indexShift;
-	uint8*              m_readBuffer;
-	uint8*              m_zlibBuffer;
-	uint32              m_zlibBufferFrame;
-	uint32*             m_index;
-	uint64              m_totalSize;
-	uint64              m_position;
+	Framework::CStream*	m_baseStream;
+	uint32				m_frameSize;
+	uint8				m_frameShift;
+	uint8				m_indexShift;
+	uint8*				m_readBuffer;
+	uint8*				m_zlibBuffer;
+	uint32				m_zlibBufferFrame;
+	uint32*				m_index;
+	uint64				m_totalSize;
+	uint64				m_position;
 };

--- a/Source/IszImageStream.h
+++ b/Source/IszImageStream.h
@@ -10,11 +10,11 @@ public:
                         CIszImageStream(Framework::CStream*);
     virtual             ~CIszImageStream();
 
-    virtual void        Seek(int64, Framework::STREAM_SEEK_DIRECTION);
-    virtual uint64      Tell();
-    virtual uint64      Read(void*, uint64);
-    virtual uint64      Write(const void*, uint64);
-    virtual bool        IsEOF();
+    virtual void        Seek(int64, Framework::STREAM_SEEK_DIRECTION) override;
+    virtual uint64      Tell() override;
+    virtual uint64      Read(void*, uint64) override;
+    virtual uint64      Write(const void*, uint64) override;
+    virtual bool        IsEOF() override;
 
 private:
 #pragma pack(push, 1)

--- a/Source/PS2VM.cpp
+++ b/Source/PS2VM.cpp
@@ -20,6 +20,7 @@
 #include "Posix_VolumeStream.h"
 #endif
 #include "stricmp.h"
+#include "CsoImageStream.h"
 #include "IszImageStream.h"
 #include "MemoryStateFile.h"
 #include "zip/ZipArchiveWriter.h"
@@ -689,6 +690,10 @@ void CPS2VM::CDROM0_Mount(const char* path)
 			if(!stricmp(extension, ".isz"))
 			{
 				stream = new CIszImageStream(new Framework::CStdStream(path, "rb"));
+			}
+			else if(!stricmp(extension, ".cso"))
+			{
+				stream = new CCsoImageStream(new Framework::CStdStream(path, "rb"));
 			}
 #ifdef WIN32
 			else if(path[0] == '\\')

--- a/Source/macosxui/ApplicationDelegate.mm
+++ b/Source/macosxui/ApplicationDelegate.mm
@@ -73,7 +73,7 @@
 -(IBAction)bootDiskImageMenuSelected: (id)sender
 {
 	NSOpenPanel* openPanel = [NSOpenPanel openPanel];
-	NSArray* fileTypes = [NSArray arrayWithObjects: @"iso", @"isz", nil];
+	NSArray* fileTypes = [NSArray arrayWithObjects: @"iso", @"isz", @"cso", nil];
 	openPanel.allowedFileTypes = fileTypes;
 	openPanel.canChooseDirectories = NO;
 	if([openPanel runModal] != NSOKButton)

--- a/Source/macosxui/VfsManagerBindings.mm
+++ b/Source/macosxui/VfsManagerBindings.mm
@@ -221,7 +221,7 @@
 -(void)requestModification
 {
 	NSOpenPanel* openPanel = [NSOpenPanel openPanel];
-	NSArray* fileTypes = [NSArray arrayWithObjects: @"iso", @"isz", nil];
+	NSArray* fileTypes = [NSArray arrayWithObjects: @"iso", @"isz", @"cso", nil];
 	if([openPanel runModalForTypes:fileTypes] != NSOKButton)
 	{
 		return;

--- a/Source/win32ui/FileFilters.h
+++ b/Source/win32ui/FileFilters.h
@@ -5,7 +5,7 @@
         _T("All supported types\0*.iso;*.bin;*.isz;*.cso\0") \
         _T("ISO9660 Disk Images (*.iso; *.bin)\0*.iso;*.bin\0") \
         _T("UltraISO Compressed Disk Images (*.isz)\0*.isz\0") \
-		_T("CISO Compressed Disk Images (*.cso)\0*.cso\0") \
+        _T("CISO Compressed Disk Images (*.cso)\0*.cso\0") \
         _T("All files (*.*)\0*.*\0")
 
 #endif

--- a/Source/win32ui/FileFilters.h
+++ b/Source/win32ui/FileFilters.h
@@ -2,9 +2,10 @@
 #define _FILEFILTERS_H_
 
 #define DISKIMAGE_FILTER \
-        _T("All supported types\0*.iso;*.bin;*.isz\0") \
+        _T("All supported types\0*.iso;*.bin;*.isz;*.cso\0") \
         _T("ISO9660 Disk Images (*.iso; *.bin)\0*.iso;*.bin\0") \
         _T("UltraISO Compressed Disk Images (*.isz)\0*.isz\0") \
+		_T("CISO Compressed Disk Images (*.cso)\0*.cso\0") \
         _T("All files (*.*)\0*.*\0")
 
 #endif

--- a/build_win32/Play.vcxproj
+++ b/build_win32/Play.vcxproj
@@ -256,6 +256,7 @@
     <ClCompile Include="..\Source\COP_SCU_Reflection.cpp" />
     <ClCompile Include="..\Source\COP_VU.cpp" />
     <ClCompile Include="..\Source\COP_VU_Reflection.cpp" />
+    <ClCompile Include="..\Source\CsoImageStream.cpp" />
     <ClCompile Include="..\Source\DMAC.cpp" />
     <ClCompile Include="..\Source\Dmac_Channel.cpp" />
     <ClCompile Include="..\Source\EEAssembler.cpp" />
@@ -484,6 +485,7 @@
     <ClInclude Include="..\Source\COP_FPU.h" />
     <ClInclude Include="..\Source\COP_SCU.h" />
     <ClInclude Include="..\Source\COP_VU.h" />
+    <ClInclude Include="..\Source\CsoImageStream.h" />
     <ClInclude Include="..\Source\DMAC.h" />
     <ClInclude Include="..\Source\Dmac_Channel.h" />
     <ClInclude Include="..\Source\EEAssembler.h" />

--- a/build_win32/Play.vcxproj.filters
+++ b/build_win32/Play.vcxproj.filters
@@ -664,6 +664,9 @@
     <ClCompile Include="..\Source\iop\Iop_LibSd.cpp">
       <Filter>Source Files\Core\Iop\Modules</Filter>
     </ClCompile>
+    <ClCompile Include="..\Source\CsoImageStream.cpp">
+      <Filter>Source Files\Core</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Source\AppConfig.h">
@@ -1295,6 +1298,9 @@
     </ClInclude>
     <ClInclude Include="..\Source\iop\Iop_LibSd.h">
       <Filter>Source Files\Core\Iop\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Source\CsoImageStream.h">
+      <Filter>Source Files\Core</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I don't have UltraISO, and searching for isz casually didn't yield any alternative compressors.  Since I already [wrote a CSO compressor](https://github.com/unknownbrackets/maxcso) for PPSSPP (though there are many slower ones available), I figured it'd be pretty easy to add support for CSO files.

CSOs are block based and fairly simple.  Some tools may not be able to handle > 4GB files, since PSP games could not be larger than 1.8GB, but this patch can, and so can maxcso (well, after a fix I just made to it.)

IMHO it might be nice to put the different ImageStreams into their own directory, though.

(this implementation is mostly just PPSSPP's implementation, although that one reads full sectors so I changed some things.  It also has larger disk reads when reading more bytes, but I didn't port that over yet.)

-[Unknown]