### PR TITLE
Linux: GameID in status bar

### DIFF
--- a/Source/ui_unix/mainwindow.cpp
+++ b/Source/ui_unix/mainwindow.cpp
@@ -215,6 +215,10 @@ void MainWindow::keyReleaseEvent(QKeyEvent *event)
 
 void MainWindow::CreateStatusBar()
 {
+    gameIDLabel = new QLabel(" GameID ");
+    gameIDLabel->setAlignment(Qt::AlignHCenter);
+    gameIDLabel->setMinimumSize(gameIDLabel->sizeHint());
+
     fpsLabel = new QLabel(" fps:00 ");
     fpsLabel->setAlignment(Qt::AlignHCenter);
     fpsLabel->setMinimumSize(fpsLabel->sizeHint());
@@ -229,6 +233,7 @@ void MainWindow::CreateStatusBar()
     m_stateLabel->setMinimumSize(m_dcLabel->sizeHint());
 
 
+    statusBar()->addWidget(gameIDLabel);
     statusBar()->addWidget(m_stateLabel);
     statusBar()->addWidget(fpsLabel);
     statusBar()->addWidget(m_dcLabel);
@@ -371,6 +376,7 @@ void MainWindow::on_actionAbout_triggered()
 void MainWindow::OnExecutableChange()
 {
     UpdateUI();
+    gameIDLabel->setText(QString(" %1 ").arg(g_virtualMachine->m_ee->m_os->GetExecutableName()));
 }
 
 void MainWindow::UpdateUI()

--- a/Source/ui_unix/mainwindow.h
+++ b/Source/ui_unix/mainwindow.h
@@ -45,6 +45,7 @@ private:
     Ui::MainWindow *ui;
 
     QWindow* m_openglpanel;
+    QLabel *gameIDLabel;
     QLabel* fpsLabel;
     QLabel* m_dcLabel;
     QLabel* m_stateLabel;


### PR DESCRIPTION
I just noticed that on both Win32/OSX the Game ID is displayed on the title bar, while on this PR I have it set to status bar, if you've issue with that I can have it changed.