### PR TITLE
Android version to accept any case file extensions

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -151,11 +151,12 @@ public class MainActivity extends Activity
 	
 	private static boolean IsLoadableDiskImageFileName(String fileName)
 	{
-		return 
-				fileName.endsWith(".iso") || 
-				fileName.endsWith(".bin") ||
-				fileName.endsWith(".cso") || 
-				fileName.endsWith(".isz");
+		
+		return  
+				fileName.toLowerCase().endsWith(".iso") ||
+				fileName.toLowerCase().endsWith(".bin") ||
+				fileName.toLowerCase().endsWith(".cso") ||
+				fileName.toLowerCase().endsWith(".isz");
 	}
 	
 	private static FileListItem[] getFileList(String directoryPath)


### PR DESCRIPTION
(With regards to the issue #84)

This quick fix allows files in any case to be picked up by the file explorer by forcing the file names to lower case for the check

