### PR TITLE
implement vsprintf. Lego starwars uses it in its sound driver.

### DIFF
--- a/Source/iop/ArgumentIterator.cpp
+++ b/Source/iop/ArgumentIterator.cpp
@@ -2,9 +2,18 @@
 
 CArgumentIterator::CArgumentIterator(CMIPS& context) :
 m_context(context),
-m_current(0)
+m_current(0),
+m_args(nullptr)
 {
    
+}
+
+CArgumentIterator::CArgumentIterator(CMIPS& context, const char* args) :
+	m_context(context),
+	m_current(0),
+	m_args(args)
+{
+
 }
 
 CArgumentIterator::~CArgumentIterator()
@@ -14,7 +23,15 @@ CArgumentIterator::~CArgumentIterator()
 
 uint32 CArgumentIterator::GetNext()
 {
-    if(m_current > 3)
+	if (m_args)
+	{
+		// m_args is not null if we have a va_list style of aguments.
+		// In this case, we never read from registers or the stack pointer.
+		const char* address = m_args + 4 * m_current;
+		m_current++;
+		return *((uint32*)address);
+	}
+	else if(m_current > 3)
     {
         uint32 address = m_context.m_State.nGPR[CMIPS::SP].nV0 + (m_current++ - 4) * 4 + 0x10;
         return m_context.m_pMemoryMap->GetWord(address);

--- a/Source/iop/ArgumentIterator.h
+++ b/Source/iop/ArgumentIterator.h
@@ -7,12 +7,14 @@ class CArgumentIterator
 {
 public:
                     CArgumentIterator(CMIPS&);
+					CArgumentIterator(CMIPS&, const char*);
     virtual         ~CArgumentIterator();
     uint32          GetNext();
 
 private:
     unsigned int    m_current;
     CMIPS&          m_context;
+	const char*		m_args;
 };
 
 #endif

--- a/Source/iop/Iop_Stdio.cpp
+++ b/Source/iop/Iop_Stdio.cpp
@@ -55,10 +55,9 @@ void CStdio::Invoke(CMIPS& context, unsigned int functionId)
 	}
 }
 
-std::string CStdio::PrintFormatted(CArgumentIterator& args)
+std::string CStdio::PrintFormatted(const char* format, CArgumentIterator& args)
 {
-	std::string output;
-	const char* format = reinterpret_cast<const char*>(&m_ram[args.GetNext()]);
+	std::string output;	
 	while(*format != 0)
 	{
 		char character = *(format++);
@@ -152,6 +151,7 @@ std::string CStdio::PrintFormatted(CArgumentIterator& args)
 void CStdio::__printf(CMIPS& context)
 {
 	CArgumentIterator args(context);
-	auto output = PrintFormatted(args);
+	const char* format = reinterpret_cast<const char*>(&m_ram[args.GetNext()]);
+	auto output = PrintFormatted(format, args);
 	m_ioman.Write(CIoman::FID_STDOUT, output.length(), output.c_str());
 }

--- a/Source/iop/Iop_Stdio.h
+++ b/Source/iop/Iop_Stdio.h
@@ -18,7 +18,7 @@ namespace Iop
 		void			Invoke(CMIPS&, unsigned int) override;
 
 		void			__printf(CMIPS&);
-		std::string		PrintFormatted(CArgumentIterator&);
+		std::string		PrintFormatted(const char*, CArgumentIterator&);
 
 	private:
 		uint8*			m_ram;

--- a/Source/iop/Iop_Sysclib.h
+++ b/Source/iop/Iop_Sysclib.h
@@ -36,6 +36,7 @@ namespace Iop
 		uint32			__strcspn(uint32, uint32);
 		uint32			__strtol(uint32, uint32, uint32);
 		uint32			__wmemcopy(uint32, uint32, uint32);
+		int				__vsprintf(char * s, const char * format, va_list arg);
 		uint8*			m_ram = nullptr;
 		uint8*			m_spr = nullptr;
 		CStdio&			m_stdio;

--- a/Source/iop/Iop_Sysclib.h
+++ b/Source/iop/Iop_Sysclib.h
@@ -36,7 +36,7 @@ namespace Iop
 		uint32			__strcspn(uint32, uint32);
 		uint32			__strtol(uint32, uint32, uint32);
 		uint32			__wmemcopy(uint32, uint32, uint32);
-		int				__vsprintf(char * s, const char * format, va_list arg);
+		uint32			__vsprintf(CMIPS& , char * s, const char * format, const char* arg);
 		uint8*			m_ram = nullptr;
 		uint8*			m_spr = nullptr;
 		CStdio&			m_stdio;


### PR DESCRIPTION
The code is mainly a duplicate of the existing printf code. The printf code could be refactored to use vsprintf in a similar manner that the standard library does. For anyone not familiar with the emulator wondering why we don't just call the system vsprintf - the problem is that any %s argument will be a ps2 pointer and so needs converting to a real host pointer before it is de-referenced.