### PR TITLE
Enable x86_64 Android

### DIFF
--- a/build_android/jni/Application.mk
+++ b/build_android/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_PLATFORM			:= android-19
-APP_ABI 				:= armeabi-v7a arm64-v8a x86
+APP_ABI 				:= armeabi-v7a arm64-v8a x86 x86_64
 APP_STL 				:= c++_static
 APP_CPPFLAGS 			+= -std=c++11
 NDK_TOOLCHAIN_VERSION 	:= clang


### PR DESCRIPTION
hi All android x86_64 roms launched so far have a bug in build.prop

ARMv8 prioritize binary load before the 32-bit x86 version if x86_x64 binary not exist.

This bug is fixed in the latest android-x86 6.0 branch source git updates a few days ago.

We needed  add x86_64 binary for prevent this error in bug build.prop roms.