### PR TITLE
Android: Add a setting to enable or disable FPS

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/EmulatorActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/EmulatorActivity.java
@@ -1,6 +1,7 @@
 package com.virtualapplications.play;
 
 import android.app.*;
+import android.content.*;
 import android.os.*;
 import android.util.*;
 import android.view.*;
@@ -34,8 +35,12 @@ public class EmulatorActivity extends Activity
 		SurfaceHolder holder = _renderView.getHolder();
 		holder.addCallback(new SurfaceCallback());
 		
-		_statsTextView = (TextView)findViewById(R.id.emulator_stats);
-		setupStatsTimer();
+		final SharedPreferences _preferences = getSharedPreferences("prefs", MODE_PRIVATE);
+		if (_preferences.getBoolean("fpsValue", false))
+		{
+			_statsTextView = (TextView)findViewById(R.id.emulator_stats);
+			setupStatsTimer();
+		}
 	}
 	
 	@Override

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -30,7 +30,7 @@ public class MainActivity extends Activity
 		
 		setContentView(R.layout.main);
 		
-		_preferences = getPreferences(MODE_PRIVATE);
+		_preferences = getSharedPreferences("prefs", MODE_PRIVATE);
 		
 		File filesDir = getFilesDir();
 		NativeInterop.setFilesDirPath(Environment.getExternalStorageDirectory().getAbsolutePath());
@@ -101,6 +101,23 @@ public class MainActivity extends Activity
 		displaySimpleMessage("About Play!", aboutMessage);
 	}
 	
+	private void setFps(MenuItem item)
+	{
+		SharedPreferences.Editor preferencesEditor = _preferences.edit();
+
+		if (item.isChecked())
+		{
+			preferencesEditor.putBoolean("fpsValue", false);
+		}
+		else
+		{
+			preferencesEditor.putBoolean("fpsValue", true);
+		}
+		preferencesEditor.commit();
+
+		item.setChecked(_preferences.getBoolean("fpsValue", false));
+	}
+	
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) 
 	{
@@ -110,12 +127,22 @@ public class MainActivity extends Activity
 	}
 	
 	@Override
+	public boolean onPrepareOptionsMenu(Menu menu)
+	{
+		menu.getItem(1).setChecked(_preferences.getBoolean("fpsValue", false));
+		return super.onPrepareOptionsMenu(menu);
+	}
+	
+	@Override
 	public boolean onOptionsItemSelected(MenuItem item) 
 	{
 		switch(item.getItemId()) 
 		{
 		case R.id.main_menu_about:
 			displayAboutDialog();
+			return true;
+		case R.id.main_menu_fps:
+			setFps(item);
 			return true;
 		default:
 			return super.onOptionsItemSelected(item);

--- a/build_android/res/layout/emulator.xml
+++ b/build_android/res/layout/emulator.xml
@@ -21,6 +21,5 @@
 		android:id="@+id/emulator_stats"
 		android:layout_width="wrap_content" 
 		android:layout_height="wrap_content" 
-		android:text="Test string label stuff" 
 	/>
 </FrameLayout>

--- a/build_android/res/layout/main_menu.xml
+++ b/build_android/res/layout/main_menu.xml
@@ -5,4 +5,10 @@
 		android:title="@string/main_menu_about"
 		android:showAsAction="never" 
 	/>
+	<item
+		android:id="@+id/main_menu_fps"
+		android:title="@string/main_menu_fps"
+		android:showAsAction="never"
+		android:checkable="true"
+	/>
 </menu>

--- a/build_android/res/values/strings.xml
+++ b/build_android/res/values/strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="app_name">Play!</string>
 	<string name="main_menu_about">About</string>
+	<string name="main_menu_fps">Enable FPS</string>
 </resources>


### PR DESCRIPTION
By default the option is disabled. I didn't think one option was enough to create an entire settings menu yet, so I just added a checkable item to the menu in the file browser, under About.