### PR TITLE
Win32 cleanup

### DIFF
--- a/build_cmake/CMakeLists.txt
+++ b/build_cmake/CMakeLists.txt
@@ -41,7 +41,7 @@ include(PrecompiledHeader)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(WIN32)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /MP")
 endif()
 
 if(ANDROID)

--- a/build_cmake/CMakeLists.txt
+++ b/build_cmake/CMakeLists.txt
@@ -41,7 +41,7 @@ include(PrecompiledHeader)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(WIN32)
-	set(CMAKE_CXX_FLAGS "/EHsc")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
 endif()
 
 if(ANDROID)


### PR DESCRIPTION
with Multi-Processes Build enabled Appvoyer now builds the project in 5 minutes compared to 12 minutes previously