### PR TITLE
Android: build date fix

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -169,23 +169,6 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 		));
 	}
 
-	private static long getBuildDate(Context context) 
-	{
-		try
-		{
-			ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), 0);
-			ZipFile zf = new ZipFile(ai.sourceDir);
-			ZipEntry ze = zf.getEntry("classes.dex");
-			long time = ze.getTime();
-			return time;
-		} 
-		catch (Exception e) 
-		{
-
-		}
-		return 0;
-	}
-
 	private void displaySimpleMessage(String title, String message)
 	{
 		AlertDialog.Builder builder = new AlertDialog.Builder(this);
@@ -260,8 +243,8 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 
 	private void displayAboutDialog()
 	{
-		long buildDate = getBuildDate(this);
-		String buildDateString = new SimpleDateFormat("yyyy/MM/dd", Locale.getDefault()).format(buildDate);
+		Date buildDate = BuildConfig.buildTime;
+		String buildDateString = new SimpleDateFormat("yyyy/MM/dd hh:mm a", Locale.getDefault()).format(buildDate);
 		String aboutMessage = String.format("Build Date: %s", buildDateString);
 		displaySimpleMessage("About Play!", aboutMessage);
 	}

--- a/build_android/build.gradle
+++ b/build_android/build.gradle
@@ -76,12 +76,14 @@ android {
 		debug {
 			debuggable true
 			jniDebuggable true
+			buildConfigField "java.util.Date", "buildTime", "new java.util.Date(" + System.currentTimeMillis() + "L)"
 		}
 		release {
 			proguardFile getDefaultProguardFile('proguard-android.txt')
 			if(project.ext.signingEnabled) {
 				signingConfig signingConfigs.release
 			}
+			buildConfigField "java.util.Date", "buildTime", "new java.util.Date(" + System.currentTimeMillis() + "L)"
 		}
 	}
 


### PR DESCRIPTION
Someone posted about this not working correctly on G+ community.

Not sure when this broke, but if i had to guess it was with the gradle upgrade.
I've added the build hour into the date as well, as it might be useful should you release multiple updates within the same day.

I got this fix from StackOverflow [post](http://stackoverflow.com/questions/3540739/how-to-programmatically-read-the-date-when-my-android-apk-was-built)