### PR TITLE
Xcode fixes.

### DIFF
--- a/build_macosx/Play.xcodeproj/project.pbxproj
+++ b/build_macosx/Play.xcodeproj/project.pbxproj
@@ -14,9 +14,6 @@
 		7011789915E25576006D1039 /* OutputWindow.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7011789815E25575006D1039 /* OutputWindow.mm */; };
 		7017B3901652F660008ACEAC /* Iop_Sio2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7017B38E1652F660008ACEAC /* Iop_Sio2.cpp */; };
 		703093B217BE5AE1009662A1 /* FrameDump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 703093AD17BE5AB1009662A1 /* FrameDump.cpp */; };
-		70320D1E1A99EAC4001E9C4B /* GeneralSettings.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 70320D1A1A99EAC4001E9C4B /* GeneralSettings.xcconfig */; };
-		70320D1F1A99EAC4001E9C4B /* GeneralSettingsDebug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 70320D1B1A99EAC4001E9C4B /* GeneralSettingsDebug.xcconfig */; };
-		70320D201A99EAC4001E9C4B /* GeneralSettingsRelease.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 70320D1C1A99EAC4001E9C4B /* GeneralSettingsRelease.xcconfig */; };
 		704F23B51B0011C8009FD916 /* Vif.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 704F23AF1B0011C8009FD916 /* Vif.cpp */; };
 		704F23B61B0011C8009FD916 /* Vif1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 704F23B11B0011C8009FD916 /* Vif1.cpp */; };
 		704F23B71B0011C8009FD916 /* Vpu.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 704F23B31B0011C8009FD916 /* Vpu.cpp */; };
@@ -208,319 +205,319 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		700DF99415DF699000818F3B /* patches.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = patches.xml; path = ../patches.xml; sourceTree = "<group>"; };
-		700DF99B15DFC0CB00818F3B /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = MainMenu.xib; sourceTree = "<group>"; };
-		700FB57F15E11E1E00C322DE /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = OutputWindow.xib; sourceTree = "<group>"; };
-		700FB58115E11FC600C322DE /* OutputWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OutputWindowController.h; path = ../Source/ui_macosx/OutputWindowController.h; sourceTree = "<group>"; };
-		700FB58215E11FC600C322DE /* OutputWindowController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = OutputWindowController.mm; path = ../Source/ui_macosx/OutputWindowController.mm; sourceTree = "<group>"; };
-		7011789615E2344F006D1039 /* PS2VM_Preferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PS2VM_Preferences.h; path = ../Source/PS2VM_Preferences.h; sourceTree = "<group>"; };
-		7011789715E25575006D1039 /* OutputWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OutputWindow.h; path = ../Source/ui_macosx/OutputWindow.h; sourceTree = "<group>"; };
-		7011789815E25575006D1039 /* OutputWindow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = OutputWindow.mm; path = ../Source/ui_macosx/OutputWindow.mm; sourceTree = "<group>"; };
-		7017B38E1652F660008ACEAC /* Iop_Sio2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Sio2.cpp; path = ../Source/iop/Iop_Sio2.cpp; sourceTree = "<group>"; };
-		7017B38F1652F660008ACEAC /* Iop_Sio2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Sio2.h; path = ../Source/iop/Iop_Sio2.h; sourceTree = "<group>"; };
-		703093AD17BE5AB1009662A1 /* FrameDump.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = FrameDump.cpp; path = ../Source/FrameDump.cpp; sourceTree = "<group>"; };
-		703093AE17BE5AB1009662A1 /* FrameDump.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FrameDump.h; path = ../Source/FrameDump.h; sourceTree = "<group>"; };
+		700DF99415DF699000818F3B /* patches.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = patches.xml; path = ../../patches.xml; sourceTree = "<group>"; };
+		700DF99B15DFC0CB00818F3B /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		700FB57F15E11E1E00C322DE /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/OutputWindow.xib; sourceTree = "<group>"; };
+		700FB58115E11FC600C322DE /* OutputWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OutputWindowController.h; sourceTree = "<group>"; };
+		700FB58215E11FC600C322DE /* OutputWindowController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OutputWindowController.mm; sourceTree = "<group>"; };
+		7011789615E2344F006D1039 /* PS2VM_Preferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PS2VM_Preferences.h; sourceTree = "<group>"; };
+		7011789715E25575006D1039 /* OutputWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OutputWindow.h; sourceTree = "<group>"; };
+		7011789815E25575006D1039 /* OutputWindow.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OutputWindow.mm; sourceTree = "<group>"; };
+		7017B38E1652F660008ACEAC /* Iop_Sio2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Sio2.cpp; sourceTree = "<group>"; };
+		7017B38F1652F660008ACEAC /* Iop_Sio2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Sio2.h; sourceTree = "<group>"; };
+		703093AD17BE5AB1009662A1 /* FrameDump.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameDump.cpp; sourceTree = "<group>"; };
+		703093AE17BE5AB1009662A1 /* FrameDump.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameDump.h; sourceTree = "<group>"; };
 		70320D1A1A99EAC4001E9C4B /* GeneralSettings.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = GeneralSettings.xcconfig; sourceTree = "<group>"; };
 		70320D1B1A99EAC4001E9C4B /* GeneralSettingsDebug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = GeneralSettingsDebug.xcconfig; sourceTree = "<group>"; };
 		70320D1C1A99EAC4001E9C4B /* GeneralSettingsRelease.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = GeneralSettingsRelease.xcconfig; sourceTree = "<group>"; };
-		704F23AF1B0011C8009FD916 /* Vif.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Vif.cpp; path = ../Source/ee/Vif.cpp; sourceTree = "<group>"; };
-		704F23B01B0011C8009FD916 /* Vif.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Vif.h; path = ../Source/ee/Vif.h; sourceTree = "<group>"; };
-		704F23B11B0011C8009FD916 /* Vif1.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Vif1.cpp; path = ../Source/ee/Vif1.cpp; sourceTree = "<group>"; };
-		704F23B21B0011C8009FD916 /* Vif1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Vif1.h; path = ../Source/ee/Vif1.h; sourceTree = "<group>"; };
-		704F23B31B0011C8009FD916 /* Vpu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Vpu.cpp; path = ../Source/ee/Vpu.cpp; sourceTree = "<group>"; };
-		704F23B41B0011C8009FD916 /* Vpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Vpu.h; path = ../Source/ee/Vpu.h; sourceTree = "<group>"; };
-		7056F2831B2683C700389AFB /* EeExecutor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EeExecutor.cpp; path = ../Source/ee/EeExecutor.cpp; sourceTree = "<group>"; };
-		7056F2841B2683C700389AFB /* EeExecutor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EeExecutor.h; path = ../Source/ee/EeExecutor.h; sourceTree = "<group>"; };
-		705AA9731C55683800775613 /* Iop_MtapMan.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_MtapMan.cpp; path = ../Source/iop/Iop_MtapMan.cpp; sourceTree = "<group>"; };
-		705AA9741C55683800775613 /* Iop_MtapMan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_MtapMan.h; path = ../Source/iop/Iop_MtapMan.h; sourceTree = "<group>"; };
-		705B16BC1B097DD00081B3C6 /* BlockProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlockProvider.h; path = ../Source/ISO9660/BlockProvider.h; sourceTree = "<group>"; };
-		705D396A1C43FFAF00D267A6 /* PreferencesWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PreferencesWindowController.h; path = ../Source/ui_macosx/PreferencesWindowController.h; sourceTree = "<group>"; };
-		705D396B1C43FFAF00D267A6 /* PreferencesWindowController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = PreferencesWindowController.mm; path = ../Source/ui_macosx/PreferencesWindowController.mm; sourceTree = "<group>"; };
-		705D396E1C43FFC900D267A6 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = PreferencesWindow.xib; sourceTree = "<group>"; };
-		705D39711C44A3FF00D267A6 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = VideoSettingsView.xib; sourceTree = "<group>"; };
-		705D39731C44A44F00D267A6 /* VideoSettingsViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = VideoSettingsViewController.mm; path = ../Source/ui_macosx/VideoSettingsViewController.mm; sourceTree = "<group>"; };
-		705D39751C44A47A00D267A6 /* VideoSettingsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = VideoSettingsViewController.h; path = ../Source/ui_macosx/VideoSettingsViewController.h; sourceTree = "<group>"; };
-		705DAEFA1C4882ED00210465 /* ScopedVmPauser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ScopedVmPauser.cpp; path = ../Source/ScopedVmPauser.cpp; sourceTree = "<group>"; };
-		705DAEFB1C4882ED00210465 /* ScopedVmPauser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ScopedVmPauser.h; path = ../Source/ScopedVmPauser.h; sourceTree = "<group>"; };
+		704F23AF1B0011C8009FD916 /* Vif.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Vif.cpp; sourceTree = "<group>"; };
+		704F23B01B0011C8009FD916 /* Vif.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Vif.h; sourceTree = "<group>"; };
+		704F23B11B0011C8009FD916 /* Vif1.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Vif1.cpp; sourceTree = "<group>"; };
+		704F23B21B0011C8009FD916 /* Vif1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Vif1.h; sourceTree = "<group>"; };
+		704F23B31B0011C8009FD916 /* Vpu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Vpu.cpp; sourceTree = "<group>"; };
+		704F23B41B0011C8009FD916 /* Vpu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Vpu.h; sourceTree = "<group>"; };
+		7056F2831B2683C700389AFB /* EeExecutor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EeExecutor.cpp; sourceTree = "<group>"; };
+		7056F2841B2683C700389AFB /* EeExecutor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EeExecutor.h; sourceTree = "<group>"; };
+		705AA9731C55683800775613 /* Iop_MtapMan.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_MtapMan.cpp; sourceTree = "<group>"; };
+		705AA9741C55683800775613 /* Iop_MtapMan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_MtapMan.h; sourceTree = "<group>"; };
+		705B16BC1B097DD00081B3C6 /* BlockProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockProvider.h; sourceTree = "<group>"; };
+		705D396A1C43FFAF00D267A6 /* PreferencesWindowController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreferencesWindowController.h; sourceTree = "<group>"; };
+		705D396B1C43FFAF00D267A6 /* PreferencesWindowController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PreferencesWindowController.mm; sourceTree = "<group>"; };
+		705D396E1C43FFC900D267A6 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/PreferencesWindow.xib; sourceTree = "<group>"; };
+		705D39711C44A3FF00D267A6 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/VideoSettingsView.xib; sourceTree = "<group>"; };
+		705D39731C44A44F00D267A6 /* VideoSettingsViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VideoSettingsViewController.mm; sourceTree = "<group>"; };
+		705D39751C44A47A00D267A6 /* VideoSettingsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VideoSettingsViewController.h; sourceTree = "<group>"; };
+		705DAEFA1C4882ED00210465 /* ScopedVmPauser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScopedVmPauser.cpp; sourceTree = "<group>"; };
+		705DAEFB1C4882ED00210465 /* ScopedVmPauser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScopedVmPauser.h; sourceTree = "<group>"; };
 		7068496E151E880E00C9574F /* CodeGen.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CodeGen.xcodeproj; path = ../../CodeGen/build_macosx/CodeGen.xcodeproj; sourceTree = "<group>"; };
 		7068497A151E883D00C9574F /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
 		7068497C151E885200C9574F /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		7068498A151E891200C9574F /* libbz2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbz2.dylib; path = usr/lib/libbz2.dylib; sourceTree = SDKROOT; };
-		7068498D151E896900C9574F /* ArgumentIterator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ArgumentIterator.cpp; path = ../Source/iop/ArgumentIterator.cpp; sourceTree = "<group>"; };
-		7068498E151E896900C9574F /* ArgumentIterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ArgumentIterator.h; path = ../Source/iop/ArgumentIterator.h; sourceTree = "<group>"; };
-		7068498F151E896900C9574F /* DirectoryDevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DirectoryDevice.cpp; path = ../Source/iop/DirectoryDevice.cpp; sourceTree = "<group>"; };
-		70684990151E896900C9574F /* DirectoryDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DirectoryDevice.h; path = ../Source/iop/DirectoryDevice.h; sourceTree = "<group>"; };
-		70684991151E896900C9574F /* Ioman_Device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Ioman_Device.h; path = ../Source/iop/Ioman_Device.h; sourceTree = "<group>"; };
-		70684992151E896900C9574F /* Iop_BiosBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_BiosBase.h; path = ../Source/iop/Iop_BiosBase.h; sourceTree = "<group>"; };
-		70684993151E896900C9574F /* Iop_Cdvdfsv.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Cdvdfsv.cpp; path = ../Source/iop/Iop_Cdvdfsv.cpp; sourceTree = "<group>"; };
-		70684994151E896900C9574F /* Iop_Cdvdfsv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Cdvdfsv.h; path = ../Source/iop/Iop_Cdvdfsv.h; sourceTree = "<group>"; };
-		70684995151E896900C9574F /* Iop_Cdvdman.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Cdvdman.cpp; path = ../Source/iop/Iop_Cdvdman.cpp; sourceTree = "<group>"; };
-		70684996151E896900C9574F /* Iop_Cdvdman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Cdvdman.h; path = ../Source/iop/Iop_Cdvdman.h; sourceTree = "<group>"; };
-		7068499B151E896900C9574F /* Iop_Dmac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Dmac.cpp; path = ../Source/iop/Iop_Dmac.cpp; sourceTree = "<group>"; };
-		7068499C151E896900C9574F /* Iop_Dmac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Dmac.h; path = ../Source/iop/Iop_Dmac.h; sourceTree = "<group>"; };
-		7068499D151E896900C9574F /* Iop_DmacChannel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_DmacChannel.cpp; path = ../Source/iop/Iop_DmacChannel.cpp; sourceTree = "<group>"; };
-		7068499E151E896900C9574F /* Iop_DmacChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_DmacChannel.h; path = ../Source/iop/Iop_DmacChannel.h; sourceTree = "<group>"; };
-		7068499F151E896900C9574F /* Iop_Dynamic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Dynamic.cpp; path = ../Source/iop/Iop_Dynamic.cpp; sourceTree = "<group>"; };
-		706849A0151E896900C9574F /* Iop_Dynamic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Dynamic.h; path = ../Source/iop/Iop_Dynamic.h; sourceTree = "<group>"; };
-		706849A1151E896900C9574F /* Iop_FileIo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_FileIo.cpp; path = ../Source/iop/Iop_FileIo.cpp; sourceTree = "<group>"; };
-		706849A2151E896900C9574F /* Iop_FileIo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_FileIo.h; path = ../Source/iop/Iop_FileIo.h; sourceTree = "<group>"; };
-		706849A3151E896900C9574F /* Iop_Intc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Intc.cpp; path = ../Source/iop/Iop_Intc.cpp; sourceTree = "<group>"; };
-		706849A4151E896900C9574F /* Iop_Intc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Intc.h; path = ../Source/iop/Iop_Intc.h; sourceTree = "<group>"; };
-		706849A5151E896900C9574F /* Iop_Intrman.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Intrman.cpp; path = ../Source/iop/Iop_Intrman.cpp; sourceTree = "<group>"; };
-		706849A6151E896900C9574F /* Iop_Intrman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Intrman.h; path = ../Source/iop/Iop_Intrman.h; sourceTree = "<group>"; };
-		706849A7151E896900C9574F /* Iop_Ioman.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Ioman.cpp; path = ../Source/iop/Iop_Ioman.cpp; sourceTree = "<group>"; };
-		706849A8151E896900C9574F /* Iop_Ioman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Ioman.h; path = ../Source/iop/Iop_Ioman.h; sourceTree = "<group>"; };
-		706849AB151E896900C9574F /* Iop_Loadcore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Loadcore.cpp; path = ../Source/iop/Iop_Loadcore.cpp; sourceTree = "<group>"; };
-		706849AC151E896900C9574F /* Iop_Loadcore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Loadcore.h; path = ../Source/iop/Iop_Loadcore.h; sourceTree = "<group>"; };
-		706849AD151E896900C9574F /* Iop_McServ.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_McServ.cpp; path = ../Source/iop/Iop_McServ.cpp; sourceTree = "<group>"; };
-		706849AE151E896900C9574F /* Iop_McServ.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_McServ.h; path = ../Source/iop/Iop_McServ.h; sourceTree = "<group>"; };
-		706849AF151E896900C9574F /* Iop_Modload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Modload.cpp; path = ../Source/iop/Iop_Modload.cpp; sourceTree = "<group>"; };
-		706849B0151E896900C9574F /* Iop_Modload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Modload.h; path = ../Source/iop/Iop_Modload.h; sourceTree = "<group>"; };
-		706849B1151E896900C9574F /* Iop_Module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Module.h; path = ../Source/iop/Iop_Module.h; sourceTree = "<group>"; };
-		706849B2151E896900C9574F /* Iop_PadMan.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_PadMan.cpp; path = ../Source/iop/Iop_PadMan.cpp; sourceTree = "<group>"; };
-		706849B3151E896900C9574F /* Iop_PadMan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_PadMan.h; path = ../Source/iop/Iop_PadMan.h; sourceTree = "<group>"; };
-		706849B4151E896900C9574F /* Iop_RootCounters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_RootCounters.cpp; path = ../Source/iop/Iop_RootCounters.cpp; sourceTree = "<group>"; };
-		706849B5151E896900C9574F /* Iop_RootCounters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_RootCounters.h; path = ../Source/iop/Iop_RootCounters.h; sourceTree = "<group>"; };
-		706849B6151E896900C9574F /* Iop_SifCmd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_SifCmd.cpp; path = ../Source/iop/Iop_SifCmd.cpp; sourceTree = "<group>"; };
-		706849B7151E896900C9574F /* Iop_SifCmd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_SifCmd.h; path = ../Source/iop/Iop_SifCmd.h; sourceTree = "<group>"; };
-		706849B8151E896900C9574F /* Iop_SifDynamic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_SifDynamic.cpp; path = ../Source/iop/Iop_SifDynamic.cpp; sourceTree = "<group>"; };
-		706849B9151E896900C9574F /* Iop_SifDynamic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_SifDynamic.h; path = ../Source/iop/Iop_SifDynamic.h; sourceTree = "<group>"; };
-		706849BA151E896900C9574F /* Iop_SifMan.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_SifMan.cpp; path = ../Source/iop/Iop_SifMan.cpp; sourceTree = "<group>"; };
-		706849BB151E896900C9574F /* Iop_Sifman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Sifman.h; path = ../Source/iop/Iop_Sifman.h; sourceTree = "<group>"; };
-		706849BC151E896900C9574F /* Iop_SifManNull.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_SifManNull.cpp; path = ../Source/iop/Iop_SifManNull.cpp; sourceTree = "<group>"; };
-		706849BD151E896900C9574F /* Iop_SifManNull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_SifManNull.h; path = ../Source/iop/Iop_SifManNull.h; sourceTree = "<group>"; };
-		706849BE151E896900C9574F /* Iop_SifManPs2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_SifManPs2.cpp; path = ../Source/iop/Iop_SifManPs2.cpp; sourceTree = "<group>"; };
-		706849BF151E896900C9574F /* Iop_SifManPs2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_SifManPs2.h; path = ../Source/iop/Iop_SifManPs2.h; sourceTree = "<group>"; };
-		706849C0151E896900C9574F /* Iop_Spu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Spu.cpp; path = ../Source/iop/Iop_Spu.cpp; sourceTree = "<group>"; };
-		706849C1151E896900C9574F /* Iop_Spu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Spu.h; path = ../Source/iop/Iop_Spu.h; sourceTree = "<group>"; };
-		706849C2151E896900C9574F /* Iop_Spu2_Core.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Spu2_Core.cpp; path = ../Source/iop/Iop_Spu2_Core.cpp; sourceTree = "<group>"; };
-		706849C3151E896900C9574F /* Iop_Spu2_Core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Spu2_Core.h; path = ../Source/iop/Iop_Spu2_Core.h; sourceTree = "<group>"; };
-		706849C4151E896900C9574F /* Iop_Spu2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Spu2.cpp; path = ../Source/iop/Iop_Spu2.cpp; sourceTree = "<group>"; };
-		706849C5151E896900C9574F /* Iop_Spu2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Spu2.h; path = ../Source/iop/Iop_Spu2.h; sourceTree = "<group>"; };
-		706849C6151E896900C9574F /* Iop_SpuBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_SpuBase.cpp; path = ../Source/iop/Iop_SpuBase.cpp; sourceTree = "<group>"; };
-		706849C7151E896900C9574F /* Iop_SpuBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_SpuBase.h; path = ../Source/iop/Iop_SpuBase.h; sourceTree = "<group>"; };
-		706849C8151E896900C9574F /* Iop_Stdio.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Stdio.cpp; path = ../Source/iop/Iop_Stdio.cpp; sourceTree = "<group>"; };
-		706849C9151E896900C9574F /* Iop_Stdio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Stdio.h; path = ../Source/iop/Iop_Stdio.h; sourceTree = "<group>"; };
-		706849CA151E896900C9574F /* Iop_SubSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_SubSystem.cpp; path = ../Source/iop/Iop_SubSystem.cpp; sourceTree = "<group>"; };
-		706849CB151E896900C9574F /* Iop_SubSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_SubSystem.h; path = ../Source/iop/Iop_SubSystem.h; sourceTree = "<group>"; };
-		706849CC151E896900C9574F /* Iop_Sysclib.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Sysclib.cpp; path = ../Source/iop/Iop_Sysclib.cpp; sourceTree = "<group>"; };
-		706849CD151E896900C9574F /* Iop_Sysclib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Sysclib.h; path = ../Source/iop/Iop_Sysclib.h; sourceTree = "<group>"; };
-		706849CE151E896900C9574F /* Iop_Sysmem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Sysmem.cpp; path = ../Source/iop/Iop_Sysmem.cpp; sourceTree = "<group>"; };
-		706849CF151E896900C9574F /* Iop_Sysmem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Sysmem.h; path = ../Source/iop/Iop_Sysmem.h; sourceTree = "<group>"; };
-		706849D0151E896900C9574F /* Iop_Thbase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Thbase.cpp; path = ../Source/iop/Iop_Thbase.cpp; sourceTree = "<group>"; };
-		706849D1151E896900C9574F /* Iop_Thbase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Thbase.h; path = ../Source/iop/Iop_Thbase.h; sourceTree = "<group>"; };
-		706849D2151E896900C9574F /* Iop_Thevent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Thevent.cpp; path = ../Source/iop/Iop_Thevent.cpp; sourceTree = "<group>"; };
-		706849D3151E896900C9574F /* Iop_Thevent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Thevent.h; path = ../Source/iop/Iop_Thevent.h; sourceTree = "<group>"; };
-		706849D4151E896900C9574F /* Iop_Thsema.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Thsema.cpp; path = ../Source/iop/Iop_Thsema.cpp; sourceTree = "<group>"; };
-		706849D5151E896900C9574F /* Iop_Thsema.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Thsema.h; path = ../Source/iop/Iop_Thsema.h; sourceTree = "<group>"; };
-		706849D6151E896900C9574F /* Iop_Timrman.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Timrman.cpp; path = ../Source/iop/Iop_Timrman.cpp; sourceTree = "<group>"; };
-		706849D7151E896900C9574F /* Iop_Timrman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Timrman.h; path = ../Source/iop/Iop_Timrman.h; sourceTree = "<group>"; };
-		706849D8151E896900C9574F /* Iop_Vblank.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Vblank.cpp; path = ../Source/iop/Iop_Vblank.cpp; sourceTree = "<group>"; };
-		706849D9151E896900C9574F /* Iop_Vblank.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Vblank.h; path = ../Source/iop/Iop_Vblank.h; sourceTree = "<group>"; };
-		706849DA151E896900C9574F /* IopBios.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IopBios.cpp; path = ../Source/iop/IopBios.cpp; sourceTree = "<group>"; };
-		706849DB151E896900C9574F /* IopBios.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IopBios.h; path = ../Source/iop/IopBios.h; sourceTree = "<group>"; };
-		706849DC151E896900C9574F /* IsoDevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IsoDevice.cpp; path = ../Source/iop/IsoDevice.cpp; sourceTree = "<group>"; };
-		706849DD151E896900C9574F /* IsoDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IsoDevice.h; path = ../Source/iop/IsoDevice.h; sourceTree = "<group>"; };
-		70684A06151E89E200C9574F /* ApplicationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ApplicationDelegate.h; path = ../Source/ui_macosx/ApplicationDelegate.h; sourceTree = "<group>"; };
-		70684A07151E89E200C9574F /* ApplicationDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = ApplicationDelegate.mm; path = ../Source/ui_macosx/ApplicationDelegate.mm; sourceTree = "<group>"; };
-		70684A0C151E89E200C9574F /* Globals.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Globals.cpp; path = ../Source/ui_macosx/Globals.cpp; sourceTree = "<group>"; };
-		70684A0D151E89E200C9574F /* Globals.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Globals.h; path = ../Source/ui_macosx/Globals.h; sourceTree = "<group>"; };
-		70684A0E151E89E200C9574F /* GSH_OpenGLMacOSX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GSH_OpenGLMacOSX.cpp; path = ../Source/ui_macosx/GSH_OpenGLMacOSX.cpp; sourceTree = "<group>"; };
-		70684A0F151E89E200C9574F /* GSH_OpenGLMacOSX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GSH_OpenGLMacOSX.h; path = ../Source/ui_macosx/GSH_OpenGLMacOSX.h; sourceTree = "<group>"; };
-		70684A15151E89E200C9574F /* PH_HidMacOSX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PH_HidMacOSX.cpp; path = ../Source/ui_macosx/PH_HidMacOSX.cpp; sourceTree = "<group>"; };
-		70684A16151E89E200C9574F /* PH_HidMacOSX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PH_HidMacOSX.h; path = ../Source/ui_macosx/PH_HidMacOSX.h; sourceTree = "<group>"; };
-		70684A19151E89E200C9574F /* VfsManagerBindings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VfsManagerBindings.h; path = ../Source/ui_macosx/VfsManagerBindings.h; sourceTree = "<group>"; };
-		70684A1A151E89E200C9574F /* VfsManagerBindings.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = VfsManagerBindings.mm; path = ../Source/ui_macosx/VfsManagerBindings.mm; sourceTree = "<group>"; };
-		70684A1B151E89E200C9574F /* VfsManagerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VfsManagerViewController.h; path = ../Source/ui_macosx/VfsManagerViewController.h; sourceTree = "<group>"; };
-		70684A1C151E89E200C9574F /* VfsManagerViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = VfsManagerViewController.mm; path = ../Source/ui_macosx/VfsManagerViewController.mm; sourceTree = "<group>"; };
+		7068498D151E896900C9574F /* ArgumentIterator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ArgumentIterator.cpp; sourceTree = "<group>"; };
+		7068498E151E896900C9574F /* ArgumentIterator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArgumentIterator.h; sourceTree = "<group>"; };
+		7068498F151E896900C9574F /* DirectoryDevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirectoryDevice.cpp; sourceTree = "<group>"; };
+		70684990151E896900C9574F /* DirectoryDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectoryDevice.h; sourceTree = "<group>"; };
+		70684991151E896900C9574F /* Ioman_Device.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Ioman_Device.h; sourceTree = "<group>"; };
+		70684992151E896900C9574F /* Iop_BiosBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_BiosBase.h; sourceTree = "<group>"; };
+		70684993151E896900C9574F /* Iop_Cdvdfsv.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Cdvdfsv.cpp; sourceTree = "<group>"; };
+		70684994151E896900C9574F /* Iop_Cdvdfsv.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Cdvdfsv.h; sourceTree = "<group>"; };
+		70684995151E896900C9574F /* Iop_Cdvdman.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Cdvdman.cpp; sourceTree = "<group>"; };
+		70684996151E896900C9574F /* Iop_Cdvdman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Cdvdman.h; sourceTree = "<group>"; };
+		7068499B151E896900C9574F /* Iop_Dmac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Dmac.cpp; sourceTree = "<group>"; };
+		7068499C151E896900C9574F /* Iop_Dmac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Dmac.h; sourceTree = "<group>"; };
+		7068499D151E896900C9574F /* Iop_DmacChannel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_DmacChannel.cpp; sourceTree = "<group>"; };
+		7068499E151E896900C9574F /* Iop_DmacChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_DmacChannel.h; sourceTree = "<group>"; };
+		7068499F151E896900C9574F /* Iop_Dynamic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Dynamic.cpp; sourceTree = "<group>"; };
+		706849A0151E896900C9574F /* Iop_Dynamic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Dynamic.h; sourceTree = "<group>"; };
+		706849A1151E896900C9574F /* Iop_FileIo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_FileIo.cpp; sourceTree = "<group>"; };
+		706849A2151E896900C9574F /* Iop_FileIo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_FileIo.h; sourceTree = "<group>"; };
+		706849A3151E896900C9574F /* Iop_Intc.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Intc.cpp; sourceTree = "<group>"; };
+		706849A4151E896900C9574F /* Iop_Intc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Intc.h; sourceTree = "<group>"; };
+		706849A5151E896900C9574F /* Iop_Intrman.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Intrman.cpp; sourceTree = "<group>"; };
+		706849A6151E896900C9574F /* Iop_Intrman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Intrman.h; sourceTree = "<group>"; };
+		706849A7151E896900C9574F /* Iop_Ioman.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Ioman.cpp; sourceTree = "<group>"; };
+		706849A8151E896900C9574F /* Iop_Ioman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Ioman.h; sourceTree = "<group>"; };
+		706849AB151E896900C9574F /* Iop_Loadcore.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Loadcore.cpp; sourceTree = "<group>"; };
+		706849AC151E896900C9574F /* Iop_Loadcore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Loadcore.h; sourceTree = "<group>"; };
+		706849AD151E896900C9574F /* Iop_McServ.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_McServ.cpp; sourceTree = "<group>"; };
+		706849AE151E896900C9574F /* Iop_McServ.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_McServ.h; sourceTree = "<group>"; };
+		706849AF151E896900C9574F /* Iop_Modload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Modload.cpp; sourceTree = "<group>"; };
+		706849B0151E896900C9574F /* Iop_Modload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Modload.h; sourceTree = "<group>"; };
+		706849B1151E896900C9574F /* Iop_Module.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Module.h; sourceTree = "<group>"; };
+		706849B2151E896900C9574F /* Iop_PadMan.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_PadMan.cpp; sourceTree = "<group>"; };
+		706849B3151E896900C9574F /* Iop_PadMan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_PadMan.h; sourceTree = "<group>"; };
+		706849B4151E896900C9574F /* Iop_RootCounters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_RootCounters.cpp; sourceTree = "<group>"; };
+		706849B5151E896900C9574F /* Iop_RootCounters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_RootCounters.h; sourceTree = "<group>"; };
+		706849B6151E896900C9574F /* Iop_SifCmd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_SifCmd.cpp; sourceTree = "<group>"; };
+		706849B7151E896900C9574F /* Iop_SifCmd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_SifCmd.h; sourceTree = "<group>"; };
+		706849B8151E896900C9574F /* Iop_SifDynamic.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_SifDynamic.cpp; sourceTree = "<group>"; };
+		706849B9151E896900C9574F /* Iop_SifDynamic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_SifDynamic.h; sourceTree = "<group>"; };
+		706849BA151E896900C9574F /* Iop_SifMan.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_SifMan.cpp; sourceTree = "<group>"; };
+		706849BB151E896900C9574F /* Iop_Sifman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Sifman.h; sourceTree = "<group>"; };
+		706849BC151E896900C9574F /* Iop_SifManNull.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_SifManNull.cpp; sourceTree = "<group>"; };
+		706849BD151E896900C9574F /* Iop_SifManNull.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_SifManNull.h; sourceTree = "<group>"; };
+		706849BE151E896900C9574F /* Iop_SifManPs2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_SifManPs2.cpp; sourceTree = "<group>"; };
+		706849BF151E896900C9574F /* Iop_SifManPs2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_SifManPs2.h; sourceTree = "<group>"; };
+		706849C0151E896900C9574F /* Iop_Spu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Spu.cpp; sourceTree = "<group>"; };
+		706849C1151E896900C9574F /* Iop_Spu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Spu.h; sourceTree = "<group>"; };
+		706849C2151E896900C9574F /* Iop_Spu2_Core.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Spu2_Core.cpp; sourceTree = "<group>"; };
+		706849C3151E896900C9574F /* Iop_Spu2_Core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Spu2_Core.h; sourceTree = "<group>"; };
+		706849C4151E896900C9574F /* Iop_Spu2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Spu2.cpp; sourceTree = "<group>"; };
+		706849C5151E896900C9574F /* Iop_Spu2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Spu2.h; sourceTree = "<group>"; };
+		706849C6151E896900C9574F /* Iop_SpuBase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_SpuBase.cpp; sourceTree = "<group>"; };
+		706849C7151E896900C9574F /* Iop_SpuBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_SpuBase.h; sourceTree = "<group>"; };
+		706849C8151E896900C9574F /* Iop_Stdio.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Stdio.cpp; sourceTree = "<group>"; };
+		706849C9151E896900C9574F /* Iop_Stdio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Stdio.h; sourceTree = "<group>"; };
+		706849CA151E896900C9574F /* Iop_SubSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_SubSystem.cpp; sourceTree = "<group>"; };
+		706849CB151E896900C9574F /* Iop_SubSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_SubSystem.h; sourceTree = "<group>"; };
+		706849CC151E896900C9574F /* Iop_Sysclib.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Sysclib.cpp; sourceTree = "<group>"; };
+		706849CD151E896900C9574F /* Iop_Sysclib.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Sysclib.h; sourceTree = "<group>"; };
+		706849CE151E896900C9574F /* Iop_Sysmem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Sysmem.cpp; sourceTree = "<group>"; };
+		706849CF151E896900C9574F /* Iop_Sysmem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Sysmem.h; sourceTree = "<group>"; };
+		706849D0151E896900C9574F /* Iop_Thbase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Thbase.cpp; sourceTree = "<group>"; };
+		706849D1151E896900C9574F /* Iop_Thbase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Thbase.h; sourceTree = "<group>"; };
+		706849D2151E896900C9574F /* Iop_Thevent.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Thevent.cpp; sourceTree = "<group>"; };
+		706849D3151E896900C9574F /* Iop_Thevent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Thevent.h; sourceTree = "<group>"; };
+		706849D4151E896900C9574F /* Iop_Thsema.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Thsema.cpp; sourceTree = "<group>"; };
+		706849D5151E896900C9574F /* Iop_Thsema.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Thsema.h; sourceTree = "<group>"; };
+		706849D6151E896900C9574F /* Iop_Timrman.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Timrman.cpp; sourceTree = "<group>"; };
+		706849D7151E896900C9574F /* Iop_Timrman.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Timrman.h; sourceTree = "<group>"; };
+		706849D8151E896900C9574F /* Iop_Vblank.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Vblank.cpp; sourceTree = "<group>"; };
+		706849D9151E896900C9574F /* Iop_Vblank.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Vblank.h; sourceTree = "<group>"; };
+		706849DA151E896900C9574F /* IopBios.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IopBios.cpp; sourceTree = "<group>"; };
+		706849DB151E896900C9574F /* IopBios.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IopBios.h; sourceTree = "<group>"; };
+		706849DC151E896900C9574F /* IsoDevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IsoDevice.cpp; sourceTree = "<group>"; };
+		706849DD151E896900C9574F /* IsoDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IsoDevice.h; sourceTree = "<group>"; };
+		70684A06151E89E200C9574F /* ApplicationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ApplicationDelegate.h; sourceTree = "<group>"; };
+		70684A07151E89E200C9574F /* ApplicationDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ApplicationDelegate.mm; sourceTree = "<group>"; };
+		70684A0C151E89E200C9574F /* Globals.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Globals.cpp; sourceTree = "<group>"; };
+		70684A0D151E89E200C9574F /* Globals.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Globals.h; sourceTree = "<group>"; };
+		70684A0E151E89E200C9574F /* GSH_OpenGLMacOSX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GSH_OpenGLMacOSX.cpp; sourceTree = "<group>"; };
+		70684A0F151E89E200C9574F /* GSH_OpenGLMacOSX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSH_OpenGLMacOSX.h; sourceTree = "<group>"; };
+		70684A15151E89E200C9574F /* PH_HidMacOSX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PH_HidMacOSX.cpp; sourceTree = "<group>"; };
+		70684A16151E89E200C9574F /* PH_HidMacOSX.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PH_HidMacOSX.h; sourceTree = "<group>"; };
+		70684A19151E89E200C9574F /* VfsManagerBindings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VfsManagerBindings.h; sourceTree = "<group>"; };
+		70684A1A151E89E200C9574F /* VfsManagerBindings.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VfsManagerBindings.mm; sourceTree = "<group>"; };
+		70684A1B151E89E200C9574F /* VfsManagerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VfsManagerViewController.h; sourceTree = "<group>"; };
+		70684A1C151E89E200C9574F /* VfsManagerViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = VfsManagerViewController.mm; sourceTree = "<group>"; };
 		70684A28151E8A2C00C9574F /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
-		70684A35151E8B2400C9574F /* English */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = English; path = InfoPlist.strings; sourceTree = "<group>"; };
-		70684A39151E8B2400C9574F /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = VfsManagerView.xib; sourceTree = "<group>"; };
-		7075D0AE1B6325540010D69C /* DiskUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DiskUtils.cpp; path = ../Source/DiskUtils.cpp; sourceTree = "<group>"; };
-		7075D0AF1B6325540010D69C /* DiskUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DiskUtils.h; path = ../Source/DiskUtils.h; sourceTree = "<group>"; };
-		7076A8041C8A7F5300C6B873 /* Iop_Thvpool.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Thvpool.cpp; path = ../Source/iop/Iop_Thvpool.cpp; sourceTree = "<group>"; };
-		7076A8051C8A7F5300C6B873 /* Iop_Thvpool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Thvpool.h; path = ../Source/iop/Iop_Thvpool.h; sourceTree = "<group>"; };
-		707AF6B61ADE04AB00EA1374 /* CsoImageStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CsoImageStream.cpp; path = ../Source/CsoImageStream.cpp; sourceTree = "<group>"; };
-		707AF6B71ADE04AB00EA1374 /* CsoImageStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CsoImageStream.h; path = ../Source/CsoImageStream.h; sourceTree = "<group>"; };
-		70B4147D1AA21D1100AC7DE4 /* Iop_FileIoHandler1000.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_FileIoHandler1000.cpp; path = ../Source/iop/Iop_FileIoHandler1000.cpp; sourceTree = "<group>"; };
-		70B4147E1AA21D1100AC7DE4 /* Iop_FileIoHandler1000.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_FileIoHandler1000.h; path = ../Source/iop/Iop_FileIoHandler1000.h; sourceTree = "<group>"; };
-		70B4147F1AA21D1100AC7DE4 /* Iop_FileIoHandler2100.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_FileIoHandler2100.cpp; path = ../Source/iop/Iop_FileIoHandler2100.cpp; sourceTree = "<group>"; };
-		70B414801AA21D1100AC7DE4 /* Iop_FileIoHandler2100.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_FileIoHandler2100.h; path = ../Source/iop/Iop_FileIoHandler2100.h; sourceTree = "<group>"; };
-		70B414811AA21D1100AC7DE4 /* Iop_FileIoHandler2300.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_FileIoHandler2300.cpp; path = ../Source/iop/Iop_FileIoHandler2300.cpp; sourceTree = "<group>"; };
-		70B414821AA21D1100AC7DE4 /* Iop_FileIoHandler2300.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_FileIoHandler2300.h; path = ../Source/iop/Iop_FileIoHandler2300.h; sourceTree = "<group>"; };
-		70B414831AA21D1100AC7DE4 /* Iop_LibSd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_LibSd.cpp; path = ../Source/iop/Iop_LibSd.cpp; sourceTree = "<group>"; };
-		70B414841AA21D1100AC7DE4 /* Iop_LibSd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_LibSd.h; path = ../Source/iop/Iop_LibSd.h; sourceTree = "<group>"; };
-		70C0C84D1ADC97A900492241 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "Play!/Images.xcassets"; sourceTree = "<group>"; };
+		70684A35151E8B2400C9574F /* English */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		70684A39151E8B2400C9574F /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/VfsManagerView.xib; sourceTree = "<group>"; };
+		7075D0AE1B6325540010D69C /* DiskUtils.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DiskUtils.cpp; sourceTree = "<group>"; };
+		7075D0AF1B6325540010D69C /* DiskUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DiskUtils.h; sourceTree = "<group>"; };
+		7076A8041C8A7F5300C6B873 /* Iop_Thvpool.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Thvpool.cpp; sourceTree = "<group>"; };
+		7076A8051C8A7F5300C6B873 /* Iop_Thvpool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Thvpool.h; sourceTree = "<group>"; };
+		707AF6B61ADE04AB00EA1374 /* CsoImageStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CsoImageStream.cpp; sourceTree = "<group>"; };
+		707AF6B71ADE04AB00EA1374 /* CsoImageStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CsoImageStream.h; sourceTree = "<group>"; };
+		70B4147D1AA21D1100AC7DE4 /* Iop_FileIoHandler1000.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_FileIoHandler1000.cpp; sourceTree = "<group>"; };
+		70B4147E1AA21D1100AC7DE4 /* Iop_FileIoHandler1000.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_FileIoHandler1000.h; sourceTree = "<group>"; };
+		70B4147F1AA21D1100AC7DE4 /* Iop_FileIoHandler2100.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_FileIoHandler2100.cpp; sourceTree = "<group>"; };
+		70B414801AA21D1100AC7DE4 /* Iop_FileIoHandler2100.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_FileIoHandler2100.h; sourceTree = "<group>"; };
+		70B414811AA21D1100AC7DE4 /* Iop_FileIoHandler2300.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_FileIoHandler2300.cpp; sourceTree = "<group>"; };
+		70B414821AA21D1100AC7DE4 /* Iop_FileIoHandler2300.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_FileIoHandler2300.h; sourceTree = "<group>"; };
+		70B414831AA21D1100AC7DE4 /* Iop_LibSd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_LibSd.cpp; sourceTree = "<group>"; };
+		70B414841AA21D1100AC7DE4 /* Iop_LibSd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_LibSd.h; sourceTree = "<group>"; };
+		70C0C84D1ADC97A900492241 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = "../../build_macosx/Play!/Images.xcassets"; sourceTree = "<group>"; };
 		70CCA2701CB1E965006F99CA /* OpenAL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenAL.framework; path = System/Library/Frameworks/OpenAL.framework; sourceTree = SDKROOT; };
-		70CCA2721CB1E99A006F99CA /* SH_OpenAL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SH_OpenAL.cpp; path = ../tools/PsfPlayer/Source/SH_OpenAL.cpp; sourceTree = "<group>"; };
-		70CCA2731CB1E99A006F99CA /* SH_OpenAL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SH_OpenAL.h; path = ../tools/PsfPlayer/Source/SH_OpenAL.h; sourceTree = "<group>"; };
-		70D9F0ED1AFB016900197BBE /* COP_VU_Reflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = COP_VU_Reflection.cpp; path = ../Source/ee/COP_VU_Reflection.cpp; sourceTree = "<group>"; };
-		70D9F0EE1AFB016900197BBE /* COP_VU.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = COP_VU.cpp; path = ../Source/ee/COP_VU.cpp; sourceTree = "<group>"; };
-		70D9F0EF1AFB016900197BBE /* COP_VU.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = COP_VU.h; path = ../Source/ee/COP_VU.h; sourceTree = "<group>"; };
-		70D9F0F01AFB016900197BBE /* Dmac_Channel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Dmac_Channel.cpp; path = ../Source/ee/Dmac_Channel.cpp; sourceTree = "<group>"; };
-		70D9F0F11AFB016900197BBE /* Dmac_Channel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Dmac_Channel.h; path = ../Source/ee/Dmac_Channel.h; sourceTree = "<group>"; };
-		70D9F0F21AFB016900197BBE /* DMAC.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DMAC.cpp; path = ../Source/ee/DMAC.cpp; sourceTree = "<group>"; };
-		70D9F0F31AFB016900197BBE /* DMAC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DMAC.h; path = ../Source/ee/DMAC.h; sourceTree = "<group>"; };
-		70D9F0F41AFB016900197BBE /* Ee_SubSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Ee_SubSystem.cpp; path = ../Source/ee/Ee_SubSystem.cpp; sourceTree = "<group>"; };
-		70D9F0F51AFB016900197BBE /* Ee_SubSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Ee_SubSystem.h; path = ../Source/ee/Ee_SubSystem.h; sourceTree = "<group>"; };
-		70D9F0F61AFB016900197BBE /* EEAssembler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = EEAssembler.cpp; path = ../Source/ee/EEAssembler.cpp; sourceTree = "<group>"; };
-		70D9F0F71AFB016900197BBE /* EEAssembler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EEAssembler.h; path = ../Source/ee/EEAssembler.h; sourceTree = "<group>"; };
-		70D9F0F81AFB016900197BBE /* FpAddTruncate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FpAddTruncate.cpp; path = ../Source/ee/FpAddTruncate.cpp; sourceTree = "<group>"; };
-		70D9F0F91AFB016900197BBE /* FpAddTruncate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FpAddTruncate.h; path = ../Source/ee/FpAddTruncate.h; sourceTree = "<group>"; };
-		70D9F0FA1AFB016900197BBE /* FpMulTruncate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = FpMulTruncate.cpp; path = ../Source/ee/FpMulTruncate.cpp; sourceTree = "<group>"; };
-		70D9F0FB1AFB016900197BBE /* FpMulTruncate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FpMulTruncate.h; path = ../Source/ee/FpMulTruncate.h; sourceTree = "<group>"; };
-		70D9F0FC1AFB016900197BBE /* GIF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GIF.cpp; path = ../Source/ee/GIF.cpp; sourceTree = "<group>"; };
-		70D9F0FD1AFB016900197BBE /* GIF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GIF.h; path = ../Source/ee/GIF.h; sourceTree = "<group>"; };
-		70D9F0FE1AFB016900197BBE /* INTC.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = INTC.cpp; path = ../Source/ee/INTC.cpp; sourceTree = "<group>"; };
-		70D9F0FF1AFB016900197BBE /* INTC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = INTC.h; path = ../Source/ee/INTC.h; sourceTree = "<group>"; };
-		70D9F1001AFB016900197BBE /* IPU_DmVectorTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IPU_DmVectorTable.cpp; path = ../Source/ee/IPU_DmVectorTable.cpp; sourceTree = "<group>"; };
-		70D9F1011AFB016900197BBE /* IPU_DmVectorTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IPU_DmVectorTable.h; path = ../Source/ee/IPU_DmVectorTable.h; sourceTree = "<group>"; };
-		70D9F1021AFB016900197BBE /* IPU_MacroblockAddressIncrementTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IPU_MacroblockAddressIncrementTable.cpp; path = ../Source/ee/IPU_MacroblockAddressIncrementTable.cpp; sourceTree = "<group>"; };
-		70D9F1031AFB016900197BBE /* IPU_MacroblockAddressIncrementTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IPU_MacroblockAddressIncrementTable.h; path = ../Source/ee/IPU_MacroblockAddressIncrementTable.h; sourceTree = "<group>"; };
-		70D9F1041AFB016900197BBE /* IPU_MacroblockTypeBTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IPU_MacroblockTypeBTable.cpp; path = ../Source/ee/IPU_MacroblockTypeBTable.cpp; sourceTree = "<group>"; };
-		70D9F1051AFB016900197BBE /* IPU_MacroblockTypeBTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IPU_MacroblockTypeBTable.h; path = ../Source/ee/IPU_MacroblockTypeBTable.h; sourceTree = "<group>"; };
-		70D9F1061AFB016900197BBE /* IPU_MacroblockTypeITable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IPU_MacroblockTypeITable.cpp; path = ../Source/ee/IPU_MacroblockTypeITable.cpp; sourceTree = "<group>"; };
-		70D9F1071AFB016900197BBE /* IPU_MacroblockTypeITable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IPU_MacroblockTypeITable.h; path = ../Source/ee/IPU_MacroblockTypeITable.h; sourceTree = "<group>"; };
-		70D9F1081AFB016900197BBE /* IPU_MacroblockTypePTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IPU_MacroblockTypePTable.cpp; path = ../Source/ee/IPU_MacroblockTypePTable.cpp; sourceTree = "<group>"; };
-		70D9F1091AFB016900197BBE /* IPU_MacroblockTypePTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IPU_MacroblockTypePTable.h; path = ../Source/ee/IPU_MacroblockTypePTable.h; sourceTree = "<group>"; };
-		70D9F10A1AFB016900197BBE /* IPU_MotionCodeTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IPU_MotionCodeTable.cpp; path = ../Source/ee/IPU_MotionCodeTable.cpp; sourceTree = "<group>"; };
-		70D9F10B1AFB016900197BBE /* IPU_MotionCodeTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IPU_MotionCodeTable.h; path = ../Source/ee/IPU_MotionCodeTable.h; sourceTree = "<group>"; };
-		70D9F10C1AFB016900197BBE /* IPU.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IPU.cpp; path = ../Source/ee/IPU.cpp; sourceTree = "<group>"; };
-		70D9F10D1AFB016900197BBE /* IPU.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IPU.h; path = ../Source/ee/IPU.h; sourceTree = "<group>"; };
-		70D9F10E1AFB016900197BBE /* MA_EE_Reflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MA_EE_Reflection.cpp; path = ../Source/ee/MA_EE_Reflection.cpp; sourceTree = "<group>"; };
-		70D9F10F1AFB016900197BBE /* MA_EE.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MA_EE.cpp; path = ../Source/ee/MA_EE.cpp; sourceTree = "<group>"; };
-		70D9F1101AFB016900197BBE /* MA_EE.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MA_EE.h; path = ../Source/ee/MA_EE.h; sourceTree = "<group>"; };
-		70D9F1111AFB016900197BBE /* MA_VU_Lower.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MA_VU_Lower.cpp; path = ../Source/ee/MA_VU_Lower.cpp; sourceTree = "<group>"; };
-		70D9F1121AFB016900197BBE /* MA_VU_LowerReflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MA_VU_LowerReflection.cpp; path = ../Source/ee/MA_VU_LowerReflection.cpp; sourceTree = "<group>"; };
-		70D9F1131AFB016900197BBE /* MA_VU_Upper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MA_VU_Upper.cpp; path = ../Source/ee/MA_VU_Upper.cpp; sourceTree = "<group>"; };
-		70D9F1141AFB016900197BBE /* MA_VU_UpperReflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MA_VU_UpperReflection.cpp; path = ../Source/ee/MA_VU_UpperReflection.cpp; sourceTree = "<group>"; };
-		70D9F1151AFB016900197BBE /* MA_VU.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MA_VU.cpp; path = ../Source/ee/MA_VU.cpp; sourceTree = "<group>"; };
-		70D9F1161AFB016900197BBE /* MA_VU.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MA_VU.h; path = ../Source/ee/MA_VU.h; sourceTree = "<group>"; };
-		70D9F1171AFB016900197BBE /* PS2OS.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PS2OS.cpp; path = ../Source/ee/PS2OS.cpp; sourceTree = "<group>"; };
-		70D9F1181AFB016900197BBE /* PS2OS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PS2OS.h; path = ../Source/ee/PS2OS.h; sourceTree = "<group>"; };
-		70D9F1191AFB016900197BBE /* SIF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SIF.cpp; path = ../Source/ee/SIF.cpp; sourceTree = "<group>"; };
-		70D9F11A1AFB016900197BBE /* SIF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SIF.h; path = ../Source/ee/SIF.h; sourceTree = "<group>"; };
-		70D9F11B1AFB016900197BBE /* Timer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Timer.cpp; path = ../Source/ee/Timer.cpp; sourceTree = "<group>"; };
-		70D9F11C1AFB016900197BBE /* Timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Timer.h; path = ../Source/ee/Timer.h; sourceTree = "<group>"; };
-		70D9F1231AFB016900197BBE /* VuAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VuAnalysis.cpp; path = ../Source/ee/VuAnalysis.cpp; sourceTree = "<group>"; };
-		70D9F1241AFB016900197BBE /* VuAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VuAnalysis.h; path = ../Source/ee/VuAnalysis.h; sourceTree = "<group>"; };
-		70D9F1251AFB016900197BBE /* VuBasicBlock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VuBasicBlock.cpp; path = ../Source/ee/VuBasicBlock.cpp; sourceTree = "<group>"; };
-		70D9F1261AFB016900197BBE /* VuBasicBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VuBasicBlock.h; path = ../Source/ee/VuBasicBlock.h; sourceTree = "<group>"; };
-		70D9F1271AFB016900197BBE /* VuExecutor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VuExecutor.cpp; path = ../Source/ee/VuExecutor.cpp; sourceTree = "<group>"; };
-		70D9F1281AFB016900197BBE /* VuExecutor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VuExecutor.h; path = ../Source/ee/VuExecutor.h; sourceTree = "<group>"; };
-		70D9F1291AFB016900197BBE /* VUShared_Reflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VUShared_Reflection.cpp; path = ../Source/ee/VUShared_Reflection.cpp; sourceTree = "<group>"; };
-		70D9F12A1AFB016900197BBE /* VUShared.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VUShared.cpp; path = ../Source/ee/VUShared.cpp; sourceTree = "<group>"; };
-		70D9F12B1AFB016900197BBE /* VUShared.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VUShared.h; path = ../Source/ee/VUShared.h; sourceTree = "<group>"; };
-		70D9F1501AFB018900197BBE /* GsCachedArea.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GsCachedArea.cpp; path = ../Source/gs/GsCachedArea.cpp; sourceTree = "<group>"; };
-		70D9F1511AFB018900197BBE /* GsCachedArea.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GsCachedArea.h; path = ../Source/gs/GsCachedArea.h; sourceTree = "<group>"; };
-		70D9F1521AFB018900197BBE /* GSH_Null.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GSH_Null.cpp; path = ../Source/gs/GSH_Null.cpp; sourceTree = "<group>"; };
-		70D9F1531AFB018900197BBE /* GSH_Null.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GSH_Null.h; path = ../Source/gs/GSH_Null.h; sourceTree = "<group>"; };
-		70D9F1541AFB018900197BBE /* GSHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GSHandler.cpp; path = ../Source/gs/GSHandler.cpp; sourceTree = "<group>"; };
-		70D9F1551AFB018900197BBE /* GSHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GSHandler.h; path = ../Source/gs/GSHandler.h; sourceTree = "<group>"; };
-		70D9F1561AFB018900197BBE /* GsPixelFormats.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GsPixelFormats.cpp; path = ../Source/gs/GsPixelFormats.cpp; sourceTree = "<group>"; };
-		70D9F1571AFB018900197BBE /* GsPixelFormats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GsPixelFormats.h; path = ../Source/gs/GsPixelFormats.h; sourceTree = "<group>"; };
-		70D9F15C1AFB019F00197BBE /* GSH_OpenGL_Shader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GSH_OpenGL_Shader.cpp; path = ../Source/gs/GSH_OpenGL/GSH_OpenGL_Shader.cpp; sourceTree = "<group>"; };
-		70D9F15D1AFB019F00197BBE /* GSH_OpenGL_Texture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GSH_OpenGL_Texture.cpp; path = ../Source/gs/GSH_OpenGL/GSH_OpenGL_Texture.cpp; sourceTree = "<group>"; };
-		70D9F15E1AFB019F00197BBE /* GSH_OpenGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GSH_OpenGL.cpp; path = ../Source/gs/GSH_OpenGL/GSH_OpenGL.cpp; sourceTree = "<group>"; };
-		70D9F15F1AFB019F00197BBE /* GSH_OpenGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GSH_OpenGL.h; path = ../Source/gs/GSH_OpenGL/GSH_OpenGL.h; sourceTree = "<group>"; };
-		70F0372C15D83D0E006A96F1 /* Iop_Thmsgbx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Iop_Thmsgbx.cpp; path = ../Source/iop/Iop_Thmsgbx.cpp; sourceTree = "<group>"; };
-		70F0372D15D83D0E006A96F1 /* Iop_Thmsgbx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Iop_Thmsgbx.h; path = ../Source/iop/Iop_Thmsgbx.h; sourceTree = "<group>"; };
-		70F2AB0A1CBB558B00D0773D /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = AudioSettingsView.xib; sourceTree = "<group>"; };
-		70F2AB0C1CBB56B600D0773D /* AudioSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AudioSettingsViewController.h; path = ../Source/ui_macosx/AudioSettingsViewController.h; sourceTree = "<group>"; };
-		70F2AB0D1CBB56B600D0773D /* AudioSettingsViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AudioSettingsViewController.mm; path = ../Source/ui_macosx/AudioSettingsViewController.mm; sourceTree = "<group>"; };
-		70F2AB0F1CBC544C00D0773D /* PreferenceDefs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PreferenceDefs.h; path = ../Source/ui_macosx/PreferenceDefs.h; sourceTree = "<group>"; };
-		7E4C15711517CBD400357777 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Source/ui_macosx/Info.plist; sourceTree = "<group>"; };
-		7E4C15721517CBD400357777 /* main.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = main.mm; path = ../Source/ui_macosx/main.mm; sourceTree = "<group>"; };
-		7E4C15731517CBD400357777 /* Purei_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Purei_Prefix.pch; path = ../Source/ui_macosx/Purei_Prefix.pch; sourceTree = "<group>"; };
+		70CCA2721CB1E99A006F99CA /* SH_OpenAL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SH_OpenAL.cpp; path = ../../tools/PsfPlayer/Source/SH_OpenAL.cpp; sourceTree = "<group>"; };
+		70CCA2731CB1E99A006F99CA /* SH_OpenAL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SH_OpenAL.h; path = ../../tools/PsfPlayer/Source/SH_OpenAL.h; sourceTree = "<group>"; };
+		70D9F0ED1AFB016900197BBE /* COP_VU_Reflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = COP_VU_Reflection.cpp; sourceTree = "<group>"; };
+		70D9F0EE1AFB016900197BBE /* COP_VU.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = COP_VU.cpp; sourceTree = "<group>"; };
+		70D9F0EF1AFB016900197BBE /* COP_VU.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = COP_VU.h; sourceTree = "<group>"; };
+		70D9F0F01AFB016900197BBE /* Dmac_Channel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Dmac_Channel.cpp; sourceTree = "<group>"; };
+		70D9F0F11AFB016900197BBE /* Dmac_Channel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Dmac_Channel.h; sourceTree = "<group>"; };
+		70D9F0F21AFB016900197BBE /* DMAC.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DMAC.cpp; sourceTree = "<group>"; };
+		70D9F0F31AFB016900197BBE /* DMAC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DMAC.h; sourceTree = "<group>"; };
+		70D9F0F41AFB016900197BBE /* Ee_SubSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Ee_SubSystem.cpp; sourceTree = "<group>"; };
+		70D9F0F51AFB016900197BBE /* Ee_SubSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Ee_SubSystem.h; sourceTree = "<group>"; };
+		70D9F0F61AFB016900197BBE /* EEAssembler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EEAssembler.cpp; sourceTree = "<group>"; };
+		70D9F0F71AFB016900197BBE /* EEAssembler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EEAssembler.h; sourceTree = "<group>"; };
+		70D9F0F81AFB016900197BBE /* FpAddTruncate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FpAddTruncate.cpp; sourceTree = "<group>"; };
+		70D9F0F91AFB016900197BBE /* FpAddTruncate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FpAddTruncate.h; sourceTree = "<group>"; };
+		70D9F0FA1AFB016900197BBE /* FpMulTruncate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FpMulTruncate.cpp; sourceTree = "<group>"; };
+		70D9F0FB1AFB016900197BBE /* FpMulTruncate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FpMulTruncate.h; sourceTree = "<group>"; };
+		70D9F0FC1AFB016900197BBE /* GIF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GIF.cpp; sourceTree = "<group>"; };
+		70D9F0FD1AFB016900197BBE /* GIF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GIF.h; sourceTree = "<group>"; };
+		70D9F0FE1AFB016900197BBE /* INTC.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = INTC.cpp; sourceTree = "<group>"; };
+		70D9F0FF1AFB016900197BBE /* INTC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = INTC.h; sourceTree = "<group>"; };
+		70D9F1001AFB016900197BBE /* IPU_DmVectorTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IPU_DmVectorTable.cpp; sourceTree = "<group>"; };
+		70D9F1011AFB016900197BBE /* IPU_DmVectorTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPU_DmVectorTable.h; sourceTree = "<group>"; };
+		70D9F1021AFB016900197BBE /* IPU_MacroblockAddressIncrementTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IPU_MacroblockAddressIncrementTable.cpp; sourceTree = "<group>"; };
+		70D9F1031AFB016900197BBE /* IPU_MacroblockAddressIncrementTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPU_MacroblockAddressIncrementTable.h; sourceTree = "<group>"; };
+		70D9F1041AFB016900197BBE /* IPU_MacroblockTypeBTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IPU_MacroblockTypeBTable.cpp; sourceTree = "<group>"; };
+		70D9F1051AFB016900197BBE /* IPU_MacroblockTypeBTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPU_MacroblockTypeBTable.h; sourceTree = "<group>"; };
+		70D9F1061AFB016900197BBE /* IPU_MacroblockTypeITable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IPU_MacroblockTypeITable.cpp; sourceTree = "<group>"; };
+		70D9F1071AFB016900197BBE /* IPU_MacroblockTypeITable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPU_MacroblockTypeITable.h; sourceTree = "<group>"; };
+		70D9F1081AFB016900197BBE /* IPU_MacroblockTypePTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IPU_MacroblockTypePTable.cpp; sourceTree = "<group>"; };
+		70D9F1091AFB016900197BBE /* IPU_MacroblockTypePTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPU_MacroblockTypePTable.h; sourceTree = "<group>"; };
+		70D9F10A1AFB016900197BBE /* IPU_MotionCodeTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IPU_MotionCodeTable.cpp; sourceTree = "<group>"; };
+		70D9F10B1AFB016900197BBE /* IPU_MotionCodeTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPU_MotionCodeTable.h; sourceTree = "<group>"; };
+		70D9F10C1AFB016900197BBE /* IPU.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IPU.cpp; sourceTree = "<group>"; };
+		70D9F10D1AFB016900197BBE /* IPU.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IPU.h; sourceTree = "<group>"; };
+		70D9F10E1AFB016900197BBE /* MA_EE_Reflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MA_EE_Reflection.cpp; sourceTree = "<group>"; };
+		70D9F10F1AFB016900197BBE /* MA_EE.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MA_EE.cpp; sourceTree = "<group>"; };
+		70D9F1101AFB016900197BBE /* MA_EE.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MA_EE.h; sourceTree = "<group>"; };
+		70D9F1111AFB016900197BBE /* MA_VU_Lower.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MA_VU_Lower.cpp; sourceTree = "<group>"; };
+		70D9F1121AFB016900197BBE /* MA_VU_LowerReflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MA_VU_LowerReflection.cpp; sourceTree = "<group>"; };
+		70D9F1131AFB016900197BBE /* MA_VU_Upper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MA_VU_Upper.cpp; sourceTree = "<group>"; };
+		70D9F1141AFB016900197BBE /* MA_VU_UpperReflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MA_VU_UpperReflection.cpp; sourceTree = "<group>"; };
+		70D9F1151AFB016900197BBE /* MA_VU.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MA_VU.cpp; sourceTree = "<group>"; };
+		70D9F1161AFB016900197BBE /* MA_VU.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MA_VU.h; sourceTree = "<group>"; };
+		70D9F1171AFB016900197BBE /* PS2OS.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PS2OS.cpp; sourceTree = "<group>"; };
+		70D9F1181AFB016900197BBE /* PS2OS.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PS2OS.h; sourceTree = "<group>"; };
+		70D9F1191AFB016900197BBE /* SIF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SIF.cpp; sourceTree = "<group>"; };
+		70D9F11A1AFB016900197BBE /* SIF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIF.h; sourceTree = "<group>"; };
+		70D9F11B1AFB016900197BBE /* Timer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Timer.cpp; sourceTree = "<group>"; };
+		70D9F11C1AFB016900197BBE /* Timer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Timer.h; sourceTree = "<group>"; };
+		70D9F1231AFB016900197BBE /* VuAnalysis.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VuAnalysis.cpp; sourceTree = "<group>"; };
+		70D9F1241AFB016900197BBE /* VuAnalysis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VuAnalysis.h; sourceTree = "<group>"; };
+		70D9F1251AFB016900197BBE /* VuBasicBlock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VuBasicBlock.cpp; sourceTree = "<group>"; };
+		70D9F1261AFB016900197BBE /* VuBasicBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VuBasicBlock.h; sourceTree = "<group>"; };
+		70D9F1271AFB016900197BBE /* VuExecutor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VuExecutor.cpp; sourceTree = "<group>"; };
+		70D9F1281AFB016900197BBE /* VuExecutor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VuExecutor.h; sourceTree = "<group>"; };
+		70D9F1291AFB016900197BBE /* VUShared_Reflection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VUShared_Reflection.cpp; sourceTree = "<group>"; };
+		70D9F12A1AFB016900197BBE /* VUShared.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VUShared.cpp; sourceTree = "<group>"; };
+		70D9F12B1AFB016900197BBE /* VUShared.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VUShared.h; sourceTree = "<group>"; };
+		70D9F1501AFB018900197BBE /* GsCachedArea.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GsCachedArea.cpp; sourceTree = "<group>"; };
+		70D9F1511AFB018900197BBE /* GsCachedArea.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GsCachedArea.h; sourceTree = "<group>"; };
+		70D9F1521AFB018900197BBE /* GSH_Null.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GSH_Null.cpp; sourceTree = "<group>"; };
+		70D9F1531AFB018900197BBE /* GSH_Null.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSH_Null.h; sourceTree = "<group>"; };
+		70D9F1541AFB018900197BBE /* GSHandler.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GSHandler.cpp; sourceTree = "<group>"; };
+		70D9F1551AFB018900197BBE /* GSHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSHandler.h; sourceTree = "<group>"; };
+		70D9F1561AFB018900197BBE /* GsPixelFormats.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GsPixelFormats.cpp; sourceTree = "<group>"; };
+		70D9F1571AFB018900197BBE /* GsPixelFormats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GsPixelFormats.h; sourceTree = "<group>"; };
+		70D9F15C1AFB019F00197BBE /* GSH_OpenGL_Shader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GSH_OpenGL_Shader.cpp; path = GSH_OpenGL/GSH_OpenGL_Shader.cpp; sourceTree = "<group>"; };
+		70D9F15D1AFB019F00197BBE /* GSH_OpenGL_Texture.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GSH_OpenGL_Texture.cpp; path = GSH_OpenGL/GSH_OpenGL_Texture.cpp; sourceTree = "<group>"; };
+		70D9F15E1AFB019F00197BBE /* GSH_OpenGL.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GSH_OpenGL.cpp; path = GSH_OpenGL/GSH_OpenGL.cpp; sourceTree = "<group>"; };
+		70D9F15F1AFB019F00197BBE /* GSH_OpenGL.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GSH_OpenGL.h; path = GSH_OpenGL/GSH_OpenGL.h; sourceTree = "<group>"; };
+		70F0372C15D83D0E006A96F1 /* Iop_Thmsgbx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Iop_Thmsgbx.cpp; sourceTree = "<group>"; };
+		70F0372D15D83D0E006A96F1 /* Iop_Thmsgbx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Iop_Thmsgbx.h; sourceTree = "<group>"; };
+		70F2AB0A1CBB558B00D0773D /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/AudioSettingsView.xib; sourceTree = "<group>"; };
+		70F2AB0C1CBB56B600D0773D /* AudioSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AudioSettingsViewController.h; sourceTree = "<group>"; };
+		70F2AB0D1CBB56B600D0773D /* AudioSettingsViewController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioSettingsViewController.mm; sourceTree = "<group>"; };
+		70F2AB0F1CBC544C00D0773D /* PreferenceDefs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PreferenceDefs.h; sourceTree = "<group>"; };
+		7E4C15711517CBD400357777 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7E4C15721517CBD400357777 /* main.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
+		7E4C15731517CBD400357777 /* Purei_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Purei_Prefix.pch; sourceTree = "<group>"; };
 		7E4C15761517CDD000357777 /* Framework.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Framework.xcodeproj; path = ../../Framework/build_macosx/Framework.xcodeproj; sourceTree = "<group>"; };
-		7E4C15911519A8FE00357777 /* AppConfig.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = AppConfig.cpp; path = ../Source/AppConfig.cpp; sourceTree = "<group>"; };
-		7E4C15921519A8FE00357777 /* AppConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = AppConfig.h; path = ../Source/AppConfig.h; sourceTree = "<group>"; };
-		7E4C15931519A8FE00357777 /* BasicBlock.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = BasicBlock.cpp; path = ../Source/BasicBlock.cpp; sourceTree = "<group>"; };
-		7E4C15941519A8FE00357777 /* BasicBlock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = BasicBlock.h; path = ../Source/BasicBlock.h; sourceTree = "<group>"; };
-		7E4C15951519A8FE00357777 /* ControllerInfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ControllerInfo.cpp; path = ../Source/ControllerInfo.cpp; sourceTree = "<group>"; };
-		7E4C15961519A8FE00357777 /* ControllerInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ControllerInfo.h; path = ../Source/ControllerInfo.h; sourceTree = "<group>"; };
-		7E4C15971519A8FE00357777 /* COP_FPU.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = COP_FPU.cpp; path = ../Source/COP_FPU.cpp; sourceTree = "<group>"; };
-		7E4C15981519A8FE00357777 /* COP_FPU.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = COP_FPU.h; path = ../Source/COP_FPU.h; sourceTree = "<group>"; };
-		7E4C15991519A8FE00357777 /* COP_FPU_Reflection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = COP_FPU_Reflection.cpp; path = ../Source/COP_FPU_Reflection.cpp; sourceTree = "<group>"; };
-		7E4C159A1519A8FE00357777 /* COP_SCU.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = COP_SCU.cpp; path = ../Source/COP_SCU.cpp; sourceTree = "<group>"; };
-		7E4C159B1519A8FE00357777 /* COP_SCU.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = COP_SCU.h; path = ../Source/COP_SCU.h; sourceTree = "<group>"; };
-		7E4C159C1519A8FE00357777 /* COP_SCU_Reflection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = COP_SCU_Reflection.cpp; path = ../Source/COP_SCU_Reflection.cpp; sourceTree = "<group>"; };
-		7E4C15A41519A8FE00357777 /* ELF.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ELF.cpp; path = ../Source/ELF.cpp; sourceTree = "<group>"; };
-		7E4C15A51519A8FE00357777 /* ELF.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ELF.h; path = ../Source/ELF.h; sourceTree = "<group>"; };
-		7E4C15A61519A8FE00357777 /* ElfFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ElfFile.cpp; path = ../Source/ElfFile.cpp; sourceTree = "<group>"; };
-		7E4C15A71519A8FE00357777 /* ElfFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ElfFile.h; path = ../Source/ElfFile.h; sourceTree = "<group>"; };
-		7E4C15B51519A8FE00357777 /* Integer64.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Integer64.h; path = ../Source/Integer64.h; sourceTree = "<group>"; };
-		7E4C15C51519A96700357777 /* DirectoryRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DirectoryRecord.cpp; path = ../Source/ISO9660/DirectoryRecord.cpp; sourceTree = "<group>"; };
-		7E4C15C61519A96700357777 /* DirectoryRecord.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DirectoryRecord.h; path = ../Source/ISO9660/DirectoryRecord.h; sourceTree = "<group>"; };
-		7E4C15C71519A96700357777 /* File.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = File.cpp; path = ../Source/ISO9660/File.cpp; sourceTree = "<group>"; };
-		7E4C15C81519A96700357777 /* File.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = File.h; path = ../Source/ISO9660/File.h; sourceTree = "<group>"; };
-		7E4C15C91519A96700357777 /* ISO9660.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ISO9660.cpp; path = ../Source/ISO9660/ISO9660.cpp; sourceTree = "<group>"; };
-		7E4C15CA1519A96700357777 /* ISO9660.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ISO9660.h; path = ../Source/ISO9660/ISO9660.h; sourceTree = "<group>"; };
-		7E4C15CB1519A96700357777 /* PathTable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PathTable.cpp; path = ../Source/ISO9660/PathTable.cpp; sourceTree = "<group>"; };
-		7E4C15CC1519A96700357777 /* PathTable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PathTable.h; path = ../Source/ISO9660/PathTable.h; sourceTree = "<group>"; };
-		7E4C15CD1519A96700357777 /* PathTableRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PathTableRecord.cpp; path = ../Source/ISO9660/PathTableRecord.cpp; sourceTree = "<group>"; };
-		7E4C15CE1519A96700357777 /* PathTableRecord.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PathTableRecord.h; path = ../Source/ISO9660/PathTableRecord.h; sourceTree = "<group>"; };
-		7E4C15CF1519A96700357777 /* VolumeDescriptor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = VolumeDescriptor.cpp; path = ../Source/ISO9660/VolumeDescriptor.cpp; sourceTree = "<group>"; };
-		7E4C15D01519A96700357777 /* VolumeDescriptor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = VolumeDescriptor.h; path = ../Source/ISO9660/VolumeDescriptor.h; sourceTree = "<group>"; };
-		7E4C15D11519A99100357777 /* IszImageStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = IszImageStream.cpp; path = ../Source/IszImageStream.cpp; sourceTree = "<group>"; };
-		7E4C15D21519A99100357777 /* IszImageStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = IszImageStream.h; path = ../Source/IszImageStream.h; sourceTree = "<group>"; };
-		7E4C15D31519A99100357777 /* Log.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Log.cpp; path = ../Source/Log.cpp; sourceTree = "<group>"; };
-		7E4C15D41519A99100357777 /* Log.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Log.h; path = ../Source/Log.h; sourceTree = "<group>"; };
-		7E4C15D81519A99200357777 /* MA_MIPSIV.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MA_MIPSIV.cpp; path = ../Source/MA_MIPSIV.cpp; sourceTree = "<group>"; };
-		7E4C15D91519A99200357777 /* MA_MIPSIV.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MA_MIPSIV.h; path = ../Source/MA_MIPSIV.h; sourceTree = "<group>"; };
-		7E4C15DA1519A99300357777 /* MA_MIPSIV_Reflection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MA_MIPSIV_Reflection.cpp; path = ../Source/MA_MIPSIV_Reflection.cpp; sourceTree = "<group>"; };
-		7E4C15DB1519A99300357777 /* MA_MIPSIV_Templates.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MA_MIPSIV_Templates.cpp; path = ../Source/MA_MIPSIV_Templates.cpp; sourceTree = "<group>"; };
-		7E4C15E21519A99400357777 /* MailBox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MailBox.cpp; path = ../Source/MailBox.cpp; sourceTree = "<group>"; };
-		7E4C15E31519A99500357777 /* MailBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MailBox.h; path = ../Source/MailBox.h; sourceTree = "<group>"; };
-		7E4C15E41519A99500357777 /* MemoryMap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MemoryMap.cpp; path = ../Source/MemoryMap.cpp; sourceTree = "<group>"; };
-		7E4C15E51519A99500357777 /* MemoryMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MemoryMap.h; path = ../Source/MemoryMap.h; sourceTree = "<group>"; };
-		7E4C15E61519A99600357777 /* MemoryStateFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MemoryStateFile.cpp; path = ../Source/MemoryStateFile.cpp; sourceTree = "<group>"; };
-		7E4C15E71519A99700357777 /* MemoryStateFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MemoryStateFile.h; path = ../Source/MemoryStateFile.h; sourceTree = "<group>"; };
-		7E4C15E81519A99700357777 /* MemoryUtils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MemoryUtils.cpp; path = ../Source/MemoryUtils.cpp; sourceTree = "<group>"; };
-		7E4C15E91519A99700357777 /* MemoryUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MemoryUtils.h; path = ../Source/MemoryUtils.h; sourceTree = "<group>"; };
-		7E4C15EA1519A99700357777 /* MIPS.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MIPS.cpp; path = ../Source/MIPS.cpp; sourceTree = "<group>"; };
-		7E4C15EB1519A99700357777 /* MIPS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MIPS.h; path = ../Source/MIPS.h; sourceTree = "<group>"; };
-		7E4C15EC1519A99700357777 /* MIPSAnalysis.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MIPSAnalysis.cpp; path = ../Source/MIPSAnalysis.cpp; sourceTree = "<group>"; };
-		7E4C15ED1519A99800357777 /* MIPSAnalysis.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MIPSAnalysis.h; path = ../Source/MIPSAnalysis.h; sourceTree = "<group>"; };
-		7E4C15EE1519A99800357777 /* MIPSArchitecture.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MIPSArchitecture.cpp; path = ../Source/MIPSArchitecture.cpp; sourceTree = "<group>"; };
-		7E4C15EF1519A99B00357777 /* MIPSArchitecture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MIPSArchitecture.h; path = ../Source/MIPSArchitecture.h; sourceTree = "<group>"; };
-		7E4C15F01519A99B00357777 /* MIPSAssembler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MIPSAssembler.cpp; path = ../Source/MIPSAssembler.cpp; sourceTree = "<group>"; };
-		7E4C15F11519A99B00357777 /* MIPSAssembler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MIPSAssembler.h; path = ../Source/MIPSAssembler.h; sourceTree = "<group>"; };
-		7E4C15F41519A99C00357777 /* MIPSCoprocessor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MIPSCoprocessor.cpp; path = ../Source/MIPSCoprocessor.cpp; sourceTree = "<group>"; };
-		7E4C15F51519A99C00357777 /* MIPSCoprocessor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MIPSCoprocessor.h; path = ../Source/MIPSCoprocessor.h; sourceTree = "<group>"; };
-		7E4C15F61519A99C00357777 /* MipsExecutor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MipsExecutor.cpp; path = ../Source/MipsExecutor.cpp; sourceTree = "<group>"; };
-		7E4C15F71519A99C00357777 /* MipsExecutor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MipsExecutor.h; path = ../Source/MipsExecutor.h; sourceTree = "<group>"; };
-		7E4C15F81519A99D00357777 /* MIPSInstructionFactory.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MIPSInstructionFactory.cpp; path = ../Source/MIPSInstructionFactory.cpp; sourceTree = "<group>"; };
-		7E4C15F91519A99D00357777 /* MIPSInstructionFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MIPSInstructionFactory.h; path = ../Source/MIPSInstructionFactory.h; sourceTree = "<group>"; };
-		7E4C15FA1519A99D00357777 /* MipsJitter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MipsJitter.cpp; path = ../Source/MipsJitter.cpp; sourceTree = "<group>"; };
-		7E4C15FB1519A99E00357777 /* MipsJitter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MipsJitter.h; path = ../Source/MipsJitter.h; sourceTree = "<group>"; };
-		7E4C15FC1519A99E00357777 /* MIPSReflection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MIPSReflection.cpp; path = ../Source/MIPSReflection.cpp; sourceTree = "<group>"; };
-		7E4C15FD1519A99E00357777 /* MIPSReflection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MIPSReflection.h; path = ../Source/MIPSReflection.h; sourceTree = "<group>"; };
-		7E4C15FE1519A99E00357777 /* MIPSTags.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MIPSTags.cpp; path = ../Source/MIPSTags.cpp; sourceTree = "<group>"; };
-		7E4C15FF1519A99E00357777 /* MIPSTags.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MIPSTags.h; path = ../Source/MIPSTags.h; sourceTree = "<group>"; };
-		7E4C16001519A99E00357777 /* PadHandler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PadHandler.cpp; path = ../Source/PadHandler.cpp; sourceTree = "<group>"; };
-		7E4C16011519A9A300357777 /* PadHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PadHandler.h; path = ../Source/PadHandler.h; sourceTree = "<group>"; };
-		7E4C16021519A9A300357777 /* PadListener.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PadListener.cpp; path = ../Source/PadListener.cpp; sourceTree = "<group>"; };
-		7E4C16031519A9A400357777 /* PadListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PadListener.h; path = ../Source/PadListener.h; sourceTree = "<group>"; };
-		7E4C16041519A9A400357777 /* Posix_VolumeStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Posix_VolumeStream.cpp; path = ../Source/Posix_VolumeStream.cpp; sourceTree = "<group>"; };
-		7E4C16051519A9A400357777 /* Posix_VolumeStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Posix_VolumeStream.h; path = ../Source/Posix_VolumeStream.h; sourceTree = "<group>"; };
-		7E4C16061519A9A400357777 /* Profiler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Profiler.cpp; path = ../Source/Profiler.cpp; sourceTree = "<group>"; };
-		7E4C16071519A9A400357777 /* Profiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Profiler.h; path = ../Source/Profiler.h; sourceTree = "<group>"; };
-		7E4C16081519A9A400357777 /* Ps2Const.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Ps2Const.h; path = ../Source/Ps2Const.h; sourceTree = "<group>"; };
-		7E4C160B1519A9A500357777 /* PS2VM.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PS2VM.cpp; path = ../Source/PS2VM.cpp; sourceTree = "<group>"; };
-		7E4C160C1519A9A500357777 /* PS2VM.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PS2VM.h; path = ../Source/PS2VM.h; sourceTree = "<group>"; };
-		7E4C160D1519A9A500357777 /* RegisterStateFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RegisterStateFile.cpp; path = ../Source/RegisterStateFile.cpp; sourceTree = "<group>"; };
-		7E4C160E1519A9A500357777 /* RegisterStateFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RegisterStateFile.h; path = ../Source/RegisterStateFile.h; sourceTree = "<group>"; };
-		7E4C16111519A9A600357777 /* SifModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SifModule.h; path = ../Source/SifModule.h; sourceTree = "<group>"; };
-		7E4C16121519A9A600357777 /* SifModuleAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SifModuleAdapter.h; path = ../Source/SifModuleAdapter.h; sourceTree = "<group>"; };
-		7E4C16131519A9A600357777 /* StructCollectionStateFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = StructCollectionStateFile.cpp; path = ../Source/StructCollectionStateFile.cpp; sourceTree = "<group>"; };
-		7E4C16141519A9A600357777 /* StructCollectionStateFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = StructCollectionStateFile.h; path = ../Source/StructCollectionStateFile.h; sourceTree = "<group>"; };
-		7E4C16151519A9A600357777 /* StructFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = StructFile.cpp; path = ../Source/StructFile.cpp; sourceTree = "<group>"; };
-		7E4C16161519A9A600357777 /* StructFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = StructFile.h; path = ../Source/StructFile.h; sourceTree = "<group>"; };
-		7E4C16191519A9A700357777 /* uint128.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = uint128.h; path = ../Source/uint128.h; sourceTree = "<group>"; };
-		7E4C161A1519A9A700357777 /* Utils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Utils.cpp; path = ../Source/Utils.cpp; sourceTree = "<group>"; };
-		7E4C161B1519A9A700357777 /* Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Utils.h; path = ../Source/Utils.h; sourceTree = "<group>"; };
-		7E4C161E1519A9A700357777 /* VirtualMachine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = VirtualMachine.h; path = ../Source/VirtualMachine.h; sourceTree = "<group>"; };
+		7E4C15911519A8FE00357777 /* AppConfig.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AppConfig.cpp; sourceTree = "<group>"; };
+		7E4C15921519A8FE00357777 /* AppConfig.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppConfig.h; sourceTree = "<group>"; };
+		7E4C15931519A8FE00357777 /* BasicBlock.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BasicBlock.cpp; sourceTree = "<group>"; };
+		7E4C15941519A8FE00357777 /* BasicBlock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BasicBlock.h; sourceTree = "<group>"; };
+		7E4C15951519A8FE00357777 /* ControllerInfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ControllerInfo.cpp; sourceTree = "<group>"; };
+		7E4C15961519A8FE00357777 /* ControllerInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ControllerInfo.h; sourceTree = "<group>"; };
+		7E4C15971519A8FE00357777 /* COP_FPU.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = COP_FPU.cpp; sourceTree = "<group>"; };
+		7E4C15981519A8FE00357777 /* COP_FPU.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = COP_FPU.h; sourceTree = "<group>"; };
+		7E4C15991519A8FE00357777 /* COP_FPU_Reflection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = COP_FPU_Reflection.cpp; sourceTree = "<group>"; };
+		7E4C159A1519A8FE00357777 /* COP_SCU.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = COP_SCU.cpp; sourceTree = "<group>"; };
+		7E4C159B1519A8FE00357777 /* COP_SCU.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = COP_SCU.h; sourceTree = "<group>"; };
+		7E4C159C1519A8FE00357777 /* COP_SCU_Reflection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = COP_SCU_Reflection.cpp; sourceTree = "<group>"; };
+		7E4C15A41519A8FE00357777 /* ELF.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ELF.cpp; sourceTree = "<group>"; };
+		7E4C15A51519A8FE00357777 /* ELF.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ELF.h; sourceTree = "<group>"; };
+		7E4C15A61519A8FE00357777 /* ElfFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ElfFile.cpp; sourceTree = "<group>"; };
+		7E4C15A71519A8FE00357777 /* ElfFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ElfFile.h; sourceTree = "<group>"; };
+		7E4C15B51519A8FE00357777 /* Integer64.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Integer64.h; sourceTree = "<group>"; };
+		7E4C15C51519A96700357777 /* DirectoryRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DirectoryRecord.cpp; sourceTree = "<group>"; };
+		7E4C15C61519A96700357777 /* DirectoryRecord.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DirectoryRecord.h; sourceTree = "<group>"; };
+		7E4C15C71519A96700357777 /* File.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = File.cpp; sourceTree = "<group>"; };
+		7E4C15C81519A96700357777 /* File.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = File.h; sourceTree = "<group>"; };
+		7E4C15C91519A96700357777 /* ISO9660.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ISO9660.cpp; sourceTree = "<group>"; };
+		7E4C15CA1519A96700357777 /* ISO9660.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ISO9660.h; sourceTree = "<group>"; };
+		7E4C15CB1519A96700357777 /* PathTable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PathTable.cpp; sourceTree = "<group>"; };
+		7E4C15CC1519A96700357777 /* PathTable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PathTable.h; sourceTree = "<group>"; };
+		7E4C15CD1519A96700357777 /* PathTableRecord.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PathTableRecord.cpp; sourceTree = "<group>"; };
+		7E4C15CE1519A96700357777 /* PathTableRecord.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PathTableRecord.h; sourceTree = "<group>"; };
+		7E4C15CF1519A96700357777 /* VolumeDescriptor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VolumeDescriptor.cpp; sourceTree = "<group>"; };
+		7E4C15D01519A96700357777 /* VolumeDescriptor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VolumeDescriptor.h; sourceTree = "<group>"; };
+		7E4C15D11519A99100357777 /* IszImageStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IszImageStream.cpp; sourceTree = "<group>"; };
+		7E4C15D21519A99100357777 /* IszImageStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IszImageStream.h; sourceTree = "<group>"; };
+		7E4C15D31519A99100357777 /* Log.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Log.cpp; sourceTree = "<group>"; };
+		7E4C15D41519A99100357777 /* Log.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Log.h; sourceTree = "<group>"; };
+		7E4C15D81519A99200357777 /* MA_MIPSIV.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MA_MIPSIV.cpp; sourceTree = "<group>"; };
+		7E4C15D91519A99200357777 /* MA_MIPSIV.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MA_MIPSIV.h; sourceTree = "<group>"; };
+		7E4C15DA1519A99300357777 /* MA_MIPSIV_Reflection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MA_MIPSIV_Reflection.cpp; sourceTree = "<group>"; };
+		7E4C15DB1519A99300357777 /* MA_MIPSIV_Templates.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MA_MIPSIV_Templates.cpp; sourceTree = "<group>"; };
+		7E4C15E21519A99400357777 /* MailBox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MailBox.cpp; sourceTree = "<group>"; };
+		7E4C15E31519A99500357777 /* MailBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MailBox.h; sourceTree = "<group>"; };
+		7E4C15E41519A99500357777 /* MemoryMap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryMap.cpp; sourceTree = "<group>"; };
+		7E4C15E51519A99500357777 /* MemoryMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MemoryMap.h; sourceTree = "<group>"; };
+		7E4C15E61519A99600357777 /* MemoryStateFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryStateFile.cpp; sourceTree = "<group>"; };
+		7E4C15E71519A99700357777 /* MemoryStateFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MemoryStateFile.h; sourceTree = "<group>"; };
+		7E4C15E81519A99700357777 /* MemoryUtils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryUtils.cpp; sourceTree = "<group>"; };
+		7E4C15E91519A99700357777 /* MemoryUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MemoryUtils.h; sourceTree = "<group>"; };
+		7E4C15EA1519A99700357777 /* MIPS.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MIPS.cpp; sourceTree = "<group>"; };
+		7E4C15EB1519A99700357777 /* MIPS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MIPS.h; sourceTree = "<group>"; };
+		7E4C15EC1519A99700357777 /* MIPSAnalysis.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MIPSAnalysis.cpp; sourceTree = "<group>"; };
+		7E4C15ED1519A99800357777 /* MIPSAnalysis.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MIPSAnalysis.h; sourceTree = "<group>"; };
+		7E4C15EE1519A99800357777 /* MIPSArchitecture.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MIPSArchitecture.cpp; sourceTree = "<group>"; };
+		7E4C15EF1519A99B00357777 /* MIPSArchitecture.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MIPSArchitecture.h; sourceTree = "<group>"; };
+		7E4C15F01519A99B00357777 /* MIPSAssembler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MIPSAssembler.cpp; sourceTree = "<group>"; };
+		7E4C15F11519A99B00357777 /* MIPSAssembler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MIPSAssembler.h; sourceTree = "<group>"; };
+		7E4C15F41519A99C00357777 /* MIPSCoprocessor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MIPSCoprocessor.cpp; sourceTree = "<group>"; };
+		7E4C15F51519A99C00357777 /* MIPSCoprocessor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MIPSCoprocessor.h; sourceTree = "<group>"; };
+		7E4C15F61519A99C00357777 /* MipsExecutor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MipsExecutor.cpp; sourceTree = "<group>"; };
+		7E4C15F71519A99C00357777 /* MipsExecutor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MipsExecutor.h; sourceTree = "<group>"; };
+		7E4C15F81519A99D00357777 /* MIPSInstructionFactory.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MIPSInstructionFactory.cpp; sourceTree = "<group>"; };
+		7E4C15F91519A99D00357777 /* MIPSInstructionFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MIPSInstructionFactory.h; sourceTree = "<group>"; };
+		7E4C15FA1519A99D00357777 /* MipsJitter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MipsJitter.cpp; sourceTree = "<group>"; };
+		7E4C15FB1519A99E00357777 /* MipsJitter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MipsJitter.h; sourceTree = "<group>"; };
+		7E4C15FC1519A99E00357777 /* MIPSReflection.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MIPSReflection.cpp; sourceTree = "<group>"; };
+		7E4C15FD1519A99E00357777 /* MIPSReflection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MIPSReflection.h; sourceTree = "<group>"; };
+		7E4C15FE1519A99E00357777 /* MIPSTags.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MIPSTags.cpp; sourceTree = "<group>"; };
+		7E4C15FF1519A99E00357777 /* MIPSTags.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MIPSTags.h; sourceTree = "<group>"; };
+		7E4C16001519A99E00357777 /* PadHandler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PadHandler.cpp; sourceTree = "<group>"; };
+		7E4C16011519A9A300357777 /* PadHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PadHandler.h; sourceTree = "<group>"; };
+		7E4C16021519A9A300357777 /* PadListener.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PadListener.cpp; sourceTree = "<group>"; };
+		7E4C16031519A9A400357777 /* PadListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PadListener.h; sourceTree = "<group>"; };
+		7E4C16041519A9A400357777 /* Posix_VolumeStream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Posix_VolumeStream.cpp; sourceTree = "<group>"; };
+		7E4C16051519A9A400357777 /* Posix_VolumeStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Posix_VolumeStream.h; sourceTree = "<group>"; };
+		7E4C16061519A9A400357777 /* Profiler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Profiler.cpp; sourceTree = "<group>"; };
+		7E4C16071519A9A400357777 /* Profiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Profiler.h; sourceTree = "<group>"; };
+		7E4C16081519A9A400357777 /* Ps2Const.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Ps2Const.h; sourceTree = "<group>"; };
+		7E4C160B1519A9A500357777 /* PS2VM.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PS2VM.cpp; sourceTree = "<group>"; };
+		7E4C160C1519A9A500357777 /* PS2VM.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PS2VM.h; sourceTree = "<group>"; };
+		7E4C160D1519A9A500357777 /* RegisterStateFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RegisterStateFile.cpp; sourceTree = "<group>"; };
+		7E4C160E1519A9A500357777 /* RegisterStateFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RegisterStateFile.h; sourceTree = "<group>"; };
+		7E4C16111519A9A600357777 /* SifModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SifModule.h; sourceTree = "<group>"; };
+		7E4C16121519A9A600357777 /* SifModuleAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SifModuleAdapter.h; sourceTree = "<group>"; };
+		7E4C16131519A9A600357777 /* StructCollectionStateFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StructCollectionStateFile.cpp; sourceTree = "<group>"; };
+		7E4C16141519A9A600357777 /* StructCollectionStateFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StructCollectionStateFile.h; sourceTree = "<group>"; };
+		7E4C16151519A9A600357777 /* StructFile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StructFile.cpp; sourceTree = "<group>"; };
+		7E4C16161519A9A600357777 /* StructFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StructFile.h; sourceTree = "<group>"; };
+		7E4C16191519A9A700357777 /* uint128.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = uint128.h; sourceTree = "<group>"; };
+		7E4C161A1519A9A700357777 /* Utils.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Utils.cpp; sourceTree = "<group>"; };
+		7E4C161B1519A9A700357777 /* Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Utils.h; sourceTree = "<group>"; };
+		7E4C161E1519A9A700357777 /* VirtualMachine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VirtualMachine.h; sourceTree = "<group>"; };
 		7E7832A71516710A00C04C62 /* Play!.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Play!.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E7832AB1516710A00C04C62 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		7E7832AE1516710A00C04C62 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -660,7 +657,7 @@
 				706849DC151E896900C9574F /* IsoDevice.cpp */,
 				706849DD151E896900C9574F /* IsoDevice.h */,
 			);
-			name = iop;
+			path = iop;
 			sourceTree = "<group>";
 		};
 		70684A05151E89BC00C9574F /* ui_macosx */ = {
@@ -668,7 +665,13 @@
 			children = (
 				70684A06151E89E200C9574F /* ApplicationDelegate.h */,
 				70684A07151E89E200C9574F /* ApplicationDelegate.mm */,
-				70684A33151E8B2400C9574F /* English.lproj */,
+				70684A34151E8B2400C9574F /* InfoPlist.strings */,
+				700DF99A15DFC0CB00818F3B /* MainMenu.xib */,
+				700FB57E15E11E1E00C322DE /* OutputWindow.xib */,
+				705D396D1C43FFC900D267A6 /* PreferencesWindow.xib */,
+				70684A38151E8B2400C9574F /* VfsManagerView.xib */,
+				705D39701C44A3FF00D267A6 /* VideoSettingsView.xib */,
+				70F2AB091CBB558B00D0773D /* AudioSettingsView.xib */,
 				70684A0C151E89E200C9574F /* Globals.cpp */,
 				70684A0D151E89E200C9574F /* Globals.h */,
 				70684A0E151E89E200C9574F /* GSH_OpenGLMacOSX.cpp */,
@@ -690,22 +693,8 @@
 				70CCA2731CB1E99A006F99CA /* SH_OpenAL.h */,
 			);
 			name = ui_macosx;
-			sourceTree = "<group>";
-		};
-		70684A33151E8B2400C9574F /* English.lproj */ = {
-			isa = PBXGroup;
-			children = (
-				70684A34151E8B2400C9574F /* InfoPlist.strings */,
-				700DF99A15DFC0CB00818F3B /* MainMenu.xib */,
-				700FB57E15E11E1E00C322DE /* OutputWindow.xib */,
-				705D396D1C43FFC900D267A6 /* PreferencesWindow.xib */,
-				70684A38151E8B2400C9574F /* VfsManagerView.xib */,
-				705D39701C44A3FF00D267A6 /* VideoSettingsView.xib */,
-				70F2AB091CBB558B00D0773D /* AudioSettingsView.xib */,
-			);
-			name = English.lproj;
-			path = ../Source/ui_macosx/English.lproj;
-			sourceTree = "<group>";
+			path = ../Source/ui_macosx;
+			sourceTree = SOURCE_ROOT;
 		};
 		707AF6B51ADE047400EA1374 /* DiskStreams */ = {
 			isa = PBXGroup;
@@ -737,7 +726,7 @@
 			name = PreferencesWindow;
 			sourceTree = "<group>";
 		};
-		70D9F0EC1AFB013400197BBE /* Ee */ = {
+		70D9F0EC1AFB013400197BBE /* ee */ = {
 			isa = PBXGroup;
 			children = (
 				70D9F0ED1AFB016900197BBE /* COP_VU_Reflection.cpp */,
@@ -806,10 +795,10 @@
 				70D9F12A1AFB016900197BBE /* VUShared.cpp */,
 				70D9F12B1AFB016900197BBE /* VUShared.h */,
 			);
-			name = Ee;
+			path = ee;
 			sourceTree = "<group>";
 		};
-		70D9F14F1AFB017700197BBE /* Gs */ = {
+		70D9F14F1AFB017700197BBE /* gs */ = {
 			isa = PBXGroup;
 			children = (
 				70D9F1501AFB018900197BBE /* GsCachedArea.cpp */,
@@ -825,7 +814,7 @@
 				70D9F1561AFB018900197BBE /* GsPixelFormats.cpp */,
 				70D9F1571AFB018900197BBE /* GsPixelFormats.h */,
 			);
-			name = Gs;
+			path = gs;
 			sourceTree = "<group>";
 		};
 		7E4C15701517CBB900357777 /* Source Files */ = {
@@ -835,6 +824,7 @@
 				7E4C15901519A8D900357777 /* Play Core */,
 			);
 			name = "Source Files";
+			path = ../Source;
 			sourceTree = "<group>";
 		};
 		7E4C15771517CDD000357777 /* Products */ = {
@@ -863,14 +853,14 @@
 				707AF6B51ADE047400EA1374 /* DiskStreams */,
 				7075D0AE1B6325540010D69C /* DiskUtils.cpp */,
 				7075D0AF1B6325540010D69C /* DiskUtils.h */,
-				70D9F0EC1AFB013400197BBE /* Ee */,
+				70D9F0EC1AFB013400197BBE /* ee */,
 				7E4C15A41519A8FE00357777 /* ELF.cpp */,
 				7E4C15A51519A8FE00357777 /* ELF.h */,
 				7E4C15A61519A8FE00357777 /* ElfFile.cpp */,
 				7E4C15A71519A8FE00357777 /* ElfFile.h */,
 				703093AD17BE5AB1009662A1 /* FrameDump.cpp */,
 				703093AE17BE5AB1009662A1 /* FrameDump.h */,
-				70D9F14F1AFB017700197BBE /* Gs */,
+				70D9F14F1AFB017700197BBE /* gs */,
 				7E4C15B51519A8FE00357777 /* Integer64.h */,
 				7068498C151E894A00C9574F /* iop */,
 				7E4C15C41519A94900357777 /* ISO9660 */,
@@ -934,7 +924,8 @@
 				7E4C161E1519A9A700357777 /* VirtualMachine.h */,
 			);
 			name = "Play Core";
-			sourceTree = "<group>";
+			path = ../Source;
+			sourceTree = SOURCE_ROOT;
 		};
 		7E4C15C41519A94900357777 /* ISO9660 */ = {
 			isa = PBXGroup;
@@ -953,7 +944,7 @@
 				7E4C15CF1519A96700357777 /* VolumeDescriptor.cpp */,
 				7E4C15D01519A96700357777 /* VolumeDescriptor.h */,
 			);
-			name = ISO9660;
+			path = ISO9660;
 			sourceTree = "<group>";
 		};
 		7E78329C1516710900C04C62 = {
@@ -1073,8 +1064,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				70684A3A151E8B2400C9574F /* InfoPlist.strings in Resources */,
-				70320D1F1A99EAC4001E9C4B /* GeneralSettingsDebug.xcconfig in Resources */,
-				70320D201A99EAC4001E9C4B /* GeneralSettingsRelease.xcconfig in Resources */,
 				70684A3C151E8B2400C9574F /* VfsManagerView.xib in Resources */,
 				705D39721C44A3FF00D267A6 /* VideoSettingsView.xib in Resources */,
 				70C0C84E1ADC97A900492241 /* Images.xcassets in Resources */,
@@ -1083,7 +1072,6 @@
 				70F2AB0B1CBB558B00D0773D /* AudioSettingsView.xib in Resources */,
 				700DF99C15DFC0CB00818F3B /* MainMenu.xib in Resources */,
 				700FB58015E11E1E00C322DE /* OutputWindow.xib in Resources */,
-				70320D1E1A99EAC4001E9C4B /* GeneralSettings.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Have the Xcode project refer to files by relation to groups.
Remove Xcode config files from copy phase: they aren't used there.