### PR TITLE
Android:Moved UI operation until after creating.

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/EmulatorActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/EmulatorActivity.java
@@ -39,6 +39,12 @@ public class EmulatorActivity extends Activity
 				View.SYSTEM_UI_FLAG_HIDE_NAVIGATION |
 				View.SYSTEM_UI_FLAG_FULLSCREEN |
 				View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+	}
+
+	@Override 
+	protected void onPostCreate(Bundle savedInstanceState) 
+	{
+		super.onPostCreate(savedInstanceState);
 		
 		_renderView = (SurfaceView)findViewById(R.id.emulator_view);
 		SurfaceHolder holder = _renderView.getHolder();


### PR DESCRIPTION
Not sure, why, but every now and then this causes problems in my build.
Well, the problem is, the ui it's trying to access wasn't created yet, but every know and then it works.

Just so, you should probably give the UI time to startup before attempting to access it.

you can also, use Startup() which is called after OnCreate but before OnPostCreate, but since non of these methods are time-critical, this is just as good.