### PR TITLE
CMake Debugger build

### DIFF
--- a/Source/ee/PS2OS.cpp
+++ b/Source/ee/PS2OS.cpp
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <exception>
 #include <boost/filesystem/path.hpp>
+#include "string_format.h"
 #include "PS2OS.h"
 #include "StdStream.h"
 #ifdef __ANDROID__
@@ -3185,7 +3186,7 @@ BiosDebugThreadInfoArray CPS2OS::GetThreadsDebugInfo() const
 			threadInfo.stateDescription = "Sleeping";
 			break;
 		case THREAD_WAITING:
-			threadInfo.stateDescription = "Waiting (Semaphore: " + boost::lexical_cast<std::string>(thread->semaWait) + ")";
+			threadInfo.stateDescription = string_format("Waiting (Semaphore: %d)", thread->semaWait);
 			break;
 		case THREAD_SUSPENDED:
 			threadInfo.stateDescription = "Suspended";
@@ -3194,7 +3195,7 @@ BiosDebugThreadInfoArray CPS2OS::GetThreadsDebugInfo() const
 			threadInfo.stateDescription = "Suspended+Sleeping";
 			break;
 		case THREAD_SUSPENDED_WAITING:
-			threadInfo.stateDescription = "Suspended+Waiting (Semaphore: " + boost::lexical_cast<std::string>(thread->semaWait) + ")";
+			threadInfo.stateDescription =  string_format("Suspended+Waiting (Semaphore: %d)", thread->semaWait);
 			break;
 		case THREAD_ZOMBIE:
 			threadInfo.stateDescription = "Zombie";

--- a/build_cmake/CMakeLists.txt
+++ b/build_cmake/CMakeLists.txt
@@ -58,6 +58,10 @@ endif()
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D_DEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG")
 
+if (DEBUGGER_INCLUDED)
+	add_definitions(-DDEBUGGER_INCLUDED)
+endif()
+
 add_definitions(-D_IOP_EMULATE_MODULES)
 add_definitions(-DGLEW_STATIC)
 
@@ -384,6 +388,7 @@ set(COMMON_SRC_FILES
 	../Source/MIPSAssembler.cpp 
 	../Source/MIPSCoprocessor.cpp 
 	../Source/MipsExecutor.cpp 
+	../Source/MipsFunctionPatternDb.cpp 
 	../Source/MIPSInstructionFactory.cpp 
 	../Source/MipsJitter.cpp 
 	../Source/MIPSReflection.cpp 
@@ -733,7 +738,7 @@ if (WIN32)
 		../Source/ui_win32/
 		../Source/gs/GSH_OpenGL
 	)
-	if (CMAKE_BUILD_TYPE MATCHES DEBUG)
+	if (DEBUGGER_INCLUDED)
 		set(DEBUG_SRC
 			../Source/ui_win32/CallStackWnd.cpp
 			../Source/ui_win32/Debugger.cpp

--- a/build_cmake/CMakeLists.txt
+++ b/build_cmake/CMakeLists.txt
@@ -745,6 +745,8 @@ if (WIN32)
 			../Source/ui_win32/DebugView.cpp
 			../Source/ui_win32/FunctionsView.cpp
 			../Source/ui_win32/ThreadsViewWnd.cpp
+
+			../Source/ui_win32/ElfViewRes.rc
 		)
 	endif()
 	if(ARCH STREQUAL "x86")


### PR DESCRIPTION
Current Issue with this build PR, starting a game creates a small/empty non-closable window, restarting the game or a new game causes that window to grow to cover the full screen.... is that an issue you had before? (quick note: lexical_cast wasn't included from boost and noticed one of your earlier commit, so i just followed suit and replaced it)

over the weekend, I've been attempting to setup windows Debugger build as it was setup in visual studio. i.e: `cmake --build . --config Debug/ReleaseWithDebugger` however I've ran into issues, as that would create different build per config, and cmake didn't support that ( there is a work around, but that would involve wrapping the debugger source (aka`DEBUG_SRC` in `CMakeLists.txt`) with `#ifdef debugger_included`).
e.g how that would look during build. (branch [multiconfig](https://github.com/Thunder07/Play-/tree/multiconfig))
```
cmake .. -G"Visual Studio 14 2015"
cmake --build . --config ReleaseWithDebugger
```
the advantage of this that, you can build Release,Debug,ReleaseWithDebugger,DebugWithDebugger and they'll automatically be build into their respective folders.

While for this PR, Debug/Release get their own folder, but Debugger version builds into Debug/Release as well, however what you can do is create `build` and `build_debugger` folders to keep them separate.
which is what I'm proposing in this PR.
```
cmake .. -G"Visual Studio 14 2015" -DDEBUGGER_INCLUDED=on
cmake --build . --config Release
```

edit: spelling + link (branch [multiconfig](https://github.com/Thunder07/Play-/tree/multiconfig))