### PR TITLE
Manifest updated to begin support for Android TV

### DIFF
--- a/build_android/AndroidManifest.xml
+++ b/build_android/AndroidManifest.xml
@@ -6,15 +6,21 @@
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="22" />
 	<uses-feature android:glEsVersion="0x00030000" android:required="true" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-feature android:name="android.hardware.gamepad" android:required="false"/>
+	<uses-feature android:name="android.software.leanback" android:required="false" />
+	<uses-feature android:name="android.hardware.touchscreen" android:required="false" />
 	<application 
 		android:label="@string/app_name"
 		android:icon="@drawable/ic_launcher">
+		android:banner="@drawable/banner" >
 		<activity 
 			android:name=".MainActivity"
 			android:configChanges="orientation|locale|keyboard|keyboardHidden|navigation"
 			android:label="@string/app_name">
+			android:isGame="true"
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
+				<category android:name="android.intent.category.LEANBACK_LAUNCHER" />
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
 		</activity>


### PR DESCRIPTION
I added a few changes so that the app will show up on the Android TV Leanback Launcher as well as declaring support for touchscreen as well as controllers.