### PR TITLE
MacOS: replace deprecated functions

### DIFF
--- a/Source/ui_macosx/ApplicationDelegate.mm
+++ b/Source/ui_macosx/ApplicationDelegate.mm
@@ -181,7 +181,11 @@
 {
 	if(g_virtualMachine->LoadState("state.st0.zip"))
 	{
-		NSRunCriticalAlertPanel(@"Error occured while trying to load state.", @"", NULL, NULL, NULL);
+		NSAlert *alert = [[NSAlert alloc] init];
+		[alert addButtonWithTitle:@"OK"];
+		[alert setMessageText:@"Error occured while trying to load state."];
+		[alert setAlertStyle:NSAlertStyleCritical];
+		[alert runModal];
 	}
 }
 
@@ -199,7 +203,12 @@
 	catch(const std::exception& exception)
 	{
 		NSString* errorMessage = [[NSString alloc] initWithUTF8String: exception.what()];
-		NSRunCriticalAlertPanel(@"Load ELF error:", @"%@", NULL, NULL, NULL, errorMessage);
+		NSAlert *alert = [[NSAlert alloc] init];
+		[alert addButtonWithTitle:@"OK"];
+		[alert setMessageText:@"Load ELF error:"];
+		[alert setInformativeText:errorMessage];
+		[alert setAlertStyle:NSAlertStyleCritical];
+		[alert runModal];
 	}
 }
 
@@ -217,7 +226,12 @@
 	catch(const std::exception& exception)
 	{
 		NSString* errorMessage = [[NSString alloc] initWithUTF8String: exception.what()];
-		NSRunCriticalAlertPanel(@"Load ELF error:", @"%@", NULL, NULL, NULL, errorMessage);
+		NSAlert *alert = [[NSAlert alloc] init];
+		[alert addButtonWithTitle:@"OK"];
+		[alert setMessageText:@"Load ELF error:"];
+		[alert setInformativeText:errorMessage];
+		[alert setAlertStyle:NSAlertStyleCritical];
+		[alert runModal];
 	}
 }
 

--- a/Source/ui_macosx/VfsManagerBindings.mm
+++ b/Source/ui_macosx/VfsManagerBindings.mm
@@ -163,7 +163,7 @@
 	[openPanel setCanChooseDirectories: YES];
 	[openPanel setCanCreateDirectories: YES];
 	[openPanel setCanChooseFiles: NO];
-	if([openPanel runModal] != NSOKButton)
+	if([openPanel runModal] != NSModalResponseOK)
 	{
 		return;
 	}
@@ -223,7 +223,7 @@
 	NSOpenPanel* openPanel = [NSOpenPanel openPanel];
 	NSArray* fileTypes = [NSArray arrayWithObjects: @"iso", @"isz", @"cso", nil];
 	openPanel.allowedFileTypes = fileTypes;
-	if([openPanel runModal] != NSOKButton)
+	if([openPanel runModal] != NSModalResponseOK)
 	{
 		return;
 	}


### PR DESCRIPTION
Since you're targeting osx 10.9, I've update osx code to silence these 2 warnings
```
'NSRunCriticalAlertPanel' is deprecated: first deprecated in macOS 10.10 - Use NSAlert instead

'NSOKButton' is deprecated: first deprecated in OS X 10.10 - Use NSModalResponseOK instead
```

Edit: this also brought to my attention that we don't set target OS in cmake as such it uses the highest available, which is how I spotted this warnings, while i guess there is no harm in updating the code, since it will be deprecated, we should also address cmake target.