### PR TITLE
Lego spike

### DIFF
--- a/Source/MIPS.h
+++ b/Source/MIPS.h
@@ -102,6 +102,9 @@ __attribute__((aligned(16)))
 	uint32				cmsar0;
 	uint32				callMsEnabled;
 	uint32				callMsAddr;
+
+	uint32				savedIntReg;
+	uint32				savedIntRegTemp;
 };
 
 #define MIPS_INVALID_PC			(0x00000001)

--- a/Source/ee/VuBasicBlock.cpp
+++ b/Source/ee/VuBasicBlock.cpp
@@ -2,8 +2,6 @@
 #include "MA_VU.h"
 #include "offsetof_def.h"
 
-#pragma optimize("", off)
-
 CVuBasicBlock::CVuBasicBlock(CMIPS& context, uint32 begin, uint32 end)
 : CBasicBlock(context, begin, end)
 {

--- a/Source/ee/VuBasicBlock.cpp
+++ b/Source/ee/VuBasicBlock.cpp
@@ -51,8 +51,9 @@ void CVuBasicBlock::CompileRange(CMipsJitter* jitter)
 		// Test if the block ends with a conditional branch instruction where the condition variable has been
 		// set in the prior instruction.
 		// In this case, the pipeline shortcut fails and we need to use the value from 4 instructions previous.
+		// If the relevant set instruction is not part of this block, skip the fix and fall back to the broken implementation.
 		int length = (fixedEnd - m_begin) >> 3;
-		if (length > 2)
+		if (length > 4)
 		{
 			// Check if we have a conditional branch instruction. Luckily these populate the contiguous opcode range 0x28 -> 0x2F inclusive
 			uint32 opcodeLo = m_context.m_pMemoryMap->GetInstruction(adjustedEnd - 8);
@@ -73,7 +74,7 @@ void CVuBasicBlock::CompileRange(CMipsJitter* jitter)
 					{
 						// argh - we need to use the value of incReg 4 steps prior.
 						delayedReg = loOps.writeI;
-						delayedRegTime = std::max(adjustedEnd - 5 * 8, static_cast<int>(m_begin));
+						delayedRegTime = adjustedEnd - 5 * 8;
 						delayedRegTargetTime = adjustedEnd - 8;
 					}
 				}			

--- a/Source/ee/VuBasicBlock.cpp
+++ b/Source/ee/VuBasicBlock.cpp
@@ -65,13 +65,15 @@ void CVuBasicBlock::CompileRange(CMipsJitter* jitter)
 				uint32 priorOpcodeLo = m_context.m_pMemoryMap->GetInstruction(priorOpcodeAddr);
 
 				VUShared::OPERANDSET loOps = arch->GetAffectedOperands(&m_context, priorOpcodeAddr, priorOpcodeLo);
-				if (loOps.writeI != 0) {
+				if (loOps.writeI != 0)
+				{
 					uint8  is = static_cast<uint8> ((opcodeLo >> 11) & 0x001F);
 					uint8  it = static_cast<uint8> ((opcodeLo >> 16) & 0x001F);
-					if (is == loOps.writeI || it == loOps.writeI) {
+					if (is == loOps.writeI || it == loOps.writeI)
+					{
 						// argh - we need to use the value of incReg 4 steps prior.
 						delayedReg = loOps.writeI;
-						delayedRegTime = adjustedEnd - 5 * 8;
+						delayedRegTime = std::max(adjustedEnd - 5 * 8, static_cast<int>(m_begin));
 						delayedRegTargetTime = adjustedEnd - 8;
 					}
 				}			


### PR DESCRIPTION
Deal with the special case where an integer register is written immediately before a conditional branch which uses it. Fixes Lego star wars.