### PR TITLE
Android:Fix:reset long click

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -477,6 +477,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		} else {
 			
 			((TextView) childview.findViewById(R.id.game_text)).setText(game.getName());
+			childview.findViewById(R.id.childview).setOnLongClickListener(null);
 			
 			final String[] gameStats = gameInfo.getGameInfo(game, childview);
 			


### PR DESCRIPTION
if long click is not reset, it will be associated with another view that does not set a new long click, such as ELFs.