### PR TITLE
Android: Theme statusbar fix

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -28,7 +28,6 @@ import org.apache.commons.io.comparator.LastModifiedFileComparator;
 import org.apache.commons.io.comparator.SizeFileComparator;
 import org.apache.commons.lang3.StringUtils;
 import com.android.util.FileUtils;
-import android.graphics.Point;
 
 import com.virtualapplications.play.database.GameInfo;
 import com.virtualapplications.play.database.SqliteHelper.Games;
@@ -89,9 +88,10 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 //		if (isAndroidTV(this)) {
 //			// Load the menus for Android TV
 //		} else {
-			Toolbar toolbar = getSupportToolbar();
+			Toolbar toolbar = (Toolbar) findViewById(R.id.my_awesome_toolbar);
 			setSupportActionBar(toolbar);
 			toolbar.bringToFront();
+			setUIcolor();
 
 			mNavigationDrawerFragment = (NavigationDrawerFragment)
 					getFragmentManager().findFragmentById(R.id.navigation_drawer);
@@ -115,17 +115,8 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		prepareFileListView(false);
 	}
 
-	private Toolbar getSupportToolbar() {
-
-		View toolbar = findViewById(R.id.my_awesome_toolbar);
-		final LinearLayout content = (LinearLayout) findViewById(R.id.content_frame);
-
-		setUIcolor(content);
-
-		return (Toolbar) toolbar;
-	}
-
-	private void setUIcolor(LinearLayout content){
+	private void setUIcolor(){
+		View content = findViewById(R.id.content_frame) ;
 		if (content != null) {
 			int[] colors = new int[2];// you can increase array size to add more colors to gradient.
 			TypedArray a = getTheme().obtainStyledAttributes(new int[]{R.attr.colorPrimary});
@@ -201,7 +192,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 	protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 		if (requestCode == 0) {
 			SettingsActivity.ChangeTheme(null, this);
-			setUIcolor((LinearLayout) findViewById(R.id.content_frame));
+			setUIcolor();
 		}
 	}
 
@@ -222,7 +213,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		mNavigationDrawerFragment.onConfigurationChanged(newConfig);
 		if (newConfig.orientation != currentOrientation) {
 			currentOrientation = newConfig.orientation;
-			getSupportToolbar();
+			setUIcolor();
 			if (currentGames != null && !currentGames.isEmpty()) {
 				prepareFileListView(true);
 			} else {

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -115,35 +115,12 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		prepareFileListView(false);
 	}
 
-	public int getStatusBarHeight() {
-		int result = 0;
-		int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
-		if (resourceId > 0) {
-			result = getResources().getDimensionPixelSize(resourceId);
-		}
-		return result;
-	}
-
 	private Toolbar getSupportToolbar() {
-		//this sets toolbar margin, but in effect moving the DrawerLayout
-		int statusBarHeight = getStatusBarHeight();
 
 		View toolbar = findViewById(R.id.my_awesome_toolbar);
 		final LinearLayout content = (LinearLayout) findViewById(R.id.content_frame);
-		
-		ViewGroup.MarginLayoutParams dlp = (ViewGroup.MarginLayoutParams) content.getLayoutParams();
-		dlp.topMargin = statusBarHeight;
-		content.setLayoutParams(dlp);
 
 		setUIcolor(content);
-
-		ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) toolbar.getLayoutParams();
-		mlp.bottomMargin = - statusBarHeight;
-		toolbar.setLayoutParams(mlp);
-		View navigation_drawer = findViewById(R.id.navigation_drawer);
-		ViewGroup.MarginLayoutParams mlp2 = (ViewGroup.MarginLayoutParams) navigation_drawer.getLayoutParams();
-		mlp2.topMargin = statusBarHeight;
-		navigation_drawer.setLayoutParams(mlp2);
 
 		return (Toolbar) toolbar;
 	}

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
@@ -1,10 +1,12 @@
 package com.virtualapplications.play;
 
 import android.app.Activity;
+import android.content.res.TypedArray;
 import android.os.*;
 import android.preference.*;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.*;
 import java.util.*;
 import android.support.v7.widget.Toolbar;
@@ -56,36 +58,37 @@ public class SettingsActivity extends PreferenceActivity
 			case 0:
 				if (TB != null){TB.setBackgroundResource(R.color.action_bar_Yellow);}
 				theme = R.style.Yellow;
-				mContext.setTheme(R.style.Yellow);
 				break;
 			default:
 			case 1:
 				if (TB != null){TB.setBackgroundResource(R.color.action_bar_Blue);}
 				theme = R.style.Blue;
-				mContext.setTheme(R.style.Blue);
 				break;
 			case 2:
 				if (TB != null){TB.setBackgroundResource(R.color.action_bar_Pink);}
 				theme = R.style.Pink;
-				mContext.setTheme(R.style.Pink);
 				break;
 			case 3:
 				if (TB != null){TB.setBackgroundResource(R.color.action_bar_purple);}
 				theme = R.style.Purple;
-				mContext.setTheme(R.style.Purple);
 				break;
 			case 4:
 				if (TB != null){TB.setBackgroundResource(R.color.action_bar_Teal);}
 				theme = R.style.Teal;
-				mContext.setTheme(R.style.Teal);
 				break;
 			case 5:
 				if (TB != null){TB.setBackgroundResource(R.color.action_bar_Dark_Purple);}
 				theme = R.style.Dark_Purple;
-				mContext.setTheme(R.style.Dark_Purple);
 				break;
 		}
 		mContext.getTheme().applyStyle(theme,true);
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+			TypedArray a = mContext.getTheme().obtainStyledAttributes(new int[]{R.attr.colorPrimaryDark});
+			int attributeResourceId = a.getColor(0, 0);
+			a.recycle();
+			mContext.getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+			mContext.getWindow().setStatusBarColor(attributeResourceId);
+		}
 	}
 
 	@Override
@@ -145,7 +148,7 @@ public class SettingsActivity extends PreferenceActivity
             
             final Preference button_f = (Preference)getPreferenceManager().findPreference("ui.clearfolder");
             if (button_f != null) {
-                button_f.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+				button_f.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                     @Override
                     public boolean onPreferenceClick(Preference arg0) {
                         MainActivity.resetDirectory();

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -97,7 +97,7 @@ public class GameInfo {
 			if (childview != null) {
 				ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
 				preview.setImageBitmap(cachedImage);
-				preview.setScaleType(ScaleType.CENTER_INSIDE);
+				preview.setScaleType(ScaleType.FIT_XY);
 				((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 			}
 			return cachedImage;

--- a/build_android/res/layout/main.xml
+++ b/build_android/res/layout/main.xml
@@ -13,8 +13,6 @@
 		android:layout_width="match_parent"
 		android:background="?attr/colorPrimary"
 		app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-		android:paddingTop="@dimen/tool_bar_top_padding"
-		android:layout_marginBottom="@dimen/tool_bar_top_padding_inv"
 		android:layout_alignParentTop="true"
 		android:layout_alignParentLeft="true"
 		android:layout_alignParentStart="true" />
@@ -49,7 +47,6 @@
 			android:layout_gravity="start"
 			tools:layout="@layout/fragment_navigation_drawer"
 			android:visibility="gone"
-			android:layout_marginTop="@dimen/tool_bar_top_padding_inv_inv"
 			/>
 	</android.support.v4.widget.DrawerLayout>
 </RelativeLayout>

--- a/build_android/res/layout/settings_toolbar.xml
+++ b/build_android/res/layout/settings_toolbar.xml
@@ -8,8 +8,6 @@
     android:minHeight="?attr/actionBarSize"
     android:background="?attr/colorPrimary"
     app:theme="@style/ThemeOverlay.AppCompat.ActionBar"
-    android:paddingTop="@dimen/tool_bar_top_padding"
-    android:layout_marginBottom="@dimen/tool_bar_top_padding_inv"
     android:layout_alignParentTop="true"
     android:layout_alignParentLeft="true"
     android:layout_alignParentStart="true"

--- a/build_android/res/values/dimens.xml
+++ b/build_android/res/values/dimens.xml
@@ -2,10 +2,6 @@
 <resources>
     <dimen name="navigation_drawer_width">240dp</dimen>
 
-    <dimen name="tool_bar_top_padding">0dp</dimen>
-    <dimen name="tool_bar_top_padding_inv">-26dp</dimen>
-    <dimen name="tool_bar_top_padding_inv_inv">26dp</dimen>
-
     <dimen name="cover_width">172dp</dimen>
     <dimen name="cover_height">242dp</dimen>
 </resources>

--- a/build_android/res/values/styles.xml
+++ b/build_android/res/values/styles.xml
@@ -7,7 +7,7 @@
         <item name="colorPrimary">@color/action_bar_purple</item>
 
         <!-- colorPrimaryDark is used for the status bar -->
-        <item name="colorPrimaryDark">#c84dff</item>
+        <item name="colorPrimaryDark">#8a00b7</item>
         <!--item name="colorPrimaryDark">#ff000000</item-->
 
     </style>


### PR DESCRIPTION
with transparency removed, we're no longer colouring the statusbar with the actionbar (since it was transparent, the actionbar colour showed behind the statusbar).

I also want to point out, that we can simplify ChangeTheme() a bit more by using this
```TypedArray a = mContext.getTheme().obtainStyledAttributes(new int[]{R.attr.colorPrimary});
int attributeResourceId = a.getColor(0, 0);
a.recycle();```

however, the same logic, can be used backwards, and instead of calling R.attr.colorPrimaryDark, we can define it as a colour and call it through R.color.action_bar_Blue_Dark. initial the reason for me setting it as a resource that it was just easier to call R.color.mycolor instead of the above code

Edit:
if there is a commit you don't need/want, let me know and I'll remove it, or you can cherry-pick around it.