### PR TITLE
Ubuntu: Fixed Case-sensitive Build Error

### DIFF
--- a/Source/PS2VM.h
+++ b/Source/PS2VM.h
@@ -6,7 +6,7 @@
 #include "MIPS.h"
 #include "MailBox.h"
 #include "PadHandler.h"
-#include "iso9660/ISO9660.h"
+#include "ISO9660/ISO9660.h"
 #include "VirtualMachine.h"
 #include "ee/Ee_SubSystem.h"
 #include "iop/Iop_SubSystem.h"

--- a/Source/ee/MA_VU_Upper.cpp
+++ b/Source/ee/MA_VU_Upper.cpp
@@ -1,7 +1,7 @@
 #include "MA_VU.h"
 #include "../MIPS.h"
 #include "VUShared.h"
-#include "VIF.h"
+#include "Vif.h"
 
 using namespace std;
 

--- a/Source/ee/Vif1.cpp
+++ b/Source/ee/Vif1.cpp
@@ -4,7 +4,7 @@
 #include "../RegisterStateFile.h"
 #include "../FrameDump.h"
 #include "GIF.h"
-#include "VPU.h"
+#include "Vpu.h"
 #include "Vif1.h"
 
 #define STATE_PATH_FORMAT		("vpu/vif1_%d.xml")

--- a/Source/iop/Iop_DmacChannel.h
+++ b/Source/iop/Iop_DmacChannel.h
@@ -1,7 +1,7 @@
 #ifndef _IOP_DMACCHANNEL_H_
 #define _IOP_DMACCHANNEL_H_
 
-#include "convertible.h"
+#include "Convertible.h"
 #include "Types.h"
 #include <functional>
 

--- a/Source/iop/Iop_SifCmd.h
+++ b/Source/iop/Iop_SifCmd.h
@@ -3,7 +3,7 @@
 #include "Iop_Module.h"
 #include "Iop_SifMan.h"
 #include "Iop_SifDynamic.h"
-#include "Iop_SysMem.h"
+#include "Iop_Sysmem.h"
 #include "zip/ZipArchiveWriter.h"
 #include "zip/ZipArchiveReader.h"
 

--- a/Source/iop/Iop_SifManPs2.h
+++ b/Source/iop/Iop_SifManPs2.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Iop_SifMan.h"
-#include "../ee/Sif.h"
+#include "../ee/SIF.h"
 
 namespace Iop
 {

--- a/Source/iop/Iop_SpuBase.h
+++ b/Source/iop/Iop_SpuBase.h
@@ -2,7 +2,7 @@
 
 #include "Types.h"
 #include "BasicUnion.h"
-#include "convertible.h"
+#include "Convertible.h"
 #include "zip/ZipArchiveWriter.h"
 #include "zip/ZipArchiveReader.h"
 


### PR DESCRIPTION
there are other things which need to be changed such as "$ANDROID_SDK_ROOT/tools/android.bat to $ANDROID_SDK_ROOT/tools/android" but that would break builds on windows.

however, with that said, I've successfully built "Play!" and installed it on my phone using Ubuntu.