### PR TITLE
Android: Indexing

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/GameInfoStruct.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GameInfoStruct.java
@@ -1,0 +1,86 @@
+package com.virtualapplications.play;
+
+
+import android.graphics.Bitmap;
+
+import java.io.File;
+
+public class GameInfoStruct {
+    private String m_TitleName;
+    private String m_ID;
+    //private final String m_Serial;
+    private String m_FrontLink;
+    private Bitmap m_Thumb;
+    private Bitmap m_Thumb2;
+    private String m_Overview;
+    private File m_File;
+
+    public GameInfoStruct(String m_id, String m_titlename, String overview, String m_frontLink) {
+        m_TitleName = m_titlename;
+        m_ID = m_id;
+        m_Overview = overview;
+        m_FrontLink = m_frontLink;
+    }
+
+    public GameInfoStruct(File file) {
+        m_File = file;
+        m_TitleName = file.getName();
+
+    }
+
+    public String getTitleName(){
+        return m_TitleName;
+    }
+    public String getID(){
+        return m_ID;
+    }
+    /*public String getSerial(){
+        return m_Serial;
+    }*/
+
+    public String getFrontLink() {
+        return m_FrontLink;
+    }
+
+    public void setFrontCover(Bitmap thumb) {
+        m_Thumb = thumb;
+    }
+    public void setBackCover(Bitmap thumb) { m_Thumb2 = thumb; }
+
+    public Bitmap getFrontCover() {
+        return m_Thumb;
+    }
+
+    public Bitmap getBackCover() {
+        if (m_Thumb2 ==  null) {
+            if (m_Thumb != null) {
+                return m_Thumb;
+            } else {
+                return null;
+            }
+
+        } else {
+            return m_Thumb2;
+        }
+    }
+
+    public void setFile(File file) {
+        m_File = file;
+    }
+
+    public File getFile() {
+        return m_File;
+    }
+
+    public void setDescription(String overview) {
+        m_Overview = overview;
+    }
+
+    public String getDescription() {
+        if (m_Overview == null) {
+            return "No info";
+        } else {
+            return m_Overview;
+        }
+    }
+}

--- a/Source/ui_android/java/com/virtualapplications/play/GameInfoStruct.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GameInfoStruct.java
@@ -58,7 +58,6 @@ public class GameInfoStruct {
         } else {
             return false;
         }
-
     }
 
     public void setTitleName(String title, Context mContext){
@@ -129,6 +128,14 @@ public class GameInfoStruct {
             return "No info";
         } else {
             return m_Overview;
+        }
+    }
+
+    public boolean isDescriptionEmptyNull(){
+        if (m_Overview == null || m_Overview.isEmpty()){
+            return true;
+        } else {
+            return false;
         }
     }
 

--- a/Source/ui_android/java/com/virtualapplications/play/GameInfoStruct.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GameInfoStruct.java
@@ -4,6 +4,7 @@ package com.virtualapplications.play;
 import android.graphics.Bitmap;
 
 import java.io.File;
+import java.util.Comparator;
 
 public class GameInfoStruct {
     private String m_TitleName;
@@ -14,6 +15,8 @@ public class GameInfoStruct {
     private Bitmap m_Thumb2;
     private String m_Overview;
     private File m_File;
+    private String m_indexID;
+    private long m_lastplayed;
 
     public GameInfoStruct(String m_id, String m_titlename, String overview, String m_frontLink) {
         m_TitleName = m_titlename;
@@ -29,7 +32,13 @@ public class GameInfoStruct {
     }
 
     public String getTitleName(){
-        return m_TitleName;
+        if (m_TitleName != null){
+            return m_TitleName;
+        } else {
+            if (m_File != null)
+            return m_File.getName();
+        }
+        return null;
     }
     public String getID(){
         return m_ID;
@@ -81,6 +90,25 @@ public class GameInfoStruct {
             return "No info";
         } else {
             return m_Overview;
+        }
+    }
+
+    public void setIndexID(String indexID) {
+        this.m_indexID = indexID;
+    }
+    public void setlastplayed(long lastplayed) {
+        this.m_lastplayed = lastplayed;
+    }
+
+    public long getlastplayed() {
+        return m_lastplayed;
+    }
+
+    public static class GameInfoStructComparator implements Comparator<GameInfoStruct> {
+        @Override
+        public int compare(GameInfoStruct o1, GameInfoStruct o2) {
+
+            return o1.getlastplayed() < o2.getlastplayed() ? -1 : o1.getlastplayed() == o2.getlastplayed() ? 0 : 1;
         }
     }
 }

--- a/Source/ui_android/java/com/virtualapplications/play/GameInfoStruct.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GameInfoStruct.java
@@ -1,10 +1,17 @@
 package com.virtualapplications.play;
 
 
+import android.content.ContentValues;
+import android.content.Context;
 import android.graphics.Bitmap;
 
+import com.virtualapplications.play.database.GameIndexer;
+import com.virtualapplications.play.database.IndexingDB;
+
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 
 public class GameInfoStruct {
     private String m_TitleName;
@@ -18,11 +25,15 @@ public class GameInfoStruct {
     private String m_indexID;
     private long m_lastplayed;
 
-    public GameInfoStruct(String m_id, String m_titlename, String overview, String m_frontLink) {
+    public GameInfoStruct(String indexid, String m_id, String m_titlename, String overview, String m_frontLink, long last_played, File file) {
         m_TitleName = m_titlename;
+        m_ID = m_id;
         m_ID = m_id;
         m_Overview = overview;
         m_FrontLink = m_frontLink;
+        m_indexID = indexid;
+        m_lastplayed = last_played;
+        m_File = file;
     }
 
     public GameInfoStruct(File file) {
@@ -36,11 +47,32 @@ public class GameInfoStruct {
             return m_TitleName;
         } else {
             if (m_File != null)
-            return m_File.getName();
+                return m_File.getName();
         }
         return null;
     }
-    public String getID(){
+
+    public boolean isTitleNameEmptyNull(){
+        if (m_TitleName == null || m_TitleName.isEmpty()){
+            return true;
+        } else {
+            return false;
+        }
+
+    }
+
+    public void setTitleName(String title, Context mContext){
+        m_TitleName = title;
+        if (mContext != null){
+            IndexingDB GI = new IndexingDB(mContext);
+
+            ContentValues values = new ContentValues();
+            values.put(IndexingDB.KEY_GAMETITLE, title);
+            GI.updateIndex(values, IndexingDB.KEY_ID + "=?", new String[]{m_indexID});
+        }
+    }
+
+    public String getGameID(){
         return m_ID;
     }
     /*public String getSerial(){
@@ -81,8 +113,15 @@ public class GameInfoStruct {
         return m_File;
     }
 
-    public void setDescription(String overview) {
+    public void setDescription(String overview, Context mContext) {
         m_Overview = overview;
+        if (mContext != null){
+            IndexingDB GI = new IndexingDB(mContext);
+
+            ContentValues values = new ContentValues();
+            values.put(IndexingDB.KEY_OVERVIEW, overview);
+            GI.updateIndex(values, IndexingDB.KEY_ID + "=?", new String[]{m_indexID});
+        }
     }
 
     public String getDescription() {
@@ -96,19 +135,49 @@ public class GameInfoStruct {
     public void setIndexID(String indexID) {
         this.m_indexID = indexID;
     }
-    public void setlastplayed(long lastplayed) {
-        this.m_lastplayed = lastplayed;
+    public void setlastplayed(Context mContext) {
+        this.m_lastplayed = System.currentTimeMillis();
+        if (mContext != null){
+            IndexingDB GI = new IndexingDB(mContext);
+
+            ContentValues values = new ContentValues();
+            values.put(IndexingDB.KEY_LAST_PLAYED, System.currentTimeMillis());
+            GI.updateIndex(values, IndexingDB.KEY_ID + "=?", new String[]{m_indexID});
+        }
     }
 
     public long getlastplayed() {
         return m_lastplayed;
     }
 
+    public void setFrontLink(String frontLink, Context mContext) {
+        this.m_FrontLink = frontLink;
+        if (mContext != null){
+            IndexingDB GI = new IndexingDB(mContext);
+
+            ContentValues values = new ContentValues();
+            values.put(IndexingDB.KEY_IMAGE, frontLink);
+            GI.updateIndex(values, IndexingDB.KEY_ID + "=?", new String[]{m_indexID});
+        }
+    }
+
+    //If this method is called, then IndexDB is missing GameID, so update it to reflect that
+    public void setGameID(String id, Context mContext) {
+        this.m_ID = id;
+        if (mContext != null){
+            IndexingDB GI = new IndexingDB(mContext);
+
+            ContentValues values = new ContentValues();
+            values.put(IndexingDB.KEY_GAMEID, id);
+            GI.updateIndex(values, IndexingDB.KEY_ID + "=?", new String[]{m_indexID});
+        }
+    }
+
     public static class GameInfoStructComparator implements Comparator<GameInfoStruct> {
         @Override
         public int compare(GameInfoStruct o1, GameInfoStruct o2) {
 
-            return o1.getlastplayed() < o2.getlastplayed() ? -1 : o1.getlastplayed() == o2.getlastplayed() ? 0 : 1;
+            return o1.getlastplayed() > o2.getlastplayed() ? -1 : o1.getlastplayed() == o2.getlastplayed() ? 1 : 0;
         }
     }
 }

--- a/Source/ui_android/java/com/virtualapplications/play/LICENSES/LICENSE
+++ b/Source/ui_android/java/com/virtualapplications/play/LICENSES/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -475,6 +475,12 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 					preview.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
 					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
 				}
+			} else if (IsLoadableExecutableFileName(game.getFile().getName())) {
+				ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
+				preview.setImageResource(R.drawable.boxart);
+				preview.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
+				((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
+				childview.findViewById(R.id.childview).setOnLongClickListener(null);
 			} else {
 				childview.findViewById(R.id.childview).setOnLongClickListener(null);
 				// passing game, as to pass and use (if) any user defined values

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -424,7 +424,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 			GameIndexer GI = new GameIndexer(mActivity);
 			GI.startupindexingscan();
 
-			return GI.getindexGameInfoStruct();
+			return GI.getindexGameInfoStruct(sortMethod == SORT_HOMEBREW);
 		}
 		
 		@Override

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -465,7 +465,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 			if (game.getDescription() != null && game.getFrontLink() != null &&
 					!game.getDescription().equals("") && !game.getFrontLink().equals("")) {
 				childview.findViewById(R.id.childview).setOnLongClickListener(
-						gameInfo.configureLongClick(game.getTitleName(), game.getDescription(), game.getFile()));
+						gameInfo.configureLongClick(game.getTitleName(), game.getDescription(), game));
 
 				if (!game.getFrontLink().equals("404")) {
 					gameInfo.getImage(game.getGameID(), childview, game.getFrontLink());
@@ -483,7 +483,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 
 				if (gameStats != null) {
 					childview.findViewById(R.id.childview).setOnLongClickListener(
-							gameInfo.configureLongClick(gameStats.getTitleName(), gameStats.getDescription(), game.getFile()));
+							gameInfo.configureLongClick(gameStats.getTitleName(), gameStats.getDescription(), game));
 
 					if (gameStats.getFrontLink() != null && !gameStats.getFrontLink().equals("404")) {
 						gameInfo.getImage(gameStats.getGameID(), childview, gameStats.getFrontLink());
@@ -501,7 +501,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 
 			childview.findViewById(R.id.childview).setOnClickListener(new OnClickListener() {
 				public void onClick(View view) {
-					launchDisk(game.getFile(), false);
+					launchGame(game);
 					return;
 				}
 			});
@@ -579,22 +579,20 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		}
 	}
 	
-	public static void launchGame(File game) {
-		((MainActivity) mActivity).launchDisk(game, false);
+	public static void launchGame(GameInfoStruct game) {
+		game.setlastplayed(mActivity);
+		((MainActivity) mActivity).launchDisk(game.getFile(), false);
 	}
-
-	private void launchDisk (File game, boolean terminate) {
+	
+	private void launchDisk(File game, boolean terminate) {
 		try
 		{
 			if(IsLoadableExecutableFileName(game.getPath()))
 			{
-				//TODO:Update IndexDB instead
-				game.setLastModified(System.currentTimeMillis());
 				NativeInterop.loadElf(game.getPath());
 			}
 			else
-			{	//TODO:Update IndexDB instead
-				game.setLastModified(System.currentTimeMillis());
+			{
 				NativeInterop.bootDiskImage(game.getPath());
 			}
 			setCurrentDirectory(game.getPath().substring(0, game.getPath().lastIndexOf(File.separator)));

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -442,9 +442,10 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		}
 	}
 
+	//TODO: should pass position instead of GameInfoStruct, so we can update those values, to avoid reading database on each scroll
 	private View createListItem(final GameInfoStruct game, final View childview) {
 		if (!isConfigured) {
-
+			//isConfig is no longer needed, since we index the entire phone, there is no need for the inital game picker
 			((TextView) childview.findViewById(R.id.game_text)).setText(game.getTitleName());
 
 			childview.findViewById(R.id.childview).setOnClickListener(new OnClickListener() {
@@ -460,13 +461,14 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 			return childview;
 		} else {
 			((TextView) childview.findViewById(R.id.game_text)).setText(game.getTitleName());
+			//If user has set values, then read them, if not read from database
 			if (game.getDescription() != null && game.getFrontLink() != null &&
 					!game.getDescription().equals("") && !game.getFrontLink().equals("")) {
 				childview.findViewById(R.id.childview).setOnLongClickListener(
 						gameInfo.configureLongClick(game.getTitleName(), game.getDescription(), game.getFile()));
 
 				if (!game.getFrontLink().equals("404")) {
-					gameInfo.getImage(game.getID(), childview, game.getFrontLink());
+					gameInfo.getImage(game.getGameID(), childview, game.getFrontLink());
 					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 				} else {
 					ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
@@ -476,14 +478,15 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 				}
 			} else {
 				childview.findViewById(R.id.childview).setOnLongClickListener(null);
-				final GameInfoStruct gameStats = gameInfo.getGameInfo(game.getFile(), childview);
+				// passing game, as to pass and use (if) any user defined values
+				final GameInfoStruct gameStats = gameInfo.getGameInfo(game.getFile(), childview, game);
 
 				if (gameStats != null) {
 					childview.findViewById(R.id.childview).setOnLongClickListener(
 							gameInfo.configureLongClick(gameStats.getTitleName(), gameStats.getDescription(), game.getFile()));
 
 					if (gameStats.getFrontLink() != null && !gameStats.getFrontLink().equals("404")) {
-						gameInfo.getImage(gameStats.getID(), childview, gameStats.getFrontLink());
+						gameInfo.getImage(gameStats.getGameID(), childview, gameStats.getFrontLink());
 						((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 					}
 				} else {

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -441,79 +441,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 			}
 		}
 	}
-
-	//TODO: should pass position instead of GameInfoStruct, so we can update those values, to avoid reading database on each scroll
-	private View createListItem(final GameInfoStruct game, final View childview) {
-		if (!isConfigured) {
-			//isConfig is no longer needed, since we index the entire phone, there is no need for the inital game picker
-			((TextView) childview.findViewById(R.id.game_text)).setText(game.getTitleName());
-
-			childview.findViewById(R.id.childview).setOnClickListener(new OnClickListener() {
-				public void onClick(View view) {
-					setCurrentDirectory(game.getFile().getPath().substring(0,
-							game.getFile().getPath().lastIndexOf(File.separator)));
-					isConfigured = true;
-					prepareFileListView(false);
-					return;
-				}
-			});
-
-			return childview;
-		} else {
-			((TextView) childview.findViewById(R.id.game_text)).setText(game.getTitleName());
-			//If user has set values, then read them, if not read from database
-			if (!game.isDescriptionEmptyNull() && game.getFrontLink() != null && !game.getFrontLink().equals("")) {
-				childview.findViewById(R.id.childview).setOnLongClickListener(
-						gameInfo.configureLongClick(game.getTitleName(), game.getDescription(), game));
-
-				if (!game.getFrontLink().equals("404")) {
-					gameInfo.getImage(game.getGameID(), childview, game.getFrontLink());
-					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
-				} else {
-					ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-					preview.setImageResource(R.drawable.boxart);
-					preview.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
-					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
-				}
-			} else if (IsLoadableExecutableFileName(game.getFile().getName())) {
-				ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-				preview.setImageResource(R.drawable.boxart);
-				preview.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
-				((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
-				childview.findViewById(R.id.childview).setOnLongClickListener(null);
-			} else {
-				childview.findViewById(R.id.childview).setOnLongClickListener(null);
-				// passing game, as to pass and use (if) any user defined values
-				final GameInfoStruct gameStats = gameInfo.getGameInfo(game.getFile(), childview, game);
-
-				if (gameStats != null) {
-					childview.findViewById(R.id.childview).setOnLongClickListener(
-							gameInfo.configureLongClick(gameStats.getTitleName(), gameStats.getDescription(), game));
-
-					if (gameStats.getFrontLink() != null && !gameStats.getFrontLink().equals("404")) {
-						gameInfo.getImage(gameStats.getGameID(), childview, gameStats.getFrontLink());
-						((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
-					}
-				} else {
-					ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-					preview.setImageResource(R.drawable.boxart);
-					preview.setScaleType(ImageView.ScaleType.FIT_XY);
-					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
-				}
-			}
-
-
-
-			childview.findViewById(R.id.childview).setOnClickListener(new OnClickListener() {
-				public void onClick(View view) {
-					launchGame(game);
-					return;
-				}
-			});
-			return childview;
-		}
-	}
-
+	
 	private void populateImages(List<GameInfoStruct> images) {
 		if (sortMethod == SORT_RECENT) {
 			Collections.sort(images, new GameInfoStruct.GameInfoStructComparator());
@@ -578,10 +506,84 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 			}
 			final GameInfoStruct game = games.get(position);
 			if (game != null) {
-				createListItem(game, v);
+				createListItem(game, v, position);
 			}
 			return v;
 		}
+
+		private View createListItem(final GameInfoStruct game, final View childview, int pos) {
+			if (!isConfigured) {
+				//isConfig is no longer needed, since we index the entire phone, there is no need for the inital game picker
+				((TextView) childview.findViewById(R.id.game_text)).setText(game.getTitleName());
+
+				childview.findViewById(R.id.childview).setOnClickListener(new OnClickListener() {
+					public void onClick(View view) {
+						setCurrentDirectory(game.getFile().getPath().substring(0,
+								game.getFile().getPath().lastIndexOf(File.separator)));
+						isConfigured = true;
+						prepareFileListView(false);
+						return;
+					}
+				});
+
+				return childview;
+			} else {
+
+				((TextView) childview.findViewById(R.id.game_text)).setText(game.getTitleName());
+				//If user has set values, then read them, if not read from database
+				if (!game.isDescriptionEmptyNull() && game.getFrontLink() != null && !game.getFrontLink().equals("")) {
+					childview.findViewById(R.id.childview).setOnLongClickListener(
+							gameInfo.configureLongClick(game.getTitleName(), game.getDescription(), game));
+
+					if (!game.getFrontLink().equals("404")) {
+						gameInfo.getImage(game.getGameID(), childview, game.getFrontLink());
+						((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
+					} else {
+						ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
+						preview.setImageResource(R.drawable.boxart);
+						preview.setScaleType(ImageView.ScaleType.FIT_XY);
+						((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
+					}
+				} else if (IsLoadableExecutableFileName(game.getFile().getName())) {
+					ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
+					preview.setImageResource(R.drawable.boxart);
+					preview.setScaleType(ImageView.ScaleType.FIT_XY);
+					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
+					childview.findViewById(R.id.childview).setOnLongClickListener(null);
+				} else {
+					childview.findViewById(R.id.childview).setOnLongClickListener(null);
+					// passing game, as to pass and use (if) any user defined values
+					final GameInfoStruct gameStats = gameInfo.getGameInfo(game.getFile(), childview, game);
+					games.set(pos, gameStats);
+
+					if (gameStats != null) {
+						childview.findViewById(R.id.childview).setOnLongClickListener(
+								gameInfo.configureLongClick(gameStats.getTitleName(), gameStats.getDescription(), game));
+
+						if (gameStats.getFrontLink() != null && !gameStats.getFrontLink().equals("404")) {
+							gameInfo.getImage(gameStats.getGameID(), childview, gameStats.getFrontLink());
+							((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
+						}
+					} else {
+						ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
+						preview.setImageResource(R.drawable.boxart);
+						preview.setScaleType(ImageView.ScaleType.FIT_XY);
+						((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
+					}
+				}
+
+
+
+				childview.findViewById(R.id.childview).setOnClickListener(new OnClickListener() {
+					public void onClick(View view) {
+						launchGame(game);
+						return;
+					}
+				});
+				return childview;
+			}
+		}
+
 	}
 	
 	public static void launchGame(GameInfoStruct game) {

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -462,8 +462,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		} else {
 			((TextView) childview.findViewById(R.id.game_text)).setText(game.getTitleName());
 			//If user has set values, then read them, if not read from database
-			if (game.getDescription() != null && game.getFrontLink() != null &&
-					!game.getDescription().equals("") && !game.getFrontLink().equals("")) {
+			if (!game.isDescriptionEmptyNull() && game.getFrontLink() != null && !game.getFrontLink().equals("")) {
 				childview.findViewById(R.id.childview).setOnLongClickListener(
 						gameInfo.configureLongClick(game.getTitleName(), game.getDescription(), game));
 

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -479,14 +479,14 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 			((TextView) childview.findViewById(R.id.game_text)).setText(game.getName());
 			childview.findViewById(R.id.childview).setOnLongClickListener(null);
 			
-			final String[] gameStats = gameInfo.getGameInfo(game, childview);
+			final GameInfoStruct gameStats = gameInfo.getGameInfo(game, childview);
 			
 			if (gameStats != null) {
 				childview.findViewById(R.id.childview).setOnLongClickListener(
-					gameInfo.configureLongClick(gameStats[1], gameStats[2], game));
-				
-				if (!gameStats[3].equals("404")) {
-					gameInfo.getImage(gameStats[0], childview, gameStats[3]);
+					gameInfo.configureLongClick(gameStats.getTitleName(), gameStats.getDescription(), game));
+
+				if (gameStats.getFrontLink() != null && !gameStats.getFrontLink().equals("404")) {
+					gameInfo.getImage(gameStats.getID(), childview, gameStats.getFrontLink());
 					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 				}
 			} else {

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -479,9 +479,9 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 				childview.findViewById(R.id.childview).setOnLongClickListener(null);
 				// passing game, as to pass and use (if) any user defined values
 				final GameInfoStruct gameStats = gameInfo.getGameInfo(game.getFile(), childview, game);
-				games.set(pos, gameStats);
 
 				if (gameStats != null) {
+					games.set(pos, gameStats);
 					childview.findViewById(R.id.childview).setOnLongClickListener(
 							gameInfo.configureLongClick(gameStats.getTitleName(), gameStats.getDescription(), game));
 

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
@@ -119,12 +119,12 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
             
             addPreferencesFromResource(R.xml.settings_ui_fragment);
             
-            final Preference button_f = (Preference)getPreferenceManager().findPreference("ui.clearfolder");
+            final Preference button_f = (Preference)getPreferenceManager().findPreference("ui.rescan");
             if (button_f != null) {
 				button_f.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                     @Override
                     public boolean onPreferenceClick(Preference arg0) {
-                        MainActivity.resetDirectory();
+                        MainActivity.FullDirectoryScan();
                         getPreferenceScreen().removePreference(button_f);
                         return true;
                     }

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
@@ -158,13 +158,13 @@ public class GameIndexer {
         return db.getAllIndexList();
     }
 
-    public List<GameInfoStruct> getindexGameInfoStruct() {
+    public List<GameInfoStruct> getindexGameInfoStruct(boolean homebrew) {
         if (db == null){
             if ((db = new IndexingDB(mContext)) == null){
                 Log.e("PLAY!", "Failed To Initiate IndexDB");
             }
         }
-        return db.getAllIndexGameInfoStruct();
+        return db.getAllIndexGameInfoStruct(homebrew);
     }
 
     private List<String> getpath() {

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
@@ -35,29 +35,16 @@ public class GameIndexer {
     }
 
     public void startupindexingscan() {
-        long startTime = System.currentTimeMillis();
         List<String> paths = getpath();
         if (paths.isEmpty()) {
-            HashSet<String> extStorage = getExternalMounts();
-            extStorage.add(Environment.getExternalStorageDirectory().getAbsolutePath());
-            if (extStorage != null && !extStorage.isEmpty()) {
-                for (String anExtStorage : extStorage) {
-                    String sdCardPath = anExtStorage.replace("mnt/media_rw", "storage");
-                    File file = new File(sdCardPath);
-                    walk(file, file.getAbsolutePath(), sdCardPath, 9999);
-                }
-            }
-            Log.i("INDEX", " 1st Runs");
+            fullindexingscan();
         } else {
             for (String path : paths) {
                 File file = new File(path);
                 walk(file, file.getAbsolutePath(), path, 0);
             }
-            Log.i("INDEX", " 2nd Runs");
         }
-        long endTime   = System.currentTimeMillis();
-        long totalTime = endTime - startTime;
-        Log.i("INDEX", "MY Time " + totalTime);
+
     }
 
     public void fullindexingscan() {
@@ -70,7 +57,6 @@ public class GameIndexer {
                     walk(file, file.getAbsolutePath(), sdCardPath, 9999);
                 }
             }
-            Log.i("INDEX", " 1st Runs");
 
     }
 

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
@@ -1,0 +1,195 @@
+package com.virtualapplications.play.database;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.os.Environment;
+import android.util.Log;
+
+import com.virtualapplications.play.GameInfoStruct;
+import com.virtualapplications.play.NativeInterop;
+import com.virtualapplications.play.R;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+
+import static com.virtualapplications.play.MainActivity.IsLoadableExecutableFileName;
+import static com.virtualapplications.play.MainActivity.getExternalMounts;
+
+/**
+ * Based On https://github.com/LithidSoftware/android_Findex/blob/master/src/com/lithidsw/findex/utils/FileWalker.java
+ */
+public class GameIndexer {
+
+    private Context mContext;
+    String[] mediaTypes;
+    private IndexingDB db;
+
+
+    public GameIndexer(Context context){
+        this.mContext = context;
+        mediaTypes = mContext.getResources().getStringArray(R.array.disks);
+        db = new IndexingDB(mContext);
+    }
+
+    public void startupindexingscan() {
+        long startTime = System.currentTimeMillis();
+        List<String> paths = getpath();
+        if (paths.isEmpty()) {
+            HashSet<String> extStorage = getExternalMounts();
+            extStorage.add(Environment.getExternalStorageDirectory().getAbsolutePath());
+            if (extStorage != null && !extStorage.isEmpty()) {
+                for (String anExtStorage : extStorage) {
+                    String sdCardPath = anExtStorage.replace("mnt/media_rw", "storage");
+                    File file = new File(sdCardPath);
+                    walk(file, file.getAbsolutePath(), sdCardPath, 9999);
+                }
+            }
+            Log.i("INDEX", " 1st Runs");
+        } else {
+            for (String path : paths) {
+                File file = new File(path);
+                walk(file, file.getAbsolutePath(), path, 0);
+            }
+            Log.i("INDEX", " 2nd Runs");
+        }
+        long endTime   = System.currentTimeMillis();
+        long totalTime = endTime - startTime;
+        Log.i("INDEX", "MY Time " + totalTime);
+    }
+
+    public void fullindexingscan() {
+            HashSet<String> extStorage = getExternalMounts();
+            extStorage.add(Environment.getExternalStorageDirectory().getAbsolutePath());
+            if (extStorage != null && !extStorage.isEmpty()) {
+                for (String anExtStorage : extStorage) {
+                    String sdCardPath = anExtStorage.replace("mnt/media_rw", "storage");
+                    File file = new File(sdCardPath);
+                    walk(file, file.getAbsolutePath(), sdCardPath, 9999);
+                }
+            }
+            Log.i("INDEX", " 1st Runs");
+
+    }
+
+    public void walk(File root, String folderPath, String storage, int depth) {
+        File[] list = root.listFiles();
+        if (list != null && !isNoMedia(list)) {
+            for (File f : list) {
+                if (f.isDirectory() && !f.isHidden() && !isNoMediaFolder(f, storage)) {
+                    if (depth <=0) continue;
+                    depth--;
+                    Log.e("INDEX", "PATH: " + f.getAbsolutePath());
+                    walk(f, f.getAbsolutePath(), storage, depth);
+                    depth++;
+                } else {
+                    if (!f.isHidden() && !f.isDirectory() && isCorrectExtension(f)) {
+                        if (!isIndexed(folderPath, f.getName())) {
+                            String name = f.getName();
+                            String serial = null;
+                            if (!IsLoadableExecutableFileName(f.getPath())) {
+                                serial = getSerial(f);
+                            }
+
+                            ContentValues values = new ContentValues();
+                            values.put(IndexingDB.KEY_DISKNAME, name);
+                            values.put(IndexingDB.KEY_PATH, folderPath);
+                            values.put(IndexingDB.KEY_SERIAL, serial);
+                            values.put(IndexingDB.KEY_SIZE, f.length());
+                            values.put(IndexingDB.KEY_LAST_PLAYED, f.lastModified());
+                            insert(values);
+                            //Log.i("INDEX", "Name: " + name + " PATH: " + folderPath + " Serial: " + serial + " Size " + f.length());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean isCorrectExtension(File f) {
+        for (final String type : mediaTypes) {
+            if (!(f.getParentFile().getName().startsWith(".") || f.getName().startsWith("."))) {
+                if (StringUtils.endsWithIgnoreCase(f.getName(), "." + type)) {
+                    String serial = getSerial(f);
+                    return IsLoadableExecutableFileName(f.getPath()) ||
+                            (serial != null && !serial.equals(""));
+                }
+            }
+        }
+        return false;
+    }
+
+    public String getSerial(File game) {
+        String serial = NativeInterop.getDiskId(game.getPath());
+        Log.d("Play!", game.getName() + " [" + serial + "]");
+        return serial;
+    }
+
+    private boolean isIndexed(String absolutePath, String name) {
+        if (db == null){
+            if ((db = new IndexingDB(mContext)) == null){
+                Log.e("PLAY!", "Failed To Initiate IndexDB");
+                return true;
+            }
+        }
+        String selection = IndexingDB.KEY_DISKNAME + "=? AND " + IndexingDB.KEY_PATH + "=?";
+        String[] selectionArgs = {name, absolutePath};
+        return db.isIndexed(selection, selectionArgs);
+
+    }
+
+    private void insert(ContentValues values) {
+        if (db == null){
+            if ((db = new IndexingDB(mContext)) == null){
+                Log.e("PLAY!", "Failed To Initiate IndexDB");
+            }
+        }
+        db.insert(values);
+    }
+
+    private List<ContentValues> getindex() {
+        if (db == null){
+            if ((db = new IndexingDB(mContext)) == null){
+                Log.e("PLAY!", "Failed To Initiate IndexDB");
+            }
+        }
+        return db.getAllIndexList();
+    }
+
+    public List<GameInfoStruct> getindexGameInfoStruct() {
+        if (db == null){
+            if ((db = new IndexingDB(mContext)) == null){
+                Log.e("PLAY!", "Failed To Initiate IndexDB");
+            }
+        }
+        return db.getAllIndexGameInfoStruct();
+    }
+
+    private List<String> getpath() {
+        if (db == null){
+            if ((db = new IndexingDB(mContext)) == null){
+                Log.e("PLAY!", "Failed To Initiate IndexDB");
+            }
+        }
+        return db.getPaths();
+    }
+
+    private boolean isNoMedia(File[] files) {
+        for (File file : files) {
+            if (file.getName().equalsIgnoreCase(".nomedia")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static boolean isNoMediaFolder(File file, String storage) {
+        return file.getAbsolutePath().contains(storage + "/Android") ||
+                file.getAbsolutePath().contains(storage + "/LOST.DIR") ||
+                file.getAbsolutePath().contains(storage + "/data");
+
+    }
+}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
@@ -20,6 +20,8 @@ import static com.virtualapplications.play.MainActivity.getExternalMounts;
 
 /**
  * Based On https://github.com/LithidSoftware/android_Findex/blob/master/src/com/lithidsw/findex/utils/FileWalker.java
+ * Modified for our needed functionality
+ * License in folder ../LICENSES/LICENSE
  */
 public class GameIndexer {
 

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -258,6 +258,7 @@ public class GameInfo {
 			getImage(game.getName(), childview, null);
 			return null;
 		}
+		//TODO update Index details instead of GamesDB
 		String suffix = serial.substring(5, serial.length());
 		String gameID = null,  title = null, overview = null, boxart = null;
 		ContentResolver cr = mContext.getContentResolver();

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -32,6 +32,7 @@ import android.widget.TextView;
 
 import java.util.concurrent.ExecutionException;
 
+import com.virtualapplications.play.GameInfoStruct;
 import com.virtualapplications.play.R;
 import com.virtualapplications.play.MainActivity;
 import com.virtualapplications.play.NativeInterop;
@@ -251,7 +252,7 @@ public class GameInfo {
 		};
 	}
 	
-	public String[] getGameInfo(File game, View childview) {
+	public GameInfoStruct getGameInfo(File game, View childview) {
 		String serial = getSerial(game);
 		if (serial == null) {
 			getImage(game.getName(), childview, null);
@@ -280,7 +281,7 @@ public class GameInfo {
 		}
 		if (overview != null && boxart != null &&
 			!overview.equals("") && !boxart.equals("")) {
-			return new String[] { gameID, title, overview, boxart };
+			return new GameInfoStruct(gameID, title, overview, boxart);
 		} else {
 			GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameID, serial);
 			gameDatabase.setView(childview);

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -224,7 +224,7 @@ public class GameInfo {
 		}
 	}
 	
-	public OnLongClickListener configureLongClick(final String title, final String overview, final File gameFile) {
+	public OnLongClickListener configureLongClick(final String title, final String overview, final GameInfoStruct gameFile) {
 		return new OnLongClickListener() {
 			public boolean onLongClick(View view) {
 				final AlertDialog.Builder builder = new AlertDialog.Builder(mContext);

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -285,7 +285,7 @@ public class GameInfo {
 				gameInfoStruct.setTitleName(title, mContext);
 			}
 
-			if (gameInfoStruct.getDescription() == null || gameInfoStruct.getDescription().isEmpty()){
+			if (gameInfoStruct.isDescriptionEmptyNull()){
 				gameInfoStruct.setDescription(overview, mContext);
 			}
 			if (gameInfoStruct.getFrontLink() == null || gameInfoStruct.getFrontLink().isEmpty()){

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -252,13 +252,12 @@ public class GameInfo {
 		};
 	}
 	
-	public GameInfoStruct getGameInfo(File game, View childview) {
+	public GameInfoStruct getGameInfo(File game, View childview, GameInfoStruct gameInfoStruct) {
 		String serial = getSerial(game);
 		if (serial == null) {
 			getImage(game.getName(), childview, null);
 			return null;
 		}
-		//TODO update Index details instead of GamesDB
 		String suffix = serial.substring(5, serial.length());
 		String gameID = null,  title = null, overview = null, boxart = null;
 		ContentResolver cr = mContext.getContentResolver();
@@ -282,9 +281,22 @@ public class GameInfo {
 		}
 		if (overview != null && boxart != null &&
 			!overview.equals("") && !boxart.equals("")) {
-			return new GameInfoStruct(gameID, title, overview, boxart);
+			if (gameInfoStruct.isTitleNameEmptyNull()){
+				gameInfoStruct.setTitleName(title, mContext);
+			}
+
+			if (gameInfoStruct.getDescription() == null || gameInfoStruct.getDescription().isEmpty()){
+				gameInfoStruct.setDescription(overview, mContext);
+			}
+			if (gameInfoStruct.getFrontLink() == null || gameInfoStruct.getFrontLink().isEmpty()){
+				gameInfoStruct.setFrontLink(boxart, mContext);
+			}
+			if (gameInfoStruct.getGameID() == null){
+				gameInfoStruct.setGameID(gameID, mContext);
+			}
+			return gameInfoStruct;
 		} else {
-			GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameID, serial);
+			GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameID, serial, gameInfoStruct);
 			gameDatabase.setView(childview);
 			gameDatabase.execute(game);
 			return null;

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -225,7 +225,6 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 							gameInfo.getImage(remoteID, childview, coverImage);
 						}
 					}
-					dataID = c.getString(c.getColumnIndex(Games.KEY_GAMEID));
 					if (gameInfoStruct.getGameID() == null){
 						gameInfoStruct.setGameID(remoteID, mContext);
 					}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -148,7 +148,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 									}
 									if (childview != null) {
 										childview.findViewById(R.id.childview).setOnLongClickListener(
-											gameInfo.configureLongClick(title, overview, gameFile));
+											gameInfo.configureLongClick(title, overview, gameInfoStruct));
 										if (boxart != null) {
 											gameInfo.getImage(remoteID, childview, boxart);
 										}
@@ -220,7 +220,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 							m_title = gameInfoStruct.getTitleName();
 						}
 						childview.findViewById(R.id.childview).setOnLongClickListener(
-								gameInfo.configureLongClick(m_title, overview, gameFile));
+								gameInfo.configureLongClick(m_title, overview, gameInfoStruct));
 						if (coverImage != null) {
 							gameInfo.getImage(remoteID, childview, coverImage);
 						}

--- a/Source/ui_android/java/com/virtualapplications/play/database/IndexingDB.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/IndexingDB.java
@@ -133,11 +133,15 @@ public class IndexingDB extends SQLiteOpenHelper {
         return IndexList;
     }
 
-    public List<GameInfoStruct> getAllIndexGameInfoStruct() {
+    public List<GameInfoStruct> getAllIndexGameInfoStruct(boolean homebrew) {
         SQLiteDatabase db = this.getReadableDatabase();
         List<GameInfoStruct> IndexList = new ArrayList<>();
-        Cursor cursor = db.query(TABLE_NAME, null, null,
-                null, null, null, null, null);
+        Cursor cursor;
+        if (!homebrew){
+            cursor = db.query(TABLE_NAME, null, null, null, null, null, null, null);
+        } else {
+            cursor = db.query(TABLE_NAME, null, KEY_DISKNAME + " LIKE ? COLLATE NOCASE", new String[]{"%.elf"}, null, null, null, null);
+        }
         if (cursor != null)
             if (cursor.moveToFirst()) {
                 do {
@@ -202,5 +206,4 @@ public class IndexingDB extends SQLiteOpenHelper {
         cursor.close();
         return paths;
     }
-
 }

--- a/Source/ui_android/java/com/virtualapplications/play/database/IndexingDB.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/IndexingDB.java
@@ -1,0 +1,209 @@
+package com.virtualapplications.play.database;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+import com.virtualapplications.play.GameInfoStruct;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class IndexingDB extends SQLiteOpenHelper {
+
+    // All Static variables
+    // Database Version
+    private static final int DATABASE_VERSION = 2;
+
+    // Database Name
+    private static final String DATABASE_NAME = "GameIndex.db";
+
+
+    // Contacts Table Columns names
+    //private static final String KEY_ID = "id";
+    public static final String KEY_ID = "id";
+    public static final String KEY_DISKNAME = "DiskName";
+    public static final String KEY_GAMETITLE = "GameTitle";
+    public static final String KEY_PATH = "Path";
+    public static final String KEY_GAMEID = "GameID";
+    public static final String KEY_OVERVIEW = "Overview";
+    public static final String KEY_SERIAL = "Serial";
+    public static final String KEY_IMAGE = "Image";
+    public static final String KEY_SIZE = "Size";
+    public static final String KEY_LAST_PLAYED = "Last_Played";
+
+    private static final String TABLE_NAME = "Games";
+
+    public IndexingDB(Context context) {
+        super(context, DATABASE_NAME, null, DATABASE_VERSION);
+    }
+
+    // Creating Tables
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        String CREATE_STOPS_TABLE = "CREATE TABLE IF NOT EXISTS " + TABLE_NAME +
+                "("
+                + KEY_ID + " INTEGER PRIMARY KEY,"
+                + KEY_DISKNAME + " TEXT,"
+                + KEY_PATH + " TEXT,"
+                + KEY_GAMEID + " INTEGER,"
+                + KEY_GAMETITLE + " TEXT,"
+                + KEY_OVERVIEW + " TEXT,"
+                + KEY_SERIAL + " TEXT,"
+                + KEY_IMAGE + " TEXT,"
+                + KEY_SIZE + " TEXT,"
+                + KEY_LAST_PLAYED + " INTEGER"
+                + ")";
+        db.execSQL(CREATE_STOPS_TABLE);
+    }
+
+    // Upgrading database
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        // Drop older table if existed
+        db.execSQL("DROP TABLE IF EXISTS " + TABLE_NAME);
+
+        // Create tables again
+        onCreate(db);
+    }
+
+    /**
+     * All CRUD(Create, Read, Update, Delete) Operations
+     */
+
+    void insert(ContentValues values) {
+        SQLiteDatabase db = this.getWritableDatabase();
+
+        // Inserting Row
+        db.insert(TABLE_NAME, null, values);
+        db.close(); // Closing database connection
+    }
+
+    ContentValues getGame(String selection, String[] selectionArgs) {
+        SQLiteDatabase db = this.getReadableDatabase();
+
+        Cursor cursor = db.query(TABLE_NAME, null, selection,
+                selectionArgs, null, null, null, null);
+        if (cursor != null)
+            cursor.moveToFirst();
+
+        ContentValues values = new ContentValues();
+        for (String col : cursor.getColumnNames()){
+            values.put(col, cursor.getString(cursor.getColumnIndex(col)));
+        }
+
+        cursor.close();
+        return values;
+    }
+
+    boolean isIndexed(String selection, String[] selectionArgs) {
+        SQLiteDatabase db = this.getReadableDatabase();
+
+        Cursor cursor = db.query(TABLE_NAME, null, selection,
+                selectionArgs, null, null, null, null);
+        boolean isGame = false;
+        if (cursor != null && cursor.getCount() > 0)
+            isGame = true;
+
+        cursor.close();
+        return isGame;
+    }
+
+    public List<ContentValues> getAllIndexList() {
+        SQLiteDatabase db = this.getReadableDatabase();
+        List<ContentValues> IndexList = new ArrayList<>();
+        Cursor cursor = db.query(TABLE_NAME, null, null,
+                null, null, null, null, null);
+        if (cursor != null)
+            if (cursor.moveToFirst()) {
+                do {
+                    ContentValues values = new ContentValues();
+                    for (String col : cursor.getColumnNames()){
+                        values.put(col, cursor.getString(cursor.getColumnIndex(col)));
+                    }
+                    IndexList.add(values);
+                } while (cursor.moveToNext());
+            }
+
+
+        cursor.close();
+        return IndexList;
+    }
+
+    public List<GameInfoStruct> getAllIndexGameInfoStruct() {
+        SQLiteDatabase db = this.getReadableDatabase();
+        List<GameInfoStruct> IndexList = new ArrayList<>();
+        Cursor cursor = db.query(TABLE_NAME, null, null,
+                null, null, null, null, null);
+        if (cursor != null)
+            if (cursor.moveToFirst()) {
+                do {
+                    String IndexID= cursor.getString(cursor.getColumnIndex(KEY_ID));
+                    String GameID= cursor.getString(cursor.getColumnIndex(KEY_GAMEID));
+                    String GameTitle= cursor.getString(cursor.getColumnIndex(KEY_GAMETITLE));
+                    String FrontCoverLink= cursor.getString(cursor.getColumnIndex(KEY_IMAGE));
+                    String OverView= cursor.getString(cursor.getColumnIndex(KEY_OVERVIEW));
+                    String Path= cursor.getString(cursor.getColumnIndex(KEY_PATH));
+                    String DiskName= cursor.getString(cursor.getColumnIndex(KEY_DISKNAME));
+                    long last_played= cursor.getLong(cursor.getColumnIndex(KEY_LAST_PLAYED));
+                    GameInfoStruct values = new GameInfoStruct(GameID,GameTitle, OverView, FrontCoverLink);
+                    values.setFile(new File(Path, DiskName));
+                    values.setIndexID(IndexID);
+                    values.setlastplayed(last_played);
+                    IndexList.add(values);
+                } while (cursor.moveToNext());
+            }
+
+
+        cursor.close();
+        return IndexList;
+    }
+
+    public int updateIndex(ContentValues values, String selection, String[] selectionArgs) {
+        SQLiteDatabase db = this.getWritableDatabase();
+
+        // updating row
+        return db.update(TABLE_NAME, values, selection, selectionArgs);
+    }
+
+    public void deleteIndex(String selection, String[] selectionArgs) {
+        SQLiteDatabase db = this.getWritableDatabase();
+        db.delete(TABLE_NAME, selection, selectionArgs);
+        db.close();
+    }
+
+
+    public int getIndexCount() {
+        SQLiteDatabase db = this.getReadableDatabase();
+
+        Cursor cursor = db.query(TABLE_NAME, null, null,
+                null, null, null, null, null);
+        int count = 0;
+        if (cursor != null)
+            count = cursor.getCount();
+
+        cursor.close();
+        // return count
+        return count;
+    }
+
+    public List<String> getPaths() {
+        SQLiteDatabase db = this.getReadableDatabase();
+
+        Cursor cursor = db.query(true, TABLE_NAME, new String[]{KEY_PATH}, null, null, KEY_PATH, null, null, null);
+        List<String> paths = new ArrayList<>();
+        if (cursor != null)
+            if (cursor.moveToFirst()) {
+                do {
+                    paths.add(cursor.getString(cursor.getColumnIndex(KEY_PATH)));
+                } while (cursor.moveToNext());
+            }
+
+        cursor.close();
+        return paths;
+    }
+
+}

--- a/Source/ui_android/java/com/virtualapplications/play/database/IndexingDB.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/IndexingDB.java
@@ -149,10 +149,7 @@ public class IndexingDB extends SQLiteOpenHelper {
                     String Path= cursor.getString(cursor.getColumnIndex(KEY_PATH));
                     String DiskName= cursor.getString(cursor.getColumnIndex(KEY_DISKNAME));
                     long last_played= cursor.getLong(cursor.getColumnIndex(KEY_LAST_PLAYED));
-                    GameInfoStruct values = new GameInfoStruct(GameID,GameTitle, OverView, FrontCoverLink);
-                    values.setFile(new File(Path, DiskName));
-                    values.setIndexID(IndexID);
-                    values.setlastplayed(last_played);
+                    GameInfoStruct values = new GameInfoStruct(IndexID, GameID,GameTitle, OverView, FrontCoverLink,last_played, new File(Path, DiskName));
                     IndexList.add(values);
                 } while (cursor.moveToNext());
             }

--- a/build_android/res/values/strings.xml
+++ b/build_android/res/values/strings.xml
@@ -42,8 +42,8 @@
     
     <string name="preferences_ui">Storage Options</string>
     
-    <string name="pref_ui_reset_folder_title">Reset Folder</string>
-    <string name="pref_ui_reset_folder_summary">Clear stored default folder</string>
+    <string name="pref_ui_rescan_all_title">Rescan Storage</string>
+    <string name="pref_ui_rescan_all_summary">Scan storage for new games</string>
     
     <string name="pref_ui_reset_cache_title">Reset Cache</string>
     <string name="pref_ui_reset_cache_summary">Clear stored cover images</string>

--- a/build_android/res/xml/settings_ui_fragment.xml
+++ b/build_android/res/xml/settings_ui_fragment.xml
@@ -4,9 +4,9 @@
     <PreferenceCategory
         android:title="@string/preferences_ui">
         <Preference
-            android:key="ui.clearfolder"
-            android:title="@string/pref_ui_reset_folder_title"
-            android:summary="@string/pref_ui_reset_folder_summary"
+            android:key="ui.rescan"
+            android:title="@string/pref_ui_rescan_all_title"
+            android:summary="@string/pref_ui_rescan_all_summary"
             android:persistent="false" />
         <Preference
             android:key="ui.clearcache"


### PR DESCRIPTION
Android: added GameInfoStruct unified structural class for data handling
Android: Replace Array with GameInfoStruct
I've added GameInfoStruct, since its much easier to handle data across multiple methods if we're using a unified structure which holds everything... also few commits down, I've also linked GameInfoStruct to updating the IndexDB.

Android: two classes in charge of setting up the IndexDB
I used SQLiteOpenHelper without ContenProvider, because according to google documentation, it's only needed if I need to expose this data to other application, which at the time of writing I don't see the point of.. also having SQLiteOpenHelper always me to predefine few methods such as getAllIndexGameInfoStruct() etc, purely making them more convenient to call.

Android: update IndexDB when game is started:
instead of editing the files modified date, I'm now using the database.

Android: moved createListItem() into Adapter, pass array position for update:
as the name suggests, createListItem() was moved so it will have access to games variable inside the adapter, so it can update it with any changes.

Android:Clean up
self explanatory, but I'm removing all the redundant functions, since they're now no longer needed.


Overall effect:
No longer need file picker, since the entire phone is indexed on 1st run (only valid images and their associated folders).
on the 2nd run, it will scan any folder which was previously detected with a  valid image.
Data from games.db will be copied into the IndexDB as required with associated image downloaded, this will come in handy later, when I add an option which allows user to set their own cover and description, since I don't want the user to have access to games.db (as this will be wiped every time we update the database).
This file scan method seems to be a bit faster as well, I've added timers into the code and this method could scan the entire content of my phone in 1 second (1000~ millisec) vs 4 seconds(results would obviously vary based on storage size, folder numbers etc), it should be due to implementation, but could be due to the checks, such as skipping ./Android ./Data, either-way it comes in handy.


TODO later: (Done)
that will be in its own pull some time in the next few days, as this pull is getting large enough.
-- allow user to modify Title, Description and Cover Image. (Done)
-- Clear Index List Option (Done)
-- Verify The Image still exist on attempted launch, since this code now relying on index for the display list, the user could have moved the game, maybe disconnected the storage, thus we should prompt him to that. (Done)

Edit:
should have mentioned this, though it was implied in my explanation, since we're indexing the devices, games from different folders will all be able to appear without having to clear folder.