### PR TITLE
Madd's Mac Patches

### DIFF
--- a/Source/ui_macosx/ApplicationDelegate.mm
+++ b/Source/ui_macosx/ApplicationDelegate.mm
@@ -199,7 +199,7 @@
 	catch(const std::exception& exception)
 	{
 		NSString* errorMessage = [[NSString alloc] initWithUTF8String: exception.what()];
-		NSRunCriticalAlertPanel(@"Load ELF error:", errorMessage, NULL, NULL, NULL);
+		NSRunCriticalAlertPanel(@"Load ELF error:", @"%@", NULL, NULL, NULL, errorMessage);
 	}
 }
 
@@ -217,7 +217,7 @@
 	catch(const std::exception& exception)
 	{
 		NSString* errorMessage = [[NSString alloc] initWithUTF8String: exception.what()];
-		NSRunCriticalAlertPanel(@"Load ELF error:", errorMessage, NULL, NULL, NULL);
+		NSRunCriticalAlertPanel(@"Load ELF error:", @"%@", NULL, NULL, NULL, errorMessage);
 	}
 }
 

--- a/Source/ui_macosx/OutputWindowController.h
+++ b/Source/ui_macosx/OutputWindowController.h
@@ -13,8 +13,8 @@
 }
 
 @property(assign, nonatomic) IBOutlet NSOpenGLView* openGlView;
+@property(assign, nonatomic) id<OutputWindowDelegate> delegate;
 
--(void)setDelegate: (id<OutputWindowDelegate>)delegate;
 -(NSSize)contentSize;
 
 @end

--- a/Source/ui_macosx/OutputWindowController.mm
+++ b/Source/ui_macosx/OutputWindowController.mm
@@ -7,11 +7,7 @@
 @implementation OutputWindowController
 
 @synthesize openGlView = _openGlView;
-
--(void)setDelegate: (id)delegate
-{
-	_delegate = delegate;
-}
+@synthesize delegate = _delegate;
 
 -(NSApplicationPresentationOptions)window: (NSWindow*)window willUseFullScreenPresentationOptions:(NSApplicationPresentationOptions)proposedOptions
 {

--- a/Source/ui_macosx/VfsManagerBindings.h
+++ b/Source/ui_macosx/VfsManagerBindings.h
@@ -13,16 +13,14 @@
 
 @end
 
-@interface VfsManagerBindings : NSObject
+@interface VfsManagerBindings : NSObject <NSTableViewDataSource>
 {
 	NSMutableArray*		m_bindings;
 }
 
 -(VfsManagerBindings*)init;
 -(void)save;
--(int)numberOfRowsInTableView: (NSTableView*)tableView;
--(id)tableView: (NSTableView*)tableView objectValueForTableColumn:(NSTableColumn*)tableColumn row:(int)row;
--(VfsManagerBinding*)getBindingAt: (unsigned int)index;
+-(VfsManagerBinding*)getBindingAt: (NSUInteger)index;
 
 @end
 

--- a/Source/ui_macosx/VfsManagerBindings.mm
+++ b/Source/ui_macosx/VfsManagerBindings.mm
@@ -192,8 +192,7 @@
 	}
 	else
 	{
-		m_value = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:preferenceValue length:strlen(preferenceValue)];
-		[m_value retain];
+		m_value = [[NSString alloc] initWithUTF8String: preferenceValue];
 	}
 	return self;
 }
@@ -236,7 +235,7 @@
 
 -(void)save
 {
-	CAppConfig::GetInstance().SetPreferenceString(PS2VM_CDROM0PATH, [m_value fileSystemRepresentation]);
+	CAppConfig::GetInstance().SetPreferenceString(PS2VM_CDROM0PATH, [m_value UTF8String]);
 }
 
 @end

--- a/Source/ui_macosx/VfsManagerBindings.mm
+++ b/Source/ui_macosx/VfsManagerBindings.mm
@@ -6,7 +6,7 @@
 
 -(VfsManagerBindings*)init
 {
-	VfsManagerBindings* result = [super init];
+	self = [super init];
 	m_bindings = [[NSMutableArray alloc] init];
 	{
 		NSObject* objectToAdd = [[VfsManagerCdrom0Binding alloc] init];
@@ -28,7 +28,7 @@
 		[objectToAdd autorelease];
 		[m_bindings addObject: objectToAdd];
 	}
-	return result;
+	return self;
 }
 
 -(void)dealloc
@@ -47,12 +47,12 @@
 	}
 }
 
--(int)numberOfRowsInTableView: (NSTableView*)tableView
+-(NSInteger)numberOfRowsInTableView: (NSTableView*)tableView
 {
 	return [m_bindings count];
 }
 
--(id)tableView: (NSTableView*)tableView objectValueForTableColumn: (NSTableColumn*)tableColumn row: (int)row
+-(id)tableView: (NSTableView*)tableView objectValueForTableColumn: (NSTableColumn*)tableColumn row: (NSInteger)row
 {
 	if(row >= [m_bindings count]) return @"";
 	VfsManagerBinding* binding = [m_bindings objectAtIndex: row];
@@ -71,7 +71,7 @@
 	return @"";
 }
 
--(VfsManagerBinding*)getBindingAt: (unsigned int)index
+-(VfsManagerBinding*)getBindingAt: (NSUInteger)index
 {
 	if(index >= [m_bindings count]) return nil;
 	return [m_bindings objectAtIndex: index];
@@ -119,7 +119,7 @@
 
 -(VfsManagerDirectoryBinding*)init: (NSString*)deviceName preferenceName: (NSString*)preferenceName
 {
-	VfsManagerDirectoryBinding* result = [super init];
+	self = [super init];
 	m_deviceName = deviceName;
 	m_preference = preferenceName;
 	const char* preferenceValue = CAppConfig::GetInstance().GetPreferenceString([preferenceName UTF8String]);
@@ -131,7 +131,7 @@
 	{
 		m_value = [[NSString alloc] initWithUTF8String: preferenceValue];
 	}
-	return result;
+	return self;
 }
 
 -(void)dealloc
@@ -167,7 +167,7 @@
 	{
 		return;
 	}
-	NSString* filename = [openPanel filename];
+	NSString* filename = [[openPanel URL] path];
 	[filename retain];
 	[m_value release];
 	m_value = filename;
@@ -184,7 +184,7 @@
 
 -(VfsManagerCdrom0Binding*)init
 {
-	VfsManagerCdrom0Binding* result = [super init];
+	self = [super init];
 	const char* preferenceValue = CAppConfig::GetInstance().GetPreferenceString(PS2VM_CDROM0PATH);
 	if(preferenceValue == NULL)
 	{
@@ -194,7 +194,7 @@
 	{
 		m_value = [[NSString alloc] initWithUTF8String: preferenceValue];
 	}
-	return result;
+	return self;
 }
 
 -(void)dealloc
@@ -222,11 +222,12 @@
 {
 	NSOpenPanel* openPanel = [NSOpenPanel openPanel];
 	NSArray* fileTypes = [NSArray arrayWithObjects: @"iso", @"isz", @"cso", nil];
-	if([openPanel runModalForTypes:fileTypes] != NSOKButton)
+	openPanel.allowedFileTypes = fileTypes;
+	if([openPanel runModal] != NSOKButton)
 	{
 		return;
 	}
-	NSString* filename = [openPanel filename];
+	NSString* filename = [[openPanel URL] path];
 	[filename retain];
 	[m_value release];
 	m_value = filename;	
@@ -234,7 +235,7 @@
 
 -(void)save
 {
-	CAppConfig::GetInstance().SetPreferenceString(PS2VM_CDROM0PATH, [m_value UTF8String]);
+	CAppConfig::GetInstance().SetPreferenceString(PS2VM_CDROM0PATH, [m_value fileSystemRepresentation]);
 }
 
 @end

--- a/Source/ui_macosx/VfsManagerBindings.mm
+++ b/Source/ui_macosx/VfsManagerBindings.mm
@@ -192,7 +192,8 @@
 	}
 	else
 	{
-		m_value = [[NSString alloc] initWithUTF8String: preferenceValue];
+		m_value = [[NSFileManager defaultManager] stringWithFileSystemRepresentation:preferenceValue length:strlen(preferenceValue)];
+		[m_value retain];
 	}
 	return self;
 }

--- a/Source/ui_macosx/VfsManagerViewController.mm
+++ b/Source/ui_macosx/VfsManagerViewController.mm
@@ -23,7 +23,7 @@
 
 -(void)onTableViewDblClick: (id)sender
 {
-	int selectedIndex = [bindingsTableView clickedRow];
+	NSInteger selectedIndex = [bindingsTableView clickedRow];
 	if(selectedIndex == -1) return;
 	VfsManagerBinding* binding = [bindings getBindingAt: selectedIndex];
 	[binding requestModification];


### PR DESCRIPTION
This patches quiet warnings when compiled on Xcode 8.1.
It also fixes the Objective-C initialization methods to better match current best practices.