### PR TITLE
Android: Seperate Activity For FilePickers/External Emulator Launcher

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/ExternalEmulatorLauncher.java
+++ b/Source/ui_android/java/com/virtualapplications/play/ExternalEmulatorLauncher.java
@@ -1,0 +1,70 @@
+package com.virtualapplications.play;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Environment;
+import android.util.Log;
+import android.view.ContextThemeWrapper;
+
+import java.io.File;
+
+public class ExternalEmulatorLauncher extends Activity {
+
+    public ExternalEmulatorLauncher() {
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // TODO: This method is called when the BroadcastReceiver is receiving
+        // an Intent broadcast.
+        NativeInterop.setFilesDirPath(Environment.getExternalStorageDirectory().getAbsolutePath());
+
+        EmulatorActivity.RegisterPreferences();
+
+        if(!NativeInterop.isVirtualMachineCreated())
+        {
+            NativeInterop.createVirtualMachine();
+        }
+        Intent intent = getIntent();
+        String errorMSG = null;
+        if (intent.getAction() != null) {
+            if (intent.getAction().equals(Intent.ACTION_VIEW)) {
+                try {
+                    VirtualMachineManager.launchDisk(this, new File(intent.getData().getPath()));
+                    finish();
+                } catch (Exception e) {
+                    displaySimpleMessage("Error", e.getMessage());
+                }
+            }
+        }
+    }
+
+
+
+    private void displaySimpleMessage(String title, String message)
+    {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+
+        builder.setTitle(title);
+        builder.setMessage(message);
+
+        builder.setPositiveButton("OK",
+                new DialogInterface.OnClickListener()
+                {
+                    @Override
+                    public void onClick(DialogInterface dialog, int id)
+                    {
+                        finish();
+                    }
+                }
+        )
+                .setCancelable(false);
+
+        AlertDialog dialog = builder.create();
+        dialog.show();
+    }
+}

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -33,6 +33,8 @@ import com.virtualapplications.play.database.GameIndexer;
 import com.virtualapplications.play.database.GameInfo;
 import com.virtualapplications.play.database.SqliteHelper.Games;
 
+import static com.virtualapplications.play.VirtualMachineManager.launchDisk;
+
 public class MainActivity extends ActionBarActivity implements NavigationDrawerFragment.NavigationDrawerCallbacks
 {
 	static Activity mActivity;
@@ -71,15 +73,6 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		if(!NativeInterop.isVirtualMachineCreated())
 		{
 			NativeInterop.createVirtualMachine();
-		}
-
-		Intent intent = getIntent();
-		if (intent.getAction() != null) {
-			if (intent.getAction().equals(Intent.ACTION_VIEW)) {
-				launchDisk(new File(intent.getData().getPath()), true);
-				getIntent().setData(null);
-				setIntent(null);
-			}
 		}
 
 //		if (isAndroidTV(this)) {
@@ -560,39 +553,19 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 
 	}
 	
-	public static void launchGame(GameInfoStruct game) {
+	public void launchGame(GameInfoStruct game) {
 		if (game.getFile().exists()){
 			game.setlastplayed(mActivity);
-			((MainActivity) mActivity).launchDisk(game.getFile(), false);
+			try {
+				launchDisk(this, game.getFile());
+			} catch (Exception e) {
+				displaySimpleMessage("Error", e.getMessage());
+			}
 		} else {
 			((MainActivity) mActivity).displayGameNotFound(game);
 		}
 	}
-	
-	private void launchDisk(File game, boolean terminate) {
-		try
-		{
-			if(IsLoadableExecutableFileName(game.getPath()))
-			{
-				NativeInterop.loadElf(game.getPath());
-			}
-			else
-			{
-				NativeInterop.bootDiskImage(game.getPath());
-			}
-		}
-		catch(Exception ex)
-		{
-			displaySimpleMessage("Error", ex.getMessage());
-			return;
-		}
-		//TODO: Catch errors that might happen while loading files
-		Intent intent = new Intent(getApplicationContext(), EmulatorActivity.class);
-		startActivity(intent);
-		if (terminate) {
-			finish();
-		}
-	}
+
 	
 	private boolean isAndroidTV(Context context) {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {

--- a/Source/ui_android/java/com/virtualapplications/play/VirtualMachineManager.java
+++ b/Source/ui_android/java/com/virtualapplications/play/VirtualMachineManager.java
@@ -1,0 +1,23 @@
+package com.virtualapplications.play;
+
+import android.content.Context;
+import android.content.Intent;
+
+import java.io.File;
+
+import static com.virtualapplications.play.MainActivity.IsLoadableExecutableFileName;
+
+public class VirtualMachineManager{
+    static void launchDisk(Context mContext, File game) throws Exception {
+        if(IsLoadableExecutableFileName(game.getPath()))
+        {
+            NativeInterop.loadElf(game.getPath());
+        }
+        else
+        {
+            NativeInterop.bootDiskImage(game.getPath());
+        }
+        Intent intent = new Intent(mContext, EmulatorActivity.class);
+        mContext.startActivity(intent);
+    }
+}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -267,7 +267,7 @@ public class GameInfo {
 						new DialogInterface.OnClickListener() {
 							public void onClick(DialogInterface dialog, int which) {
 								dialog.dismiss();
-								MainActivity.launchGame(gameFile);
+								((MainActivity)mContext).launchGame(gameFile);
 								return;
 							}
 						});

--- a/build_android/AndroidManifest.xml
+++ b/build_android/AndroidManifest.xml
@@ -41,6 +41,12 @@
 				<category android:name="android.intent.category.LEANBACK_LAUNCHER" />
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
+		</activity>
+		<activity
+			android:name=".ExternalEmulatorLauncher"
+			android:enabled="true"
+			android:exported="true"
+			android:label="PLAY - PS2 Game Launcher">
 			<intent-filter>
 				<action android:name="android.intent.action.VIEW" />
 				


### PR DESCRIPTION
This just moves the External Emulator Launcher to a separate activity, it mostly functions to keep the code uncluttered.
but it also does offer the possibility to customizing the luncher name to external.
however, a small notice, if the main app was launched and then closed (using the home button), then a game is launched through an external launcher, after that game is exited, the main up would show up.
however, I expect people using an external launcher wouldn't be a frequent users for the main ui.