### PR TITLE
Android: Some changes to navigation bar functions

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/EmulatorActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/EmulatorActivity.java
@@ -18,6 +18,12 @@ public class EmulatorActivity extends Activity
 		setContentView(R.layout.emulator);
 
 		getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+		getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
+				View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
+				View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
+				View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
+				View.SYSTEM_UI_FLAG_FULLSCREEN |
+				View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
 		
 		_renderView = (SurfaceView)findViewById(R.id.emulator_view);
 		SurfaceHolder holder = _renderView.getHolder();

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -44,6 +44,16 @@ public class MainActivity extends Activity
 		updateFileListView();
 	}
 
+	@Override
+	public void onBackPressed()
+	{
+		File currentDirectoryFile = new File(getCurrentDirectory());
+		File parentDirectoryFile = currentDirectoryFile.getParentFile();
+		if(parentDirectoryFile == null) return;
+		setCurrentDirectory(currentDirectoryFile.getParentFile().getAbsolutePath());
+		updateFileListView();
+	}
+
 	private static long getBuildDate(Context context) 
 	{
 		try


### PR DESCRIPTION
Just some small changes to how the navigation buttons act in the Android UI:
-On devices with on-screen navigation buttons, the navigation buttons will be hidden during emulation allowing for the full screen to be used
-In the file browser, pressing the back button will bring the user to the parent directory instead of just closing the app