### PR TITLE
Gridview fix: padding and cover size uniformity 

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -594,7 +594,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 			} else {
 				ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
 				preview.setImageResource(R.drawable.boxart);
-				preview.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
+				preview.setScaleType(ImageView.ScaleType.FIT_XY);
 				((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
 			}
 			

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -642,7 +642,8 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		private final int layoutid;
 		private final int padding;
 		private List<File> games;
-		
+		private int original_bottom_pad;
+
 		public GamesAdapter(Context context, int ResourceId, List<File> images, int padding) {
 			super(context, ResourceId, images);
 			this.games = images;
@@ -674,12 +675,21 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 			if (game != null) {
 				createListItem(game, v);
 			}
+			if (original_bottom_pad == 0){
+				original_bottom_pad = v.getPaddingBottom();
+			}
 			if (position == games.size() - 1){
 				v.setPadding(
 						v.getPaddingLeft(),
 						v.getPaddingTop(),
 						v.getPaddingRight(),
-						v.getPaddingBottom() + padding);
+						original_bottom_pad + padding);
+			} else {
+				v.setPadding(
+						v.getPaddingLeft(),
+						v.getPaddingTop(),
+						v.getPaddingRight(),
+						original_bottom_pad);
 			}
 			return v;
 		}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -76,7 +76,7 @@ public class GameInfo {
 			if (childview != null) {
 				ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
 				preview.setImageBitmap(bitmap);
-				preview.setScaleType(ScaleType.CENTER_INSIDE);
+				preview.setScaleType(ScaleType.FIT_XY);
 				((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 			}
 			return bitmap;
@@ -178,7 +178,7 @@ public class GameInfo {
 				saveImage(key, image);
 				if (preview != null) {
 					preview.setImageBitmap(image);
-					preview.setScaleType(ScaleType.CENTER_INSIDE);
+					preview.setScaleType(ScaleType.FIT_XY);
 					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 				}
 			}


### PR DESCRIPTION
I though these are better in their own PR since they're small fixes and easy to see the effect.

they'll probably conflict with the other PR later, but when and should this get merge and when and should that PR get approved it can be fixed.

Android: Fixed Cover view padding build up:
due to the reusing of the same view by the adapter, any padded cover could potentially keep getting padded and also will not lose it's padding when used in non padding position (if that same cover was set anything by last position, it would be set with the padded values), as such this fixes that, at that it will always reset the padding on any cover and always padd the original padding values as to prevent buildup.
Android: stretch cover, to make them all uniform.
simple enough, some covers are narrower, taller (albeit by few pixels by height/width) than others, as such you can see that when they're stacked side by side or on top of each other.
this is cause all of them to stretch to fit their views, giving them all the same width vs height.