### PR TITLE
Android:remove duplicate string

### DIFF
--- a/build_android/res/values/strings.xml
+++ b/build_android/res/values/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">Play!</string>
-
     <!-- Application Navigation -->
     
 	<string name="main_menu_settings">Settings</string>


### PR DESCRIPTION
this string also exists in donttranslate.xml
it also prevents Android Studio from building, with duplicate strings error.