### PR TITLE
Add an LruCache to resolve scrolling redraw

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -499,7 +499,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		
 		protected void onPreExecute() {
 			progDialog = ProgressDialog.show(MainActivity.this,
-				getString(R.string.search_games),
+				getString(isConfigured ? R.string.updating_db : R.string.search_games),
 				getString(R.string.search_games_msg), true);
 		}
 		

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -20,6 +20,7 @@ import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.StrictMode;
+import android.support.v4.util.LruCache;
 import android.util.Log;
 import android.util.SparseArray;
 import android.view.View;
@@ -39,12 +40,38 @@ import com.virtualapplications.play.database.SqliteHelper.Games;
 public class GameInfo {
 	
 	private Context mContext;
+	private LruCache<String, Bitmap> mMemoryCache;
+	final int maxMemory = (int) (Runtime.getRuntime().maxMemory() / 1024);
+	final int cacheSize = maxMemory / 4;
 	
 	public GameInfo (Context mContext) {
 		this.mContext = mContext;
+		mMemoryCache = new LruCache<String, Bitmap>(cacheSize) {
+			@Override
+			protected int sizeOf(String key, Bitmap bitmap) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) {
+					return bitmap.getByteCount() / 1024;
+                } else {
+                	return (bitmap.getRowBytes() * bitmap.getHeight()) / 1000;
+                }
+			}
+		};
+	}
+    
+	public void addBitmapToMemoryCache(String key, Bitmap bitmap) {
+		if (key != null && !key.equals(null) && bitmap != null) {
+			if (getBitmapFromMemCache(key) == null) {
+                mMemoryCache.put(key, bitmap);
+			}
+		}
+	}
+    
+    public Bitmap getBitmapFromMemCache(String key) {
+		return mMemoryCache.get(key);
 	}
 	
 	public void saveImage(String key, Bitmap image) {
+		addBitmapToMemoryCache(key, image);
 		String path = mContext.getExternalFilesDir(null) + "/covers/";
 		OutputStream fOut = null;
 		File file = new File(path, key + ".jpg"); // the File to save to
@@ -65,14 +92,25 @@ public class GameInfo {
 	}
 	
 	public Bitmap getImage(String key, View childview, String boxart) {
+		Bitmap cachedImage = getBitmapFromMemCache(key);
+		if (cachedImage != null) {
+			if (childview != null) {
+				ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
+				preview.setImageBitmap(cachedImage);
+				preview.setScaleType(ScaleType.CENTER_INSIDE);
+				((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
+			}
+			return cachedImage;
+		}
 		String path = mContext.getExternalFilesDir(null) + "/covers/";
-		
+
 		File file = new File(path, key + ".jpg");
 		if(file.exists())
 		{
 			BitmapFactory.Options options = new BitmapFactory.Options();
 			options.inPreferredConfig = Bitmap.Config.ARGB_8888;
 			Bitmap bitmap = BitmapFactory.decodeFile(file.getAbsolutePath(), options);
+            addBitmapToMemoryCache(key, bitmap);
 			if (childview != null) {
 				ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
 				preview.setImageBitmap(bitmap);

--- a/build_android/res/values/strings.xml
+++ b/build_android/res/values/strings.xml
@@ -19,8 +19,8 @@
 		<item>elf</item>
 	</string-array>
 	
-	<string name="search_games">Locating games...</string>
-	<string name="search_games_msg">Please wait...</string>
+    <string name="search_games">Building collection&#8230;</string>
+    <string name="updating_db">Updating collection&#8230;</string>
 	
 	<string name="menu_title_open">Menu</string>
 	<string name="menu_title_shut">Games</string>


### PR DESCRIPTION
Alternative to #297 that overcomes a few issues created while solving scroll lag:

Does not require an excess Singleton class (Uses the existing database / cache)
Does not delay the initial load until the image is available (Initialize the view, fill as loaded)
Supports using Async task (Parallel loading and thread safe)

This has not been fully tested against a large list of games for this emulator (since I don't have a lot of games), but it has been tested against a large collection of images for other lists and grids.