### PR TITLE
Android: associate missing serials with a database entry

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -244,7 +244,7 @@ public class GameInfo {
 			!overview.equals("") && !boxart.equals("")) {
 			return new String[] { gameID, title, overview, boxart };
 		} else {
-			GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameID);
+			GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameID, serial);
 			gameDatabase.setView(childview);
 			gameDatabase.execute(game);
 			return null;


### PR DESCRIPTION
while this solution isn't ideal, as it doesnt give the user the freedom to reset any mismatched title.
that isn't a huge issue at the moment, since they can't do so anyway, irrespective of this fix.

to test this, checkout a game such as Marvel vs Capcom 2.
the noticed difference is that its cover takes longer to load each launch, since it has no database entry associated with its serial, it make an online request for the cover everytime.