### PR TITLE
Injectable vpu

### DIFF
--- a/Source/PS2VM.cpp
+++ b/Source/PS2VM.cpp
@@ -506,7 +506,7 @@ void CPS2VM::ResumeImpl()
 #ifdef DEBUGGER_INCLUDED
 	m_ee->m_executor.DisableBreakpointsOnce();
 	m_iop->m_executor.DisableBreakpointsOnce();
-	m_ee->m_vpu1.DisableBreakpointsOnce();
+	m_ee->m_vpu1->DisableBreakpointsOnce();
 #endif
 	m_nStatus = RUNNING;
 }
@@ -860,14 +860,14 @@ void CPS2VM::EmuThread()
 				UpdateEe();
 				UpdateIop();
 
-				m_ee->m_vpu0.Execute(m_singleStepVu0);
-				m_ee->m_vpu1.Execute(m_singleStepVu1);
+				m_ee->m_vpu0->Execute(m_singleStepVu0);
+				m_ee->m_vpu1->Execute(m_singleStepVu1);
 			}
 #ifdef DEBUGGER_INCLUDED
 			if(
 			   m_ee->m_executor.MustBreak() || 
 			   m_iop->m_executor.MustBreak() ||
-			   m_ee->m_vpu1.MustBreak() ||
+			   m_ee->m_vpu1->MustBreak() ||
 			   m_singleStepEe || m_singleStepIop || m_singleStepVu0 || m_singleStepVu1)
 			{
 				m_nStatus = PAUSED;

--- a/Source/ee/Ee_SubSystem.cpp
+++ b/Source/ee/Ee_SubSystem.cpp
@@ -127,8 +127,8 @@ CSubSystem::CSubSystem(uint8* iopRam, CIopBios& iopBios)
 	m_VU0.m_vuMem = m_vuMem0;
 	m_VU1.m_vuMem = m_vuMem1;
 
-	m_dmac.SetChannelTransferFunction(0, bind(&CVif::ReceiveDMA, m_vpu0->GetVif(), PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_4));
-	m_dmac.SetChannelTransferFunction(1, bind(&CVif::ReceiveDMA, m_vpu1->GetVif(), PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_4));
+	m_dmac.SetChannelTransferFunction(0, bind(&CVif::ReceiveDMA, &m_vpu0->GetVif(), PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_4));
+	m_dmac.SetChannelTransferFunction(1, bind(&CVif::ReceiveDMA, &m_vpu1->GetVif(), PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_4));
 	m_dmac.SetChannelTransferFunction(2, bind(&CGIF::ReceiveDMA, &m_gif, PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_3, PLACEHOLDER_4));
 	m_dmac.SetChannelTransferFunction(4, bind(&CIPU::ReceiveDMA4, &m_ipu, PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_4, m_ram));
 	m_dmac.SetChannelTransferFunction(5, bind(&CSIF::ReceiveDMA5, &m_sif, PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_3, PLACEHOLDER_4));

--- a/Source/ee/Ee_SubSystem.cpp
+++ b/Source/ee/Ee_SubSystem.cpp
@@ -50,8 +50,8 @@ CSubSystem::CSubSystem(uint8* iopRam, CIopBios& iopBios)
 	assert((reinterpret_cast<size_t>(m_vuMem0) & 0x0F) == 0);
 	assert((reinterpret_cast<size_t>(m_vuMem1) & 0x0F) == 0);
 
-	m_vpu0 = new CVpu(0, CVpu::VPUINIT(m_microMem0, m_vuMem0, &m_VU0), m_gif, m_ram, m_spr);
-	m_vpu1 = new CVpu(1, CVpu::VPUINIT(m_microMem1, m_vuMem1, &m_VU1), m_gif, m_ram, m_spr);
+	m_vpu0 = std::make_shared<CVpu>(0, CVpu::VPUINIT(m_microMem0, m_vuMem0, &m_VU0), m_gif, m_ram, m_spr);
+	m_vpu1 = std::make_shared<CVpu>(1, CVpu::VPUINIT(m_microMem1, m_vuMem1, &m_VU1), m_gif, m_ram, m_spr);
 
 	//EmotionEngine context setup
 	{
@@ -149,23 +149,15 @@ CSubSystem::~CSubSystem()
 	framework_aligned_free(m_vuMem0);
 	framework_aligned_free(m_vuMem1);
 	delete m_os;
-	delete m_vpu0;
-	delete m_vpu1;
 }
 
-void CSubSystem::SetVpu0(CVpu* newVpu0)
+void CSubSystem::SetVpu0(std::shared_ptr<CVpu> newVpu0)
 {
-	if (newVpu0 != m_vpu0){
-		delete m_vpu0;
-	}
 	m_vpu0 = newVpu0;
 }
 
-void CSubSystem::SetVpu1(CVpu* newVpu1)
+void CSubSystem::SetVpu1(std::shared_ptr<CVpu> newVpu1)
 {
-	if (newVpu1 != m_vpu1){
-		delete m_vpu1;
-	}
 	m_vpu1 = newVpu1;
 }
 

--- a/Source/ee/Ee_SubSystem.cpp
+++ b/Source/ee/Ee_SubSystem.cpp
@@ -37,8 +37,6 @@ CSubSystem::CSubSystem(uint8* iopRam, CIopBios& iopBios)
 , m_dmac(m_ram, m_spr, m_vuMem0, m_EE)
 , m_gif(m_gs, m_ram, m_spr)
 , m_sif(m_dmac, m_ram, iopRam)
-, m_vpu0(0, CVpu::VPUINIT(m_microMem0, m_vuMem0, &m_VU0), m_gif, m_ram, m_spr)
-, m_vpu1(1, CVpu::VPUINIT(m_microMem1, m_vuMem1, &m_VU1), m_gif, m_ram, m_spr)
 , m_intc(m_dmac, m_gs)
 , m_timer(m_intc)
 , m_COP_SCU(MIPS_REGSIZE_64)
@@ -51,6 +49,9 @@ CSubSystem::CSubSystem(uint8* iopRam, CIopBios& iopBios)
 	assert((reinterpret_cast<size_t>(&m_VU1.m_State) & 0x0F) == 0);
 	assert((reinterpret_cast<size_t>(m_vuMem0) & 0x0F) == 0);
 	assert((reinterpret_cast<size_t>(m_vuMem1) & 0x0F) == 0);
+
+	m_vpu0 = new CVpu(0, CVpu::VPUINIT(m_microMem0, m_vuMem0, &m_VU0), m_gif, m_ram, m_spr);
+	m_vpu1 = new CVpu(1, CVpu::VPUINIT(m_microMem1, m_vuMem1, &m_VU1), m_gif, m_ram, m_spr);
 
 	//EmotionEngine context setup
 	{
@@ -126,8 +127,8 @@ CSubSystem::CSubSystem(uint8* iopRam, CIopBios& iopBios)
 	m_VU0.m_vuMem = m_vuMem0;
 	m_VU1.m_vuMem = m_vuMem1;
 
-	m_dmac.SetChannelTransferFunction(0, bind(&CVif::ReceiveDMA, &m_vpu0.GetVif(), PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_4));
-	m_dmac.SetChannelTransferFunction(1, bind(&CVif::ReceiveDMA, &m_vpu1.GetVif(), PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_4));
+	m_dmac.SetChannelTransferFunction(0, bind(&CVif::ReceiveDMA, m_vpu0->GetVif(), PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_4));
+	m_dmac.SetChannelTransferFunction(1, bind(&CVif::ReceiveDMA, m_vpu1->GetVif(), PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_4));
 	m_dmac.SetChannelTransferFunction(2, bind(&CGIF::ReceiveDMA, &m_gif, PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_3, PLACEHOLDER_4));
 	m_dmac.SetChannelTransferFunction(4, bind(&CIPU::ReceiveDMA4, &m_ipu, PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_4, m_ram));
 	m_dmac.SetChannelTransferFunction(5, bind(&CSIF::ReceiveDMA5, &m_sif, PLACEHOLDER_1, PLACEHOLDER_2, PLACEHOLDER_3, PLACEHOLDER_4));
@@ -148,6 +149,24 @@ CSubSystem::~CSubSystem()
 	framework_aligned_free(m_vuMem0);
 	framework_aligned_free(m_vuMem1);
 	delete m_os;
+	delete m_vpu0;
+	delete m_vpu1;
+}
+
+void CSubSystem::SetVpu0(CVpu* newVpu0)
+{
+	if (newVpu0 != m_vpu0){
+		delete m_vpu0;
+	}
+	m_vpu0 = newVpu0;
+}
+
+void CSubSystem::SetVpu1(CVpu* newVpu1)
+{
+	if (newVpu1 != m_vpu1){
+		delete m_vpu1;
+	}
+	m_vpu1 = newVpu1;
 }
 
 void CSubSystem::Reset()
@@ -180,8 +199,8 @@ void CSubSystem::Reset()
 	m_sif.Reset();
 	m_ipu.Reset();
 	m_gif.Reset();
-	m_vpu0.Reset();
-	m_vpu1.Reset();
+	m_vpu0->Reset();
+	m_vpu1->Reset();
 	m_dmac.Reset();
 	m_intc.Reset();
 	m_timer.Reset();
@@ -195,7 +214,7 @@ int CSubSystem::ExecuteCpu(int quota)
 	int executed = 0;
 	if(m_EE.m_State.callMsEnabled)
 	{
-		if(!m_vpu0.IsVuRunning())
+		if(!m_vpu0->IsVuRunning())
 		{
 			//callMs mode over
 			memcpy(&m_EE.m_State.nCOP2,		&m_VU0.m_State.nCOP2,	sizeof(m_EE.m_State.nCOP2));
@@ -220,12 +239,12 @@ int CSubSystem::ExecuteCpu(int quota)
 			if(m_EE.m_State.callMsEnabled)
 			{
 				//We are in callMs mode
-				assert(!m_vpu0.IsVuRunning());
+				assert(!m_vpu0->IsVuRunning());
 				//Copy the COP2 state to VPU0
 				memcpy(&m_VU0.m_State.nCOP2,	&m_EE.m_State.nCOP2,	sizeof(m_VU0.m_State.nCOP2));
 				memcpy(&m_VU0.m_State.nCOP2A,	&m_EE.m_State.nCOP2A,	sizeof(m_VU0.m_State.nCOP2A));
 				memcpy(&m_VU0.m_State.nCOP2VI,	&m_EE.m_State.nCOP2VI,	sizeof(m_VU0.m_State.nCOP2VI));
-				m_vpu0.ExecuteMicroProgram(m_EE.m_State.callMsAddr);
+				m_vpu0->ExecuteMicroProgram(m_EE.m_State.callMsAddr);
 				m_EE.m_State.nHasException = MIPS_EXCEPTION_NONE;
 			}
 			break;
@@ -271,14 +290,14 @@ bool CSubSystem::IsCpuIdle() const
 
 void CSubSystem::CountTicks(int ticks)
 {
-	if(!m_vpu0.IsVuRunning() || (m_vpu0.IsVuRunning() && !m_vpu0.GetVif().IsWaitingForProgramEnd()))
+	if(!m_vpu0->IsVuRunning() || (m_vpu0->IsVuRunning() && !m_vpu0->GetVif().IsWaitingForProgramEnd()))
 	{
 		m_dmac.ResumeDMA0();
 	}
-	if(!m_vpu1.IsVuRunning() || (m_vpu1.IsVuRunning() && !m_vpu1.GetVif().IsWaitingForProgramEnd()))
+	if(!m_vpu1->IsVuRunning() || (m_vpu1->IsVuRunning() && !m_vpu1->GetVif().IsWaitingForProgramEnd()))
 	{
 		m_dmac.ResumeDMA1();
-		if(m_vpu1.GetVif().IsStalledByInterrupt())
+		if(m_vpu1->GetVif().IsStalledByInterrupt())
 		{
 			m_intc.AssertLine(CINTC::INTC_LINE_VIF1);
 		}
@@ -328,8 +347,8 @@ void CSubSystem::SaveState(Framework::CZipArchiveWriter& archive)
 	m_dmac.SaveState(archive);
 	m_intc.SaveState(archive);
 	m_sif.SaveState(archive);
-	m_vpu0.SaveState(archive);
-	m_vpu1.SaveState(archive);
+	m_vpu0->SaveState(archive);
+	m_vpu1->SaveState(archive);
 	m_timer.SaveState(archive);
 }
 
@@ -348,8 +367,8 @@ void CSubSystem::LoadState(Framework::CZipArchiveReader& archive)
 	m_dmac.LoadState(archive);
 	m_intc.LoadState(archive);
 	m_sif.LoadState(archive);
-	m_vpu0.LoadState(archive);
-	m_vpu1.LoadState(archive);
+	m_vpu0->LoadState(archive);
+	m_vpu1->LoadState(archive);
 	m_timer.LoadState(archive);
 
 	m_executor.Reset();
@@ -372,11 +391,11 @@ uint32 CSubSystem::IOPortReadHandler(uint32 nAddress)
 	}
 	else if(nAddress >= CVif::REGS0_START && nAddress < CVif::REGS0_END)
 	{
-		nReturn = m_vpu0.GetVif().GetRegister(nAddress);
+		nReturn = m_vpu0->GetVif().GetRegister(nAddress);
 	}
 	else if(nAddress >= CVif::REGS1_START && nAddress < CVif::REGS1_END)
 	{
-		nReturn = m_vpu1.GetVif().GetRegister(nAddress);
+		nReturn = m_vpu1->GetVif().GetRegister(nAddress);
 	}
 	else if(nAddress >= 0x10008000 && nAddress <= 0x1000EFFC)
 	{
@@ -422,11 +441,11 @@ uint32 CSubSystem::IOPortWriteHandler(uint32 nAddress, uint32 nData)
 	}
 	else if(nAddress >= CVif::REGS0_START && nAddress < CVif::REGS0_END)
 	{
-		m_vpu0.GetVif().SetRegister(nAddress, nData);
+		m_vpu0->GetVif().SetRegister(nAddress, nData);
 	}
 	else if(nAddress >= CVif::REGS1_START && nAddress < CVif::REGS1_END)
 	{
-		m_vpu1.GetVif().SetRegister(nAddress, nData);
+		m_vpu1->GetVif().SetRegister(nAddress, nData);
 	}
 	else if(nAddress >= 0x10007000 && nAddress <= 0x1000702F)
 	{
@@ -470,7 +489,7 @@ uint32 CSubSystem::IOPortWriteHandler(uint32 nAddress, uint32 nData)
 uint32 CSubSystem::Vu0MicroMemWriteHandler(uint32 address, uint32 value)
 {
 	*reinterpret_cast<uint32*>(m_microMem0 + (address - PS2::MICROMEM0ADDR)) = value;
-	m_vpu0.InvalidateMicroProgram();
+	m_vpu0->InvalidateMicroProgram();
 	return 0;
 }
 
@@ -480,7 +499,7 @@ uint32 CSubSystem::Vu0IoPortReadHandler(uint32 address)
 	switch(address)
 	{
 	case CVpu::VU_ITOP:
-		result = m_vpu0.GetVif().GetITOP();
+		result = m_vpu0->GetVif().GetITOP();
 		break;
 	default:
 		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled VU0 IO port (0x%0.8X).\r\n", address);
@@ -507,10 +526,10 @@ uint32 CSubSystem::Vu1IoPortReadHandler(uint32 address)
 	switch(address)
 	{
 	case CVpu::VU_ITOP:
-		result = m_vpu1.GetVif().GetITOP();
+		result = m_vpu1->GetVif().GetITOP();
 		break;
 	case CVpu::VU_TOP:
-		result = m_vpu1.GetVif().GetTOP();
+		result = m_vpu1->GetVif().GetTOP();
 		break;
 	default:
 		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled VU1 IO port (0x%0.8X).\r\n", address);
@@ -524,7 +543,7 @@ uint32 CSubSystem::Vu1IoPortWriteHandler(uint32 address, uint32 value)
 	switch(address)
 	{
 	case CVpu::VU_XGKICK:
-		m_vpu1.ProcessXgKick(value);
+		m_vpu1->ProcessXgKick(value);
 		break;
 	default:
 		CLog::GetInstance().Print(LOG_NAME, "Wrote an unhandled VU1 IO port (0x%0.8X, 0x%0.8X).\r\n", 

--- a/Source/ee/Ee_SubSystem.h
+++ b/Source/ee/Ee_SubSystem.h
@@ -37,6 +37,9 @@ namespace Ee
 		void						SaveState(Framework::CZipArchiveWriter&);
 		void						LoadState(Framework::CZipArchiveReader&);
 
+		void						SetVpu0(CVpu*);
+		void						SetVpu1(CVpu*);
+
 		uint8*						m_ram = nullptr;
 		uint8*						m_bios = nullptr;
 		uint8*						m_spr = nullptr;
@@ -52,8 +55,8 @@ namespace Ee
 		CDMAC						m_dmac;
 		CGIF						m_gif;
 		CSIF						m_sif;
-		CVpu						m_vpu0;
-		CVpu						m_vpu1;
+		CVpu*						m_vpu0;
+		CVpu*						m_vpu1;
 		CINTC						m_intc;
 		CIPU						m_ipu;
 		CTimer						m_timer;

--- a/Source/ee/Ee_SubSystem.h
+++ b/Source/ee/Ee_SubSystem.h
@@ -37,8 +37,8 @@ namespace Ee
 		void						SaveState(Framework::CZipArchiveWriter&);
 		void						LoadState(Framework::CZipArchiveReader&);
 
-		void						SetVpu0(CVpu*);
-		void						SetVpu1(CVpu*);
+		void						SetVpu0(std::shared_ptr<CVpu>);
+		void						SetVpu1(std::shared_ptr<CVpu>);
 
 		uint8*						m_ram = nullptr;
 		uint8*						m_bios = nullptr;
@@ -55,8 +55,8 @@ namespace Ee
 		CDMAC						m_dmac;
 		CGIF						m_gif;
 		CSIF						m_sif;
-		CVpu*						m_vpu0;
-		CVpu*						m_vpu1;
+		std::shared_ptr<CVpu>		m_vpu0;
+		std::shared_ptr<CVpu>		m_vpu1;
 		CINTC						m_intc;
 		CIPU						m_ipu;
 		CTimer						m_timer;

--- a/Source/ee/Vpu.h
+++ b/Source/ee/Vpu.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "AlignedAlloc.h"
 #include "Types.h"
 #include "../MIPS.h"
 #include "../Profiler.h"
@@ -39,7 +40,17 @@ public:
 							CVpu(unsigned int, const VPUINIT&, CGIF&, uint8*, uint8*);
 	virtual					~CVpu();
 
-	virtual void			Execute(bool);
+	void* operator new(size_t allocSize)
+	{
+		return framework_aligned_alloc(allocSize, 0x10);
+	}
+
+	void operator delete(void* ptr)
+	{
+		return framework_aligned_free(ptr);
+	}
+
+	void			Execute(bool);
 	void					Reset();
 	void					SaveState(Framework::CZipArchiveWriter&);
 	void					LoadState(Framework::CZipArchiveReader&);

--- a/Source/ee/Vpu.h
+++ b/Source/ee/Vpu.h
@@ -39,7 +39,7 @@ public:
 							CVpu(unsigned int, const VPUINIT&, CGIF&, uint8*, uint8*);
 	virtual					~CVpu();
 
-	void					Execute(bool);
+	virtual void			Execute(bool);
 	void					Reset();
 	void					SaveState(Framework::CZipArchiveWriter&);
 	void					LoadState(Framework::CZipArchiveReader&);

--- a/Source/ee/Vpu.h
+++ b/Source/ee/Vpu.h
@@ -50,7 +50,7 @@ public:
 		return framework_aligned_free(ptr);
 	}
 
-	void			Execute(bool);
+	virtual void			Execute(bool);
 	void					Reset();
 	void					SaveState(Framework::CZipArchiveWriter&);
 	void					LoadState(Framework::CZipArchiveReader&);


### PR DESCRIPTION
See issue #60 
This PR makes the vpu objects heap allocated rather than stack allocated so that they can be injected at runtime rather than having their type fixed at compile time. This enables a user of the core library to provide specialised implementations (to enable enhanced features for specific games as an example).

I've tried to keep the changes in this PR as minimal as possible. I'm also open to other implementations that would provide similar configurability.

A 'better' or at least a more conventional solution would be to specify the m_vpux objects using a pure abstract interface rather than the heavyweight CVpu class. Currently any alternative implementation needs to extend CVpu - which is quite heavyweight. The downside with that approach of course is that all calls over the interface incur a vtable lookup.

Ian
