### PR TITLE
Play Qt OSX/Win32 builds

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -8,6 +8,11 @@ travis_before_install()
         sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
         sudo apt-get update -qq;
         sudo apt-get install -qq qt56base gcc-5 g++-5 cmake libalut-dev;
+    elif [ "$TARGET_OS" = "OSX" ]; then
+        if [ "$BUILD_UI" = "QT" ]; then
+            brew update
+            brew install qt5 || true
+        fi;
     elif [ "$TARGET_OS" = "Android" ]; then
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y #is this needed?
         sudo apt-get update -y
@@ -53,7 +58,11 @@ travis_script()
             cmake .. -G"$BUILD_TYPE" -DCMAKE_PREFIX_PATH=/opt/qt56/;
             cmake --build .
         elif [ "$TARGET_OS" = "OSX" ]; then
-            cmake .. -G"$BUILD_TYPE"
+            if [ "$BUILD_UI" = "QT" ]; then
+                cmake .. -G"$BUILD_TYPE" -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5/ -DUSE_QT:BOOL=ON
+            else
+                cmake .. -G"$BUILD_TYPE"
+            fi;
             cmake --build . --config Release
         elif [ "$TARGET_OS" = "IOS" ]; then
             cmake .. -G"$BUILD_TYPE" -DCMAKE_TOOLCHAIN_FILE=../../../Dependencies/cmake-ios/ios.cmake -DTARGET_IOS=ON

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,17 @@ matrix:
       env:
         - BUILD_TYPE=Xcode
         - TARGET_OS=OSX
+        - BUILD_UI=NATIVE
     - os: osx
       osx_image: xcode8.3
       env:
         - BUILD_TYPE=Xcode
         - TARGET_OS=IOS
+      osx_image: xcode8.3
+      env:
+        - BUILD_TYPE=Xcode
+        - TARGET_OS=OSX
+        - BUILD_UI=QT
     - os: linux
       dist: precise
       language: android

--- a/Source/MailBox.cpp
+++ b/Source/MailBox.cpp
@@ -1,5 +1,5 @@
 #include "MailBox.h"
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(_QT)
 #include "win32/Win32Defs.h"
 #endif
 

--- a/Source/ui_unix/GSH_OpenGLQt.cpp
+++ b/Source/ui_unix/GSH_OpenGLQt.cpp
@@ -29,9 +29,11 @@ void CGSH_OpenGLQt::InitializeImpl()
     succeeded = m_context->makeCurrent(m_renderWindow);
     Q_ASSERT(succeeded);
 
+#ifndef __APPLE__
     glewExperimental = GL_TRUE;
     auto result = glewInit();
     Q_ASSERT(result == GLEW_OK);
+#endif
 
     CGSH_OpenGL::InitializeImpl();
 }
@@ -46,5 +48,8 @@ void CGSH_OpenGLQt::ReleaseImpl()
 void CGSH_OpenGLQt::PresentBackbuffer()
 {
     if (m_renderWindow->isExposed())
+    {
         m_context->swapBuffers(m_renderWindow);
+        m_context->makeCurrent(m_renderWindow);
+    }
 }

--- a/Source/ui_unix/controllerconfigdialog.cpp
+++ b/Source/ui_unix/controllerconfigdialog.cpp
@@ -60,7 +60,7 @@ void ControllerConfigDialog::Save(int index, QWidget* tab)
         map.insert(oname, child);
 
     }
-    QString path(CAppConfig::GetBasePath().c_str());
+    QString path(CAppConfig::GetBasePath().string().c_str());
     QString filename="keymaps_%1.xml";
     filename = filename.arg(QString::number(index));
     QFile file(path +"/"+ filename);
@@ -96,7 +96,7 @@ void ControllerConfigDialog::Save(int index, QWidget* tab)
 void ControllerConfigDialog::Load(int index, QWidget* tab)
 {
     QXmlStreamReader Rxml;
-    QString path(CAppConfig::GetBasePath().c_str());
+    QString path(CAppConfig::GetBasePath().string().c_str());
     QString filename="keymaps_%1.xml";
     filename = filename.arg(QString::number(index));
     QFile file(path +"/"+ filename);
@@ -220,7 +220,7 @@ CPH_HidUnix::BindingPtr *ControllerConfigDialog::GetBinding(int pad)
     uint32 m_axis_bindings[4] = {0};
     CPH_HidUnix::BindingPtr*			m_bindings = new CPH_HidUnix::BindingPtr[PS2::CControllerInfo::MAX_BUTTONS];
     QXmlStreamReader Rxml;
-    QString path(CAppConfig::GetBasePath().c_str());
+    QString path(CAppConfig::GetBasePath().string().c_str());
     QString filename="keymaps_%1.xml";
     filename = filename.arg(QString::number(pad));
     QFile file(path +"/"+ filename);

--- a/Source/ui_unix/mainwindow.cpp
+++ b/Source/ui_unix/mainwindow.cpp
@@ -12,7 +12,11 @@
 #include <QStorageInfo>
 
 #include "GSH_OpenGLQt.h"
+#ifdef _WIN32
+#include "tools/PsfPlayer/Source/win32_ui/SH_WaveOut.h"
+#else
 #include "tools/PsfPlayer/Source/SH_OpenAL.h"
+#endif
 #include "DiskUtils.h"
 #include "PathUtils.h"
 #include <zlib.h>
@@ -107,7 +111,11 @@ void MainWindow::SetupSoundHandler()
         bool audioEnabled = CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_AUDIO_ENABLEOUTPUT);
         if(audioEnabled)
         {
+#ifdef _WIN32
+            g_virtualMachine->CreateSoundHandler(&CSH_WaveOut::HandlerFactory);
+#else
             g_virtualMachine->CreateSoundHandler(&CSH_OpenAL::HandlerFactory);
+#endif
         }
         else
         {
@@ -121,9 +129,10 @@ void MainWindow::openGLWindow_resized()
     if (g_virtualMachine != nullptr && g_virtualMachine->m_ee != nullptr  && g_virtualMachine->m_ee->m_gs != nullptr )
         {
             GLint w = m_openglpanel->size().width(), h = m_openglpanel->size().height();
+            auto presentationMode = static_cast<CGSHandler::PRESENTATION_MODE>(CAppConfig::GetInstance().GetPreferenceInteger(PREF_CGSHANDLER_PRESENTATION_MODE));
 
             CGSHandler::PRESENTATION_PARAMS presentationParams;
-            presentationParams.mode 			= (CGSHandler::PRESENTATION_MODE)CAppConfig::GetInstance().GetPreferenceInteger(PREF_CGSHANDLER_PRESENTATION_MODE);
+            presentationParams.mode 			= presentationMode;
             presentationParams.windowWidth 		= w;
             presentationParams.windowHeight 	= h;
             g_virtualMachine->m_ee->m_gs->SetPresentationParams(presentationParams);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,12 @@ version: '{build}'
 environment:
   BUILD_TYPE: Visual Studio 14 2015 Win64
   TARGET_OS: WIN32
+
   matrix:
   - CONFIG_TYPE: Release
-  - CONFIG_TYPE: Debug
+    BUILD_UI: NATIVE
+  - CONFIG_TYPE: Release
+    BUILD_UI: QT
 build_script:
 - cmd: >-
     git clone -q https://github.com/jpd002/Play-Build.git C:\Projects\Play-Build
@@ -31,6 +34,8 @@ build_script:
 
     cd build
 
-    cmake .. -G"%BUILD_TYPE%" -DCMAKE_BUILD_TYPE=%CONFIG_TYPE%
+    if "%BUILD_UI%"=="NATIVE" ( cmake .. -G"%BUILD_TYPE%" -DCMAKE_BUILD_TYPE=%CONFIG_TYPE% )
+
+    if "%BUILD_UI%"=="QT" ( cmake .. -G"%BUILD_TYPE%" -DCMAKE_BUILD_TYPE=%CONFIG_TYPE% -DUSE_QT:BOOL=on -DCMAKE_PREFIX_PATH="C:\Qt\5.8\msvc2015_64" )
 
     cmake --build . --config %CONFIG_TYPE%

--- a/build_cmake/CMakeLists.txt
+++ b/build_cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.11)
 
 option(TARGET_IOS "Enable building for iOS" OFF)
 

--- a/build_cmake/CMakeLists.txt
+++ b/build_cmake/CMakeLists.txt
@@ -143,14 +143,16 @@ if(WIN32)
 	include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../Nuanceur/include)
 	list(APPEND PROJECT_LIBS Nuanceur)
 
-	if (NOT TARGET FrameworkWinUI)
-		add_subdirectory(
-			${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/build_cmake/FrameworkWinUI
-			${CMAKE_CURRENT_BINARY_DIR}/FrameworkWinUI
-		)
+	if(NOT USE_QT)
+		if (NOT TARGET FrameworkWinUI)
+			add_subdirectory(
+				${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/build_cmake/FrameworkWinUI
+				${CMAKE_CURRENT_BINARY_DIR}/FrameworkWinUI
+			)
+		endif()
+		include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/include)
+		list(APPEND PROJECT_LIBS FrameworkWinUI)
 	endif()
-	include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../Framework/include)
-	list(APPEND PROJECT_LIBS FrameworkWinUI)
 
 	find_package(DirectX9 REQUIRED)
 	list(APPEND PROJECT_LIBS ${DirectX_D3D9_LIBRARY})
@@ -464,6 +466,8 @@ list(APPEND PROJECT_LIBS PlayCore)
 
 #UI
 if (USE_QT)
+	add_definitions(-D_QT)
+
 	include_directories(
 		../
 		../Source/ui_unix/
@@ -527,7 +531,13 @@ if (USE_QT)
 	QT5_WRAP_UI(QT_UI_HEADERS ${QT_UIS})
 	QT5_WRAP_CPP(QT_MOC_SRCS ${QT_MOC_HEADERS})
 
-	if(NOT APPLE)
+	if(WIN32)
+		if(NOT OPENAL_FOUND)
+			list(APPEND QT_SOURCES ../tools/PsfPlayer/Source/win32_ui/SH_WaveOut.cpp)
+		endif()
+		add_executable(Play WIN32 ${QT_SOURCES} ${QT_MOC_SRCS} ${QT_RES_SOURCES} ${QT_UI_HEADERS})
+		target_link_libraries(Play ${PROJECT_LIBS})
+	elseif(NOT APPLE)
 		add_executable(Play ${QT_SOURCES} ${QT_MOC_SRCS} ${QT_RES_SOURCES} ${QT_UI_HEADERS})
 		target_link_libraries(Play ${PROJECT_LIBS})
 	elseif(APPLE)
@@ -759,7 +769,7 @@ if(TARGET_PLATFORM_IOS)
 
 endif(TARGET_PLATFORM_IOS)
 
-if (WIN32)
+if (WIN32 AND NOT USE_QT)
 	ENABLE_LANGUAGE(ASM_MASM)
 
 	include_directories(
@@ -860,7 +870,7 @@ if (WIN32)
 	target_link_libraries(Play PUBLIC ${PROJECT_LIBS})
 	add_precompiled_header(Play StdAfx.h FORCEINCLUDE SOURCE_CXX ../Source/ui_win32/StdAfx.cpp)
 	add_precompiled_header(PlayCore Pch.h FORCEINCLUDE SOURCE_CXX ../Source/Pch.cpp)
-endif (WIN32)
+endif (WIN32 AND NOT USE_QT)
 
 enable_testing()
 

--- a/build_cmake/CMakeLists.txt
+++ b/build_cmake/CMakeLists.txt
@@ -31,6 +31,12 @@ set(PROJECT_Version 0.30)
 add_definitions(-DPLAY_VERSION="${PROJECT_Version}")
 set(PROJECT_LIBS)
 
+if (WIN32 OR APPLE OR ANDROID)
+	set(USE_QT off CACHE BOOL "Use Qt UI for build")
+else()
+	set(USE_QT on CACHE BOOL "Use Qt UI for build")
+endif()
+
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../Dependencies/cmake-modules
 	${CMAKE_MODULE_PATH}
@@ -457,7 +463,7 @@ target_link_libraries(PlayCore ${PROJECT_LIBS})
 list(APPEND PROJECT_LIBS PlayCore)
 
 #UI
-if (UNIX AND NOT APPLE AND NOT ANDROID)
+if (USE_QT)
 	include_directories(
 		../
 		../Source/ui_unix/
@@ -521,12 +527,42 @@ if (UNIX AND NOT APPLE AND NOT ANDROID)
 	QT5_WRAP_UI(QT_UI_HEADERS ${QT_UIS})
 	QT5_WRAP_CPP(QT_MOC_SRCS ${QT_MOC_HEADERS})
 
-	add_executable(Play ${QT_SOURCES} ${QT_MOC_SRCS} ${QT_RES_SOURCES} ${QT_UI_HEADERS})
-	target_link_libraries(Play ${PROJECT_LIBS})
-endif (UNIX AND NOT APPLE AND NOT ANDROID)
+	if(NOT APPLE)
+		add_executable(Play ${QT_SOURCES} ${QT_MOC_SRCS} ${QT_RES_SOURCES} ${QT_UI_HEADERS})
+		target_link_libraries(Play ${PROJECT_LIBS})
+	elseif(APPLE)
+		set(OSX_RES
+			${CMAKE_CURRENT_SOURCE_DIR}/../build_macosx/AppIcon.icns
+			${CMAKE_CURRENT_SOURCE_DIR}/../patches.xml
+		)
+		# Add our Executable
+		add_executable(Play MACOSX_BUNDLE ${QT_SOURCES} ${QT_MOC_SRCS} ${QT_RES_SOURCES} ${QT_UI_HEADERS} ${OSX_RES})
 
-if(APPLE AND NOT IOS)
+		# Probably a better way to set the framework link libraries.
+		target_link_libraries(Play ${PROJECT_LIBS} "-ObjC -framework Cocoa -framework OpenGL -framework OpenAL -framework IOKit -framework AppKit -framework CoreData -framework Foundation")
 
+		# Set a custom plist file for the app bundle
+		# NOTE: for these values to be used Info.plist has to be edited
+		# NOTE: from cmake 3.7.0 you can use %b for month name abbreviations
+		string(TIMESTAMP DATE "%d-%m-%Y")
+		set_target_properties(
+			Play
+			PROPERTIES
+				MACOSX_BUNDLE_INFO_STRING "${PROJECT_NAME}"
+				MACOSX_BUNDLE_GUI_IDENTIFIER "com.virtualapplications.Play"
+				MACOSX_BUNDLE_LONG_VERSION_STRING "${PROJECT_NAME} Version ${PROJECT_Version}"
+				MACOSX_BUNDLE_BUNDLE_NAME ${PROJECT_NAME}
+				MACOSX_BUNDLE_SHORT_VERSION_STRING "${PROJECT_Version}"
+				MACOSX_BUNDLE_BUNDLE_VERSION ${DATE}
+				MACOSX_BUNDLE_COPYRIGHT "© Virtual Applications, 2017"
+				MACOSX_BUNDLE_ICON_FILE "AppIcon.icns"
+				MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/../Source/ui_macosx/Info.plist.in"
+			RESOURCE "${OSX_RES}"
+		)
+	endif()
+endif (USE_QT)
+
+if(APPLE AND NOT IOS AND NOT USE_QT)
 	include_directories(
 		../
 		../Source/ui_macosx/
@@ -619,7 +655,7 @@ if(APPLE AND NOT IOS)
 				COMMENT "${CMAKE_CURRENT_SOURCE_DIR}/../Source/ui_macosx/${xib}.xib")
 
 	endforeach()
-endif(APPLE AND NOT IOS)
+endif(APPLE AND NOT IOS AND NOT USE_QT)
 
 if(TARGET_PLATFORM_IOS)
 	include_directories(


### PR DESCRIPTION
if you recall with my initial qt linux client, I tried to get the same qt client to work with OSX/Win32, but OSX had the weird resize issue and win32 crashed on resize.

for OSX it seemed like the issue was with `swapBuffers` and as [Qt](http://doc.qt.io/qt-5/qopenglcontext.html#swapBuffers) states that `makeCurrent()` must be called after `swapBuffers()` but somehow on linux, it worked fine without.
as of this PR osx client work but has 2 issues, (1) on exit the client crashes (crash stack is below)
 (2) the memory card manager can't read games name, so returns `???`, i recalled seeing a [commit](https://github.com/MaddTheSane/Play--Framework/commit/85db58817b412a3fdeb21deca96d5953850b679e) a while back from @MaddTheSane, that fixed this issue.

for Win32, the issue seemed with `CMailBox::SendCall` more specifically with `m_callFinished.wait_for(callLock, std::chrono::milliseconds(100));` as Qt will report resize multiple times until full expanded causing a mutex lock?

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	0x00007fffd727cdda __pthread_kill + 10
1   libsystem_pthread.dylib       	0x00007fffd7368787 pthread_kill + 90
2   libsystem_c.dylib             	0x00007fffd71e2420 abort + 129
3   libc++abi.dylib               	0x00007fffd5d4185a abort_message + 266
4   libc++abi.dylib               	0x00007fffd5d66b72 default_terminate_handler() + 46
5   libc++abi.dylib               	0x00007fffd5d63d69 std::__terminate(void (*)()) + 8
6   libc++abi.dylib               	0x00007fffd5d63df0 std::terminate() + 64
7   com.virtualapplications.Play  	0x000000010fd8862c CEeExecutor::~CEeExecutor() + 28
8   com.virtualapplications.Play  	0x000000010fd8648c Ee::CSubSystem::~CSubSystem() + 252
9   com.virtualapplications.Play  	0x000000010fd8662e Ee::CSubSystem::~CSubSystem() + 14
10  com.virtualapplications.Play  	0x000000010fe2d3b9 CPS2VM::~CPS2VM() + 345
11  com.virtualapplications.Play  	0x000000010fe2d5ce CPS2VM::~CPS2VM() + 14
12  com.virtualapplications.Play  	0x000000010fcdfef1 MainWindow::~MainWindow() + 177
13  com.virtualapplications.Play  	0x000000010fcde1d4 main + 84
14  libdyld.dylib                 	0x00007fffd714e255 start + 1
```
I've tried following the stack for anything obvious with no luck :/


Side Note: I've one more [PR](https://github.com/Thunder07/Play-/tree/psf_build) (PsfPlayer cmake) which I'll open should/n't this get merge as one has to be rebased onto the other, as it'll cause merge conflict and will cause some changes to the `cmakelists.txt` to be lost, after which I'll stop annoying you with PR until summer break :p

Edit: I'll rebase this PR when I'm free. but do you want the Qt ui to build through travis/Appvoyer as well, I currently have it setup this way to make sure the code remains multiplatform going ahead, although the OSX Qt build might be more feature full than Qt already.