### PR TITLE
Cleanup

### DIFF
--- a/Source/BasicBlock.cpp
+++ b/Source/BasicBlock.cpp
@@ -115,7 +115,7 @@ void CBasicBlock::Compile()
 		jmethod.method_size = m_function.GetSize();
 		jmethod.line_number_size = 0;
 
-		auto functionName = string_format("BasicBlock_0x%0.8X_0x%0.8X", m_begin, m_end);
+		auto functionName = string_format("BasicBlock_0x%08X_0x%08X", m_begin, m_end);
 
 		jmethod.method_name = const_cast<char*>(functionName.c_str());
 		iJIT_NotifyEvent(iJVM_EVENT_TYPE_METHOD_LOAD_FINISHED, reinterpret_cast<void*>(&jmethod));

--- a/Source/COP_FPU_Reflection.cpp
+++ b/Source/COP_FPU_Reflection.cpp
@@ -69,14 +69,14 @@ void CCOP_FPU::ReflOpFtOffRs(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, 
 	uint8  nFT  = static_cast<uint8> ((nOpcode >> 16) & 0x001F);
 	uint16 nImm = static_cast<uint16>((nOpcode >>  0) & 0xFFFF);
 
-	sprintf(sText, "F%i, $%0.4X(%s)", nFT, nImm, CMIPS::m_sGPRName[nRS]);
+	sprintf(sText, "F%i, $%04X(%s)", nFT, nImm, CMIPS::m_sGPRName[nRS]);
 }
 
 void CCOP_FPU::ReflOpCcOff(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)
 {
 	uint16 nImm = static_cast<uint16>((nOpcode >>  0) & 0xFFFF);
 	nAddress += 4;
-	sprintf(sText, "CC%i, $%0.8X", (nOpcode >> 18) & 0x07, nAddress + CMIPS::GetBranch(nImm));
+	sprintf(sText, "CC%i, $%08X", (nOpcode >> 18) & 0x07, nAddress + CMIPS::GetBranch(nImm));
 }
 
 uint32 CCOP_FPU::ReflEaOffset(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode)

--- a/Source/COP_SCU_Reflection.cpp
+++ b/Source/COP_SCU_Reflection.cpp
@@ -32,7 +32,7 @@ void CCOP_SCU::ReflOpCcOff(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, ui
 {
 	uint16 nImm = static_cast<uint16>((nOpcode >>  0) & 0xFFFF);
 	nAddress += 4;
-	sprintf(sText, "CC%i, $%0.8X", (nOpcode >> 18) & 0x07, nAddress + CMIPS::GetBranch(nImm));
+	sprintf(sText, "CC%i, $%08X", (nOpcode >> 18) & 0x07, nAddress + CMIPS::GetBranch(nImm));
 }
 
 uint32 CCOP_SCU::ReflEaOffset(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode)

--- a/Source/MA_MIPSIV_Reflection.cpp
+++ b/Source/MA_MIPSIV_Reflection.cpp
@@ -8,7 +8,7 @@ using namespace MIPSReflection;
 void CMA_MIPSIV::ReflOpTarget(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)
 {
 	nAddress = (nAddress & 0xF0000000) | ((nOpcode & 0x03FFFFFF) << 2);
-	sprintf(sText, "$%0.8X", nAddress);
+	sprintf(sText, "$%08X", nAddress);
 }
 
 void CMA_MIPSIV::ReflOpRtRsImm(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)
@@ -20,7 +20,7 @@ void CMA_MIPSIV::ReflOpRtRsImm(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress
 	nRT  = (uint8) ((nOpcode >> 16) & 0x001F);
 	nImm = (uint16)((nOpcode >>  0) & 0xFFFF);
 
-	sprintf(sText, "%s, %s, $%0.4X", CMIPS::m_sGPRName[nRT], CMIPS::m_sGPRName[nRS], nImm);
+	sprintf(sText, "%s, %s, $%04X", CMIPS::m_sGPRName[nRT], CMIPS::m_sGPRName[nRS], nImm);
 }
 
 void CMA_MIPSIV::ReflOpRtImm(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)
@@ -31,7 +31,7 @@ void CMA_MIPSIV::ReflOpRtImm(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, 
 	nRT  = (uint8) ((nOpcode >> 16) & 0x001F);
 	nImm = (uint16)((nOpcode >>  0) & 0xFFFF);
 
-	sprintf(sText, "%s, $%0.4X", CMIPS::m_sGPRName[nRT], nImm);
+	sprintf(sText, "%s, $%04X", CMIPS::m_sGPRName[nRT], nImm);
 }
 
 void CMA_MIPSIV::ReflOpRsRtOff(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)
@@ -44,7 +44,7 @@ void CMA_MIPSIV::ReflOpRsRtOff(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress
 	nImm = (uint16)((nOpcode >>  0) & 0xFFFF);
 
 	nAddress += 4;
-	sprintf(sText, "%s, %s, $%0.8X", CMIPS::m_sGPRName[nRS], CMIPS::m_sGPRName[nRT], (nAddress + CMIPS::GetBranch(nImm)));
+	sprintf(sText, "%s, %s, $%08X", CMIPS::m_sGPRName[nRS], CMIPS::m_sGPRName[nRT], (nAddress + CMIPS::GetBranch(nImm)));
 }
 
 void CMA_MIPSIV::ReflOpRsOff(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)
@@ -56,7 +56,7 @@ void CMA_MIPSIV::ReflOpRsOff(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, 
 	nImm = (uint16)((nOpcode >>  0) & 0xFFFF);
 
 	nAddress += 4;
-	sprintf(sText, "%s, $%0.8X", CMIPS::m_sGPRName[nRS], (nAddress + CMIPS::GetBranch(nImm)));
+	sprintf(sText, "%s, $%08X", CMIPS::m_sGPRName[nRS], (nAddress + CMIPS::GetBranch(nImm)));
 }
 
 void CMA_MIPSIV::ReflOpRtOffRs(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)
@@ -69,7 +69,7 @@ void CMA_MIPSIV::ReflOpRtOffRs(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress
 	nImm = (uint16)((nOpcode >>  0) & 0xFFFF);
 
 	nAddress += 4;
-	sprintf(sText, "%s, $%0.4X(%s)", CMIPS::m_sGPRName[nRT], nImm, CMIPS::m_sGPRName[nRS]);
+	sprintf(sText, "%s, $%04X(%s)", CMIPS::m_sGPRName[nRT], nImm, CMIPS::m_sGPRName[nRS]);
 }
 
 void CMA_MIPSIV::ReflOpHintOffRs(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)
@@ -79,7 +79,7 @@ void CMA_MIPSIV::ReflOpHintOffRs(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddre
 	uint16 nImm     = (uint16)((nOpcode >>  0) & 0xFFFF);
 
 	nAddress += 4;
-	sprintf(sText, "%i, $%0.4X(%s)", nHint, nImm, CMIPS::m_sGPRName[nRS]);
+	sprintf(sText, "%i, $%04X(%s)", nHint, nImm, CMIPS::m_sGPRName[nRS]);
 }
 
 void CMA_MIPSIV::ReflOpIdOffRs(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)
@@ -92,7 +92,7 @@ void CMA_MIPSIV::ReflOpIdOffRs(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress
 	nImm = (uint16)((nOpcode >>  0) & 0xFFFF);
 
 	nAddress += 4;
-	sprintf(sText, "$%0.2X, $%0.4X(%s)", nRT, nImm, CMIPS::m_sGPRName[nRS]);
+	sprintf(sText, "$%02X, $%04X(%s)", nRT, nImm, CMIPS::m_sGPRName[nRS]);
 }
 
 void CMA_MIPSIV::ReflOpRdRsRt(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)

--- a/Source/MIPSAnalysis.cpp
+++ b/Source/MIPSAnalysis.cpp
@@ -91,7 +91,7 @@ void CMIPSAnalysis::AnalyseSubroutines(uint32 start, uint32 end, uint32 entryPoi
 	ExpandSubroutines(start, end);
 
 	uint32 subroutinesAdded = static_cast<uint32>(m_subroutines.size() - subroutinesBefore);
-	printf("CMIPSAnalysis: Found %d subroutines in the range [0x%0.8X, 0x%0.8X].\r\n", subroutinesAdded, start, end);
+	printf("CMIPSAnalysis: Found %d subroutines in the range [0x%08X, 0x%08X].\r\n", subroutinesAdded, start, end);
 }
 
 static bool IsStackFreeingInstruction(uint32 opcode)

--- a/Source/MemoryMap.cpp
+++ b/Source/MemoryMap.cpp
@@ -105,7 +105,7 @@ void CMemoryMap::SetByte(uint32 nAddress, uint8 nValue)
 	const MEMORYMAPELEMENT* e = GetMap(m_writeMap, nAddress);
 	if(e == NULL)
 	{
-		printf("MemoryMap: Wrote to unmapped memory (0x%0.8X, 0x%0.4X).\r\n", nAddress, nValue);
+		printf("MemoryMap: Wrote to unmapped memory (0x%08X, 0x%04X).\r\n", nAddress, nValue);
 		return;
 	}
 	switch(e->nType)
@@ -185,7 +185,7 @@ void CMemoryMap_LSBF::SetHalf(uint32 nAddress, uint16 nValue)
 	const auto e = GetMap(m_writeMap, nAddress);
 	if(!e)
 	{
-		printf("MemoryMap: Wrote to unmapped memory (0x%0.8X, 0x%0.4X).\r\n", nAddress, nValue);
+		printf("MemoryMap: Wrote to unmapped memory (0x%08X, 0x%04X).\r\n", nAddress, nValue);
 		return;
 	}
 	switch(e->nType)
@@ -208,7 +208,7 @@ void CMemoryMap_LSBF::SetWord(uint32 nAddress, uint32 nValue)
 	const MEMORYMAPELEMENT* e = GetMap(m_writeMap, nAddress);
 	if(e == NULL) 
 	{
-		printf("MemoryMap: Wrote to unmapped memory (0x%0.8X, 0x%0.8X).\r\n", nAddress, nValue);
+		printf("MemoryMap: Wrote to unmapped memory (0x%08X, 0x%08X).\r\n", nAddress, nValue);
 		return;
 	}
 	switch(e->nType)

--- a/Source/MemoryUtils.cpp
+++ b/Source/MemoryUtils.cpp
@@ -97,7 +97,7 @@ void MemoryUtils_SetDoubleProxy(CMIPS* context, uint64 value64, uint32 address)
 	const CMemoryMap::MEMORYMAPELEMENT* e = context->m_pMemoryMap->GetWriteMap(address);
 	if(e == NULL) 
 	{
-		printf("MemoryMap: Wrote to unmapped memory (0x%0.8X, [0x%0.8X, 0x%0.8X]).\r\n", 
+		printf("MemoryMap: Wrote to unmapped memory (0x%08X, [0x%08X, 0x%08X]).\r\n", 
 			address, value.d0, value.d1);
 		return;
 	}
@@ -124,7 +124,7 @@ void MemoryUtils_SetQuadProxy(CMIPS* context, const uint128& value, uint32 addre
 	const CMemoryMap::MEMORYMAPELEMENT* e = context->m_pMemoryMap->GetWriteMap(address);
 	if(e == NULL) 
 	{
-		printf("MemoryMap: Wrote to unmapped memory (0x%0.8X, [0x%0.8X, 0x%0.8X, 0x%0.8X, 0x%0.8X]).\r\n", 
+		printf("MemoryMap: Wrote to unmapped memory (0x%08X, [0x%08X, 0x%08X, 0x%08X, 0x%08X]).\r\n", 
 			address, value.nV0, value.nV1, value.nV2, value.nV3);
 		return;
 	}

--- a/Source/MipsExecutor.cpp
+++ b/Source/MipsExecutor.cpp
@@ -222,7 +222,7 @@ void CMipsExecutor::CreateBlock(uint32 start, uint32 end)
 			else
 			{
 				//Delete the currently existing block otherwise
-				printf("MipsExecutor: Warning. Deleting block at %0.8X.\r\n", block->GetEndAddress());
+				printf("MipsExecutor: Warning. Deleting block at %08X.\r\n", block->GetEndAddress());
 				DeleteBlock(block);
 			}
 		}

--- a/Source/ee/COP_VU_Reflection.cpp
+++ b/Source/ee/COP_VU_Reflection.cpp
@@ -25,7 +25,7 @@ void CCOP_VU::ReflOpOff(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint3
 {
 	auto imm = static_cast<uint16>((nOpcode >> 0) & 0xFFFF);
 	nAddress += 4;
-	sprintf(sText, "$%0.8X", nAddress + CMIPS::GetBranch(imm));
+	sprintf(sText, "$%08X", nAddress + CMIPS::GetBranch(imm));
 }
 
 void CCOP_VU::ReflOpRtFd(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)
@@ -48,7 +48,7 @@ void CCOP_VU::ReflOpImm15(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uin
 {
 	uint16 nImm	= static_cast<uint16>((nOpcode >> 6) & 0x7FFF);
 
-	sprintf(sText, "$%0.4X", nImm);
+	sprintf(sText, "$%04X", nImm);
 }
 
 void CCOP_VU::ReflOpAccFsFt(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)
@@ -66,7 +66,7 @@ void CCOP_VU::ReflOpFtOffRs(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, u
 	uint8 nFT	= static_cast<uint8> ((nOpcode >> 16) & 0x001F);
 	uint16 nImm = static_cast<uint16>((nOpcode >>  0) & 0xFFFF);
 
-	sprintf(sText, "VF%i, $%0.4X(%s)", nFT, nImm, CMIPS::m_sGPRName[nRS]);
+	sprintf(sText, "VF%i, $%04X(%s)", nFT, nImm, CMIPS::m_sGPRName[nRS]);
 }
 
 void CCOP_VU::ReflOpVi27(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)

--- a/Source/ee/DMAC.cpp
+++ b/Source/ee/DMAC.cpp
@@ -455,7 +455,7 @@ uint32 CDMAC::GetRegister(uint32 nAddress)
 		break;
 
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled IO port (0x%0.8X).\r\n", nAddress);
+		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled IO port (0x%08X).\r\n", nAddress);
 		break;
 	}
 
@@ -862,7 +862,7 @@ void CDMAC::SetRegister(uint32 nAddress, uint32 nData)
 		break;
 
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Wrote to an unhandled IO port (0x%0.8X, 0x%0.8X).\r\n", nAddress, nData);
+		CLog::GetInstance().Print(LOG_NAME, "Wrote to an unhandled IO port (0x%08X, 0x%08X).\r\n", nAddress, nData);
 		break;
 	}
 
@@ -982,7 +982,7 @@ void CDMAC::DisassembleGet(uint32 nAddress)
 		LOG_GET(D_ENABLER)
 
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Reading unknown register 0x%0.8X.\r\n", nAddress);
+		CLog::GetInstance().Print(LOG_NAME, "Reading unknown register 0x%08X.\r\n", nAddress);
 		break;
 	}
 
@@ -991,7 +991,7 @@ void CDMAC::DisassembleGet(uint32 nAddress)
 
 void CDMAC::DisassembleSet(uint32 nAddress, uint32 nData)
 {
-#define LOG_SET(registerId) case registerId: CLog::GetInstance().Print(LOG_NAME, #registerId " = 0x%0.8X.\r\n", nData); break;
+#define LOG_SET(registerId) case registerId: CLog::GetInstance().Print(LOG_NAME, #registerId " = 0x%08X.\r\n", nData); break;
 
 	switch(nAddress)
 	{
@@ -1058,7 +1058,7 @@ void CDMAC::DisassembleSet(uint32 nAddress, uint32 nData)
 		LOG_SET(D_ENABLEW)
 
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Writing unknown register 0x%0.8X, 0x%0.8X.\r\n", nAddress, nData);
+		CLog::GetInstance().Print(LOG_NAME, "Writing unknown register 0x%08X, 0x%08X.\r\n", nAddress, nData);
 		break;
 	}
 

--- a/Source/ee/Ee_SubSystem.cpp
+++ b/Source/ee/Ee_SubSystem.cpp
@@ -439,7 +439,7 @@ uint32 CSubSystem::IOPortReadHandler(uint32 nAddress)
 	}
 	else
 	{
-		printf("PS2VM: Read an unhandled IO port (0x%0.8X).\r\n", nAddress);
+		printf("PS2VM: Read an unhandled IO port (0x%08X).\r\n", nAddress);
 	}
 
 	if((nAddress == CINTC::INTC_STAT) || (nAddress == CGSHandler::GS_CSR))
@@ -527,7 +527,7 @@ uint32 CSubSystem::IOPortWriteHandler(uint32 nAddress, uint32 nData)
 	}
 	else
 	{
-		printf("PS2VM: Wrote to an unhandled IO port (0x%0.8X, 0x%0.8X, PC: 0x%0.8X).\r\n", nAddress, nData, m_EE.m_State.nPC);
+		printf("PS2VM: Wrote to an unhandled IO port (0x%08X, 0x%08X, PC: 0x%08X).\r\n", nAddress, nData, m_EE.m_State.nPC);
 	}
 
 	if(
@@ -558,7 +558,7 @@ uint32 CSubSystem::Vu0IoPortReadHandler(uint32 address)
 		result = m_vpu0->GetVif().GetITOP();
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled VU0 IO port (0x%0.8X).\r\n", address);
+		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled VU0 IO port (0x%08X).\r\n", address);
 		break;
 	}
 	return result;
@@ -569,7 +569,7 @@ uint32 CSubSystem::Vu0IoPortWriteHandler(uint32 address, uint32 value)
 	switch(address)
 	{
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Wrote an unhandled VU0 IO port (0x%0.8X, 0x%0.8X).\r\n", 
+		CLog::GetInstance().Print(LOG_NAME, "Wrote an unhandled VU0 IO port (0x%08X, 0x%08X).\r\n", 
 								  address, value);
 		break;
 	}
@@ -595,7 +595,7 @@ uint32 CSubSystem::Vu1IoPortReadHandler(uint32 address)
 		result = m_vpu1->GetVif().GetTOP();
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled VU1 IO port (0x%0.8X).\r\n", address);
+		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled VU1 IO port (0x%08X).\r\n", address);
 		break;
 	}
 	return result;
@@ -609,7 +609,7 @@ uint32 CSubSystem::Vu1IoPortWriteHandler(uint32 address, uint32 value)
 		m_vpu1->ProcessXgKick(value);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Wrote an unhandled VU1 IO port (0x%0.8X, 0x%0.8X).\r\n", 
+		CLog::GetInstance().Print(LOG_NAME, "Wrote an unhandled VU1 IO port (0x%08X, 0x%08X).\r\n", 
 								  address, value);
 		break;
 	}

--- a/Source/ee/GIF.cpp
+++ b/Source/ee/GIF.cpp
@@ -276,7 +276,7 @@ uint32 CGIF::ProcessSinglePacket(const uint8* memory, uint32 address, uint32 end
 #endif
 
 #if defined(_DEBUG) && defined(DEBUGGER_INCLUDED)
-	CLog::GetInstance().Print(LOG_NAME, "Received GIF packet on path %d at 0x%0.8X of 0x%0.8X bytes.\r\n", 
+	CLog::GetInstance().Print(LOG_NAME, "Received GIF packet on path %d at 0x%08X of 0x%08X bytes.\r\n", 
 		packetMetadata.pathIndex, address, end - address);
 #endif
 
@@ -300,7 +300,7 @@ uint32 CGIF::ProcessSinglePacket(const uint8* memory, uint32 address, uint32 end
 			auto tag = *reinterpret_cast<const TAG*>(&memory[address]);
 			address += 0x10;
 #ifdef _DEBUG
-			CLog::GetInstance().Print(LOG_NAME, "TAG(loops = %d, eop = %d, pre = %d, prim = 0x%0.4X, cmd = %d, nreg = %d);\r\n",
+			CLog::GetInstance().Print(LOG_NAME, "TAG(loops = %d, eop = %d, pre = %d, prim = 0x%04X, cmd = %d, nreg = %d);\r\n",
 				tag.loops, tag.eop, tag.pre, tag.prim, tag.cmd, tag.nreg);
 #endif
 
@@ -359,7 +359,7 @@ uint32 CGIF::ProcessSinglePacket(const uint8* memory, uint32 address, uint32 end
 	flushWriteList(m_gs, packetMetadata);
 
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, "Processed 0x%0.8X bytes.\r\n", address - start);
+	CLog::GetInstance().Print(LOG_NAME, "Processed 0x%08X bytes.\r\n", address - start);
 #endif
 
 	return address - start;
@@ -465,7 +465,7 @@ void CGIF::DisassembleGet(uint32 address)
 		CLog::GetInstance().Print(LOG_NAME, "= GIF_STAT.\r\n", address);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Reading unknown register 0x%0.8X.\r\n", address);
+		CLog::GetInstance().Print(LOG_NAME, "Reading unknown register 0x%08X.\r\n", address);
 		break;
 	}
 }
@@ -475,7 +475,7 @@ void CGIF::DisassembleSet(uint32 address, uint32 value)
 	switch(address)
 	{
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Writing unknown register 0x%0.8X, 0x%0.8X.\r\n", address, value);
+		CLog::GetInstance().Print(LOG_NAME, "Writing unknown register 0x%08X, 0x%08X.\r\n", address, value);
 		break;
 	}
 }

--- a/Source/ee/INTC.cpp
+++ b/Source/ee/INTC.cpp
@@ -59,7 +59,7 @@ uint32 CINTC::GetRegister(uint32 nAddress)
 		return m_INTC_MASK;
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled register (0x%0.8X).\r\n", nAddress);
+		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled register (0x%08X).\r\n", nAddress);
 		break;
 	}
 
@@ -77,7 +77,7 @@ void CINTC::SetRegister(uint32 nAddress, uint32 nValue)
 		m_INTC_MASK ^= nValue;
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Wrote to an unhandled register (0x%0.8X).\r\n", nAddress);
+		CLog::GetInstance().Print(LOG_NAME, "Wrote to an unhandled register (0x%08X).\r\n", nAddress);
 		break;
 	}
 }

--- a/Source/ee/IPU.cpp
+++ b/Source/ee/IPU.cpp
@@ -142,7 +142,7 @@ uint32 CIPU::GetRegister(uint32 nAddress)
 		break;
 
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Reading an unhandled register (0x%0.8X).\r\n", nAddress);
+		CLog::GetInstance().Print(LOG_NAME, "Reading an unhandled register (0x%08X).\r\n", nAddress);
 		break;
 	}
 
@@ -204,7 +204,7 @@ void CIPU::SetRegister(uint32 nAddress, uint32 nValue)
 		break;
 
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Writing 0x%0.8X to an unhandled register (0x%0.8X).\r\n", nValue, nAddress);
+		CLog::GetInstance().Print(LOG_NAME, "Writing 0x%08X to an unhandled register (0x%08X).\r\n", nValue, nAddress);
 		break;
 	}
 }
@@ -573,7 +573,7 @@ void CIPU::DisassembleSet(uint32 nAddress, uint32 nValue)
 	switch(nAddress)
 	{
 	case IPU_CMD + 0x0:
-		CLog::GetInstance().Print(LOG_NAME, "IPU_CMD = 0x%0.8X\r\n", nValue);
+		CLog::GetInstance().Print(LOG_NAME, "IPU_CMD = 0x%08X\r\n", nValue);
 		break;
 	case IPU_CMD + 0x4:
 	case IPU_CMD + 0x8:
@@ -581,7 +581,7 @@ void CIPU::DisassembleSet(uint32 nAddress, uint32 nValue)
 		break;
 
 	case IPU_CTRL + 0x0:
-		CLog::GetInstance().Print(LOG_NAME, "IPU_CTRL = 0x%0.8X\r\n", nValue);
+		CLog::GetInstance().Print(LOG_NAME, "IPU_CTRL = 0x%08X\r\n", nValue);
 		break;
 	case IPU_CTRL + 0x4:
 	case IPU_CTRL + 0x8:
@@ -592,7 +592,7 @@ void CIPU::DisassembleSet(uint32 nAddress, uint32 nValue)
 	case IPU_IN_FIFO + 0x4:
 	case IPU_IN_FIFO + 0x8:
 	case IPU_IN_FIFO + 0xC:
-		CLog::GetInstance().Print(LOG_NAME, "IPU_IN_FIFO = 0x%0.8X\r\n", nValue);
+		CLog::GetInstance().Print(LOG_NAME, "IPU_IN_FIFO = 0x%08X\r\n", nValue);
 		break;
 	}
 
@@ -671,7 +671,7 @@ void CIPU::DisassembleCommand(uint32 nValue)
 			(nValue >>  0) & 0x7FF);
 		break;
 	case 9:
-		CLog::GetInstance().Print(LOG_NAME, "SETTH(th0 = 0x%0.4X, th1 = 0x%0.4X);\r\n", nValue & 0x1FF, (nValue >> 16) & 0x1FF);
+		CLog::GetInstance().Print(LOG_NAME, "SETTH(th0 = 0x%04X, th1 = 0x%04X);\r\n", nValue & 0x1FF, (nValue >> 16) & 0x1FF);
 		break;
 	}
 }
@@ -1175,7 +1175,7 @@ bool CIPU::CBDECCommand::Execute()
 			{
 #ifdef _DECODE_LOGGING
 				static int currentMbIndex = 0;
-				CLog::GetInstance().Print(DECODE_LOG_NAME, "Macroblock(%d, CBP: 0x%0.2X)\r\n", 
+				CLog::GetInstance().Print(DECODE_LOG_NAME, "Macroblock(%d, CBP: 0x%02X)\r\n", 
 					currentMbIndex++, m_codedBlockPattern);
 #endif
 				if(m_command.dcr)

--- a/Source/ee/MA_EE_Reflection.cpp
+++ b/Source/ee/MA_EE_Reflection.cpp
@@ -17,7 +17,7 @@ void CMA_EE::ReflOpRsImm(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint
 	uint8 nRS	= static_cast<uint8> ((nOpcode >> 21) & 0x001F);
 	uint16 nImm = static_cast<uint16>((nOpcode >>  0) & 0xFFFF);
 
-	sprintf(sText, "%s, $%0.4X", CMIPS::m_sGPRName[nRS], nImm);
+	sprintf(sText, "%s, $%04X", CMIPS::m_sGPRName[nRS], nImm);
 }
 
 INSTRUCTION CMA_EE::m_cReflMmi[64] =

--- a/Source/ee/MA_VU_LowerReflection.cpp
+++ b/Source/ee/MA_VU_LowerReflection.cpp
@@ -21,7 +21,7 @@ void CMA_VU::CLower::ReflOpIsOfs(INSTRUCTION* instr, CMIPS* context, uint32 addr
 
 	address += 8;
 
-	sprintf(text, "VI%i, $%0.8X", is, address + GetBranch(imm));
+	sprintf(text, "VI%i, $%08X", is, address + GetBranch(imm));
 }
 
 void CMA_VU::CLower::ReflOpIt(INSTRUCTION* instr, CMIPS* context, uint32 address, uint32 opcode, char* text, unsigned int count)
@@ -35,7 +35,7 @@ void CMA_VU::CLower::ReflOpImm12(INSTRUCTION* instr, CMIPS* context, uint32 addr
 {
 	uint16	imm	= static_cast<uint16>((opcode & 0x7FF) | (opcode & 0x00200000) >> 10);
 
-	sprintf(text, "0x%0.3X", imm);
+	sprintf(text, "0x%03X", imm);
 }
 
 void CMA_VU::CLower::ReflOpItImm12(INSTRUCTION* instr, CMIPS* context, uint32 address, uint32 opcode, char* text, unsigned int count)
@@ -43,7 +43,7 @@ void CMA_VU::CLower::ReflOpItImm12(INSTRUCTION* instr, CMIPS* context, uint32 ad
 	uint8	it	= static_cast<uint8>((opcode >> 16) & 0x001F);
 	uint16	imm	= static_cast<uint16>((opcode & 0x7FF) | (opcode & 0x00200000) >> 10);
 
-	sprintf(text, "VI%i, 0x%0.3X", it, imm);
+	sprintf(text, "VI%i, 0x%03X", it, imm);
 }
 
 void CMA_VU::CLower::ReflOpItIs(INSTRUCTION* instr, CMIPS* context, uint32 address, uint32 opcode, char* text, unsigned int count)
@@ -60,7 +60,7 @@ void CMA_VU::CLower::ReflOpOfs(INSTRUCTION* instr, CMIPS* context, uint32 addres
 
 	address += 8;
 
-	sprintf(text, "$%0.8X", address + GetBranch(imm));
+	sprintf(text, "$%08X", address + GetBranch(imm));
 }
 
 void CMA_VU::CLower::ReflOpItOfs(INSTRUCTION* instr, CMIPS* context, uint32 address, uint32 opcode, char* text, unsigned int count)
@@ -70,7 +70,7 @@ void CMA_VU::CLower::ReflOpItOfs(INSTRUCTION* instr, CMIPS* context, uint32 addr
 
 	address += 8;
 
-	sprintf(text, "VI%i, $%0.8X", it, address + GetBranch(imm));
+	sprintf(text, "VI%i, $%08X", it, address + GetBranch(imm));
 }
 
 void CMA_VU::CLower::ReflOpItIsOfs(INSTRUCTION* instr, CMIPS* context, uint32 address, uint32 opcode, char* text, unsigned int count)
@@ -81,7 +81,7 @@ void CMA_VU::CLower::ReflOpItIsOfs(INSTRUCTION* instr, CMIPS* context, uint32 ad
 
 	address += 8;
 
-	sprintf(text, "VI%i, VI%i, $%0.8X", it, is, address + GetBranch(imm));
+	sprintf(text, "VI%i, VI%i, $%08X", it, is, address + GetBranch(imm));
 }
 
 void CMA_VU::CLower::ReflOpItIsImm15(INSTRUCTION* instr, CMIPS* context, uint32 address, uint32 opcode, char* text, unsigned int count)
@@ -90,7 +90,7 @@ void CMA_VU::CLower::ReflOpItIsImm15(INSTRUCTION* instr, CMIPS* context, uint32 
 	uint8	is	= static_cast<uint8> ((opcode >> 11) & 0x001F);
 	uint16	imm	= static_cast<uint16>((opcode & 0x7FF) | (opcode & 0x01E00000) >> 10);
 
-	sprintf(text, "VI%i, VI%i, $%0.4X", it, is, imm);
+	sprintf(text, "VI%i, VI%i, $%04X", it, is, imm);
 }
 
 void CMA_VU::CLower::ReflOpItOfsIsDst(INSTRUCTION* instr, CMIPS* context, uint32 address, uint32 opcode, char* text, unsigned int count)
@@ -101,21 +101,21 @@ void CMA_VU::CLower::ReflOpItOfsIsDst(INSTRUCTION* instr, CMIPS* context, uint32
 	uint16 imm	= static_cast<uint16>((opcode >>  0) & 0x07FF);
 	if(imm & 0x400) imm |= 0xF800;
 
-	sprintf(text, "VI%i, $%0.4X(VI%i)%s", it, imm, is, m_sDestination[dest]);
+	sprintf(text, "VI%i, $%04X(VI%i)%s", it, imm, is, m_sDestination[dest]);
 }
 
 void CMA_VU::CLower::ReflOpImm24(INSTRUCTION* instr, CMIPS* context, uint32 address, uint32 opcode, char* text, unsigned int count)
 {
 	uint32 imm = opcode & 0xFFFFFF;
 
-	sprintf(text, "$%0.6X", imm);
+	sprintf(text, "$%06X", imm);
 }
 
 void CMA_VU::CLower::ReflOpVi1Imm24(INSTRUCTION* instr, CMIPS* context, uint32 address, uint32 opcode, char* text, unsigned int count)
 {
 	uint32 imm = opcode & 0xFFFFFF;
 
-	sprintf(text, "VI1, $%0.6X", imm);
+	sprintf(text, "VI1, $%06X", imm);
 }
 
 void CMA_VU::CLower::ReflOpFsDstOfsIt(INSTRUCTION* instr, CMIPS* context, uint32 address, uint32 opcode, char* text, unsigned int count)
@@ -126,7 +126,7 @@ void CMA_VU::CLower::ReflOpFsDstOfsIt(INSTRUCTION* instr, CMIPS* context, uint32
 	uint16 imm	= static_cast<uint16>((opcode >>  0) & 0x07FF);
 	if(imm & 0x400) imm |= 0xF800;
 
-	sprintf(text, "VF%i%s, $%0.4X(VI%i)", fs, m_sDestination[dest], imm, it);
+	sprintf(text, "VF%i%s, $%04X(VI%i)", fs, m_sDestination[dest], imm, it);
 }
 
 void CMA_VU::CLower::ReflOpFtDstOfsIs(INSTRUCTION* instr, CMIPS* context, uint32 address, uint32 opcode, char* text, unsigned int count)
@@ -137,7 +137,7 @@ void CMA_VU::CLower::ReflOpFtDstOfsIs(INSTRUCTION* instr, CMIPS* context, uint32
 	uint16 imm	= static_cast<uint16>((opcode >>  0) & 0x07FF);
 	if(imm & 0x400) imm |= 0xF800;
 
-	sprintf(text, "VF%i%s, $%0.4X(VI%i)", ft, m_sDestination[dest], imm, is);
+	sprintf(text, "VF%i%s, $%04X(VI%i)", ft, m_sDestination[dest], imm, is);
 }
 
 void CMA_VU::CLower::ReflOpFtDstFsDst(INSTRUCTION* instr, CMIPS* context, uint32 address, uint32 opcode, char* text, unsigned int count)
@@ -1231,7 +1231,7 @@ void CMA_VU::CLower::GetInstructionOperands(CMIPS* context, uint32 address, uint
 {
 	if(IsLOI(context, address))
 	{
-		sprintf(text, "$%0.8X", opcode);
+		sprintf(text, "$%08X", opcode);
 		return;
 	}
 

--- a/Source/ee/PS2OS.cpp
+++ b/Source/ee/PS2OS.cpp
@@ -280,7 +280,7 @@ void CPS2OS::DumpIntcHandlers()
 		auto handler = m_intcHandlers[i + 1];
 		if(handler == nullptr) continue;
 
-		printf("ID: %0.2i, Line: %i, Address: 0x%0.8X.\r\n", \
+		printf("ID: %02i, Line: %i, Address: 0x%08X.\r\n", \
 			i + 1,
 			handler->cause,
 			handler->address);
@@ -297,7 +297,7 @@ void CPS2OS::DumpDmacHandlers()
 		auto handler = m_dmacHandlers[i + 1];
 		if(handler == nullptr) continue;
 
-		printf("ID: %0.2i, Channel: %i, Address: 0x%0.8X.\r\n", \
+		printf("ID: %02i, Channel: %i, Address: 0x%08X.\r\n", \
 			i + 1,
 			handler->channel,
 			handler->address);
@@ -501,7 +501,7 @@ void CPS2OS::LoadExecutableInternal()
 				}
 				else
 				{
-					sprintf(syscallName, "syscall_%0.4X", syscallId);
+					sprintf(syscallName, "syscall_%04X", syscallId);
 				}
 				m_ee.m_Functions.InsertTag(address - 4, syscallName);
 			}
@@ -1385,7 +1385,7 @@ uint32 CPS2OS::TranslateAddress(CMIPS*, uint32 vaddrLo)
 
 void CPS2OS::sc_Unhandled()
 {
-	CLog::GetInstance().Print(LOG_NAME, "Unknown system call (0x%X) called from 0x%0.8X.\r\n", m_ee.m_State.nGPR[3].nV[0], m_ee.m_State.nPC);
+	CLog::GetInstance().Print(LOG_NAME, "Unknown system call (0x%X) called from 0x%08X.\r\n", m_ee.m_State.nGPR[3].nV[0], m_ee.m_State.nPC);
 }
 
 //02
@@ -2712,7 +2712,7 @@ void CPS2OS::sc_Deci2Call()
 		}
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown Deci2Call function (0x%0.8X) called. PC: 0x%0.8X.\r\n", function, m_ee.m_State.nPC);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown Deci2Call function (0x%08X) called. PC: 0x%08X.\r\n", function, m_ee.m_State.nPC);
 		break;
 	}
 
@@ -2744,7 +2744,7 @@ void CPS2OS::HandleSyscall()
 	if(callInstruction != 0x0000000C)
 	{
 		//This will happen if an ADDIU R0, R0, $x instruction is encountered. Not sure if there's a use for that on the EE
-		CLog::GetInstance().Print(LOG_NAME, "System call exception occured but no SYSCALL instruction found (addr = 0x%0.8X, opcode = 0x%0.8X).\r\n",
+		CLog::GetInstance().Print(LOG_NAME, "System call exception occured but no SYSCALL instruction found (addr = 0x%08X, opcode = 0x%08X).\r\n",
 			searchAddress, callInstruction);
 		m_ee.m_State.nHasException = 0;
 		return;
@@ -2814,20 +2814,20 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 		sprintf(description, SYSCALL_NAME_EXIT "();");
 		break;
 	case 0x06:
-		sprintf(description, SYSCALL_NAME_LOADEXECPS2 "(exec = 0x%0.8X, argc = %d, argv = 0x%0.8X);",
+		sprintf(description, SYSCALL_NAME_LOADEXECPS2 "(exec = 0x%08X, argc = %d, argv = 0x%08X);",
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0],
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0],
 			m_ee.m_State.nGPR[SC_PARAM2].nV[0]);
 		break;
 	case 0x07:
-		sprintf(description, SYSCALL_NAME_EXECPS2 "(pc = 0x%0.8X, gp = 0x%0.8X, argc = %d, argv = 0x%0.8X);",
+		sprintf(description, SYSCALL_NAME_EXECPS2 "(pc = 0x%08X, gp = 0x%08X, argc = %d, argv = 0x%08X);",
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0],
 			m_ee.m_State.nGPR[SC_PARAM0].nV[1],
 			m_ee.m_State.nGPR[SC_PARAM0].nV[2],
 			m_ee.m_State.nGPR[SC_PARAM0].nV[3]);
 		break;
 	case 0x10:
-		sprintf(description, SYSCALL_NAME_ADDINTCHANDLER "(cause = %i, address = 0x%0.8X, next = 0x%0.8X, arg = 0x%0.8X);",
+		sprintf(description, SYSCALL_NAME_ADDINTCHANDLER "(cause = %i, address = 0x%08X, next = 0x%08X, arg = 0x%08X);",
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0],
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0],
 			m_ee.m_State.nGPR[SC_PARAM2].nV[0],
@@ -2839,7 +2839,7 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
 	case 0x12:
-		sprintf(description, SYSCALL_NAME_ADDDMACHANDLER "(channel = %i, address = 0x%0.8X, next = %i, arg = %i);", \
+		sprintf(description, SYSCALL_NAME_ADDDMACHANDLER "(channel = %i, address = 0x%08X, next = %i, arg = %i);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0], \
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0], \
 			m_ee.m_State.nGPR[SC_PARAM2].nV[0], \
@@ -2867,7 +2867,7 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0]);
 		break;
 	case 0x18:
-		sprintf(description, SYSCALL_NAME_SETALARM "(time = %d, proc = 0x%0.8X, arg = 0x%0.8X);",
+		sprintf(description, SYSCALL_NAME_SETALARM "(time = %d, proc = 0x%08X, arg = 0x%08X);",
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0], 
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0], 
 			m_ee.m_State.nGPR[SC_PARAM2].nV[0]);
@@ -2893,15 +2893,15 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0]);
 		break;
 	case 0x20:
-		sprintf(description, SYSCALL_NAME_CREATETHREAD "(thread = 0x%0.8X);", \
+		sprintf(description, SYSCALL_NAME_CREATETHREAD "(thread = 0x%08X);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0]);
 		break;
 	case 0x21:
-		sprintf(description, SYSCALL_NAME_DELETETHREAD "(id = 0x%0.8X);", \
+		sprintf(description, SYSCALL_NAME_DELETETHREAD "(id = 0x%08X);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0]);
 		break;
 	case 0x22:
-		sprintf(description, SYSCALL_NAME_STARTTHREAD "(id = 0x%0.8X, a0 = 0x%0.8X);", \
+		sprintf(description, SYSCALL_NAME_STARTTHREAD "(id = 0x%08X, a0 = 0x%08X);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0], \
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
@@ -2912,16 +2912,16 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 		sprintf(description, SYSCALL_NAME_EXITDELETETHREAD "();");
 		break;
 	case 0x25:
-		sprintf(description, SYSCALL_NAME_TERMINATETHREAD "(id = 0x%0.8X);", \
+		sprintf(description, SYSCALL_NAME_TERMINATETHREAD "(id = 0x%08X);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0]);
 		break;
 	case 0x29:
-		sprintf(description, SYSCALL_NAME_CHANGETHREADPRIORITY "(id = 0x%0.8X, priority = %i);", \
+		sprintf(description, SYSCALL_NAME_CHANGETHREADPRIORITY "(id = 0x%08X, priority = %i);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0], \
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
 	case 0x2A:
-		sprintf(description, SYSCALL_NAME_ICHANGETHREADPRIORITY "(id = 0x%0.8X, priority = %i);", \
+		sprintf(description, SYSCALL_NAME_ICHANGETHREADPRIORITY "(id = 0x%08X, priority = %i);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0], \
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
@@ -2933,12 +2933,12 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 		sprintf(description, SYSCALL_NAME_GETTHREADID "();");
 		break;
 	case 0x30:
-		sprintf(description, SYSCALL_NAME_REFERTHREADSTATUS "(threadId = %d, infoPtr = 0x%0.8X);",
+		sprintf(description, SYSCALL_NAME_REFERTHREADSTATUS "(threadId = %d, infoPtr = 0x%08X);",
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0],
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
 	case 0x31:
-		sprintf(description, SYSCALL_NAME_IREFERTHREADSTATUS "(threadId = %d, infoPtr = 0x%0.8X);",
+		sprintf(description, SYSCALL_NAME_IREFERTHREADSTATUS "(threadId = %d, infoPtr = 0x%08X);",
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0],
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
@@ -2974,7 +2974,7 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0]);
 		break;
 	case 0x3C:
-		sprintf(description, "SetupThread(gp = 0x%0.8X, stack = 0x%0.8X, stack_size = 0x%0.8X, args = 0x%0.8X, root_func = 0x%0.8X);", \
+		sprintf(description, "SetupThread(gp = 0x%08X, stack = 0x%08X, stack_size = 0x%08X, args = 0x%08X, root_func = 0x%08X);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0], \
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0], \
 			m_ee.m_State.nGPR[SC_PARAM2].nV[0], \
@@ -2982,7 +2982,7 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 			m_ee.m_State.nGPR[SC_PARAM4].nV[0]);
 		break;
 	case 0x3D:
-		sprintf(description, "SetupHeap(heap_start = 0x%0.8X, heap_size = 0x%0.8X);", \
+		sprintf(description, "SetupHeap(heap_start = 0x%08X, heap_size = 0x%08X);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0], \
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
@@ -2990,7 +2990,7 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 		sprintf(description, SYSCALL_NAME_ENDOFHEAP "();");
 		break;
 	case 0x40:
-		sprintf(description, SYSCALL_NAME_CREATESEMA "(sema = 0x%0.8X);", \
+		sprintf(description, SYSCALL_NAME_CREATESEMA "(sema = 0x%08X);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0]);
 		break;
 	case 0x41:
@@ -3018,12 +3018,12 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0]);
 		break;
 	case 0x47:
-		sprintf(description, SYSCALL_NAME_REFERSEMASTATUS "(semaid = %i, status = 0x%0.8X);",
+		sprintf(description, SYSCALL_NAME_REFERSEMASTATUS "(semaid = %i, status = 0x%08X);",
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0],
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
 	case 0x48:
-		sprintf(description, SYSCALL_NAME_IREFERSEMASTATUS "(semaid = %i, status = 0x%0.8X);",
+		sprintf(description, SYSCALL_NAME_IREFERSEMASTATUS "(semaid = %i, status = 0x%08X);",
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0],
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
@@ -3037,16 +3037,16 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 		sprintf(description, SYSCALL_NAME_GSGETIMR "();");
 		break;
 	case 0x71:
-		sprintf(description, SYSCALL_NAME_GSPUTIMR "(GS_IMR = 0x%0.8X);", \
+		sprintf(description, SYSCALL_NAME_GSPUTIMR "(GS_IMR = 0x%08X);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0]);
 		break;
 	case 0x73:
-		sprintf(description, SYSCALL_NAME_SETVSYNCFLAG "(ptr1 = 0x%0.8X, ptr2 = 0x%0.8X);", \
+		sprintf(description, SYSCALL_NAME_SETVSYNCFLAG "(ptr1 = 0x%08X, ptr2 = 0x%08X);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0], \
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
 	case 0x74:
-		sprintf(description, SYSCALL_NAME_SETSYSCALL "(num = 0x%0.2X, address = 0x%0.8X);", \
+		sprintf(description, SYSCALL_NAME_SETSYSCALL "(num = 0x%02X, address = 0x%08X);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0], \
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
@@ -3054,7 +3054,7 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 		sprintf(description, SYSCALL_NAME_SIFDMASTAT "();");
 		break;
 	case 0x77:
-		sprintf(description, SYSCALL_NAME_SIFSETDMA "(list = 0x%0.8X, count = %i);", \
+		sprintf(description, SYSCALL_NAME_SIFSETDMA "(list = 0x%08X, count = %i);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0], \
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
@@ -3062,16 +3062,16 @@ std::string CPS2OS::GetSysCallDescription(uint8 function)
 		sprintf(description, SYSCALL_NAME_SIFSETDCHAIN "();");
 		break;
 	case 0x79:
-		sprintf(description, "SifSetReg(register = 0x%0.8X, value = 0x%0.8X);", \
+		sprintf(description, "SifSetReg(register = 0x%08X, value = 0x%08X);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0], \
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;
 	case 0x7A:
-		sprintf(description, "SifGetReg(register = 0x%0.8X);", \
+		sprintf(description, "SifGetReg(register = 0x%08X);", \
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0]);
 		break;
 	case 0x7C:
-		sprintf(description, SYSCALL_NAME_DECI2CALL "(func = 0x%0.8X, param = 0x%0.8X);",
+		sprintf(description, SYSCALL_NAME_DECI2CALL "(func = 0x%08X, param = 0x%08X);",
 			m_ee.m_State.nGPR[SC_PARAM0].nV[0],
 			m_ee.m_State.nGPR[SC_PARAM1].nV[0]);
 		break;

--- a/Source/ee/SIF.cpp
+++ b/Source/ee/SIF.cpp
@@ -157,7 +157,7 @@ uint32 CSIF::ReceiveDMA6(uint32 nSrcAddr, uint32 nSize, uint32 nDstAddr, bool is
 	{
 		auto hdr = reinterpret_cast<SIFCMDHEADER*>(m_eeRam + nSrcAddr);
 
-		CLog::GetInstance().Print(LOG_NAME, "Received command 0x%0.8X.\r\n", hdr->commandId);
+		CLog::GetInstance().Print(LOG_NAME, "Received command 0x%08X.\r\n", hdr->commandId);
 
 		switch(hdr->commandId)
 		{
@@ -190,7 +190,7 @@ uint32 CSIF::ReceiveDMA6(uint32 nSrcAddr, uint32 nSize, uint32 nDstAddr, bool is
 	else
 	{
 		assert(nDstAddr < PS2::IOP_RAM_SIZE);
-		CLog::GetInstance().Print(LOG_NAME, "WriteToIop(dstAddr = 0x%0.8X, srcAddr = 0x%0.8X, size = 0x%0.8X);\r\n", 
+		CLog::GetInstance().Print(LOG_NAME, "WriteToIop(dstAddr = 0x%08X, srcAddr = 0x%08X, size = 0x%08X);\r\n", 
 			nDstAddr, nSrcAddr, nSize);
 		nSize &= 0x7FFFFFFF;		//Fix for Gregory Horror Show's crash
 		if(nDstAddr >= 0 && nDstAddr <= CIopBios::CONTROL_BLOCK_END)
@@ -441,7 +441,7 @@ void CSIF::Cmd_Bind(const SIFCMDHEADER* hdr)
 	rend.buffer             = RPC_RECVADDR;
 	rend.cbuffer            = 0xDEADCAFE;
 
-	CLog::GetInstance().Print(LOG_NAME, "Bound client data (0x%0.8X) with server id 0x%0.8X.\r\n", bind->clientDataAddr, bind->serverId);
+	CLog::GetInstance().Print(LOG_NAME, "Bound client data (0x%08X) with server id 0x%08X.\r\n", bind->clientDataAddr, bind->serverId);
 
 	auto moduleIterator(m_modules.find(bind->serverId));
 	if(moduleIterator != m_modules.end())
@@ -460,7 +460,7 @@ void CSIF::Cmd_Call(const SIFCMDHEADER* hdr)
 	auto call = reinterpret_cast<const SIFRPCCALL*>(hdr);
 	bool sendReply = true;
 
-	CLog::GetInstance().Print(LOG_NAME, "Calling function 0x%0.8X of module 0x%0.8X.\r\n", call->rpcNumber, call->serverDataAddr);
+	CLog::GetInstance().Print(LOG_NAME, "Calling function 0x%08X of module 0x%08X.\r\n", call->rpcNumber, call->serverDataAddr);
 
 	uint32 nRecvAddr = (call->recv & (PS2::EE_RAM_SIZE - 1));
 
@@ -475,7 +475,7 @@ void CSIF::Cmd_Call(const SIFCMDHEADER* hdr)
 	}
 	else
 	{
-		CLog::GetInstance().Print(LOG_NAME, "Called an unknown module (0x%0.8X).\r\n", call->serverDataAddr);
+		CLog::GetInstance().Print(LOG_NAME, "Called an unknown module (0x%08X).\r\n", call->serverDataAddr);
 	}
 
 	{
@@ -512,7 +512,7 @@ void CSIF::Cmd_GetOtherData(const SIFCMDHEADER* hdr)
 {
 	auto otherData = reinterpret_cast<const SIFRPCOTHERDATA*>(hdr);
 
-	CLog::GetInstance().Print(LOG_NAME, "GetOtherData(dstPtr = 0x%0.8X, srcPtr = 0x%0.8X, size = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "GetOtherData(dstPtr = 0x%08X, srcPtr = 0x%08X, size = 0x%08X);\r\n",
 		otherData->dstPtr, otherData->srcPtr, otherData->size);
 
 	uint32 dstPtr = otherData->dstPtr & (PS2::EE_RAM_SIZE - 1);
@@ -579,7 +579,7 @@ uint32 CSIF::GetRegister(uint32 nRegister)
 		nRegister &= ~0x80000000;
 		if(nRegister >= MAX_USERREG)
 		{
-			printf("SIF: Warning. Trying to read an unimplemented user register (0x%0.8X).\r\n", nRegister | 0x80000000);
+			printf("SIF: Warning. Trying to read an unimplemented user register (0x%08X).\r\n", nRegister | 0x80000000);
 			return 0;
 		}
 		return m_nUserReg[nRegister];
@@ -609,7 +609,7 @@ uint32 CSIF::GetRegister(uint32 nRegister)
 			return 1;
 			break;
 		default:
-			CLog::GetInstance().Print(LOG_NAME, "Warning. Trying to read an invalid system register (0x%0.8X).\r\n", nRegister);
+			CLog::GetInstance().Print(LOG_NAME, "Warning. Trying to read an invalid system register (0x%08X).\r\n", nRegister);
 			return 0;
 			break;
 		}
@@ -624,7 +624,7 @@ void CSIF::SetRegister(uint32 nRegister, uint32 nValue)
 		nRegister &= ~0x80000000;
 		if(nRegister >= MAX_USERREG)
 		{
-			printf("SIF: Warning. Trying to write to an unimplemented user register (0x%0.8X).\r\n", nRegister | 0x80000000);
+			printf("SIF: Warning. Trying to write to an unimplemented user register (0x%08X).\r\n", nRegister | 0x80000000);
 			return;
 		}
 		m_nUserReg[nRegister] = nValue;
@@ -646,7 +646,7 @@ void CSIF::SetRegister(uint32 nRegister, uint32 nValue)
 			//Set by RPC library (initialized state?)
 			break;
 		default:
-			CLog::GetInstance().Print(LOG_NAME, "Warning. Trying to write to an invalid system register (0x%0.8X).\r\n", nRegister);
+			CLog::GetInstance().Print(LOG_NAME, "Warning. Trying to write to an invalid system register (0x%08X).\r\n", nRegister);
 			break;
 		}
 	}

--- a/Source/ee/Timer.cpp
+++ b/Source/ee/Timer.cpp
@@ -130,7 +130,7 @@ uint32 CTimer::GetRegister(uint32 nAddress)
 		break;
 
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled IO port (0x%0.8X).\r\n", nAddress);
+		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled IO port (0x%08X).\r\n", nAddress);
 		break;
 	}
 
@@ -180,7 +180,7 @@ void CTimer::SetRegister(uint32 nAddress, uint32 nValue)
 		break;
 
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Wrote to an unhandled IO port (0x%0.8X, 0x%0.8X).\r\n", nAddress, nValue);
+		CLog::GetInstance().Print(LOG_NAME, "Wrote to an unhandled IO port (0x%08X, 0x%08X).\r\n", nAddress, nValue);
 		break;
 	}
 }
@@ -216,19 +216,19 @@ void CTimer::DisassembleSet(uint32 nAddress, uint32 nValue)
 	switch(nAddress & 0x7FF)
 	{
 	case 0x00:
-		CLog::GetInstance().Print(LOG_NAME, "T%i_COUNT = 0x%0.8X\r\n", nTimerId, nValue);
+		CLog::GetInstance().Print(LOG_NAME, "T%i_COUNT = 0x%08X\r\n", nTimerId, nValue);
 		break;
 
 	case 0x10:
-		CLog::GetInstance().Print(LOG_NAME, "T%i_MODE = 0x%0.8X\r\n", nTimerId, nValue);
+		CLog::GetInstance().Print(LOG_NAME, "T%i_MODE = 0x%08X\r\n", nTimerId, nValue);
 		break;
 
 	case 0x20:
-		CLog::GetInstance().Print(LOG_NAME, "T%i_COMP = 0x%0.8X\r\n", nTimerId, nValue);
+		CLog::GetInstance().Print(LOG_NAME, "T%i_COMP = 0x%08X\r\n", nTimerId, nValue);
 		break;
 
 	case 0x30:
-		CLog::GetInstance().Print(LOG_NAME, "T%i_HOLD = 0x%0.8X\r\n", nTimerId, nValue);
+		CLog::GetInstance().Print(LOG_NAME, "T%i_HOLD = 0x%08X\r\n", nTimerId, nValue);
 		break;
 	}
 }

--- a/Source/ee/VUShared_Reflection.cpp
+++ b/Source/ee/VUShared_Reflection.cpp
@@ -273,7 +273,7 @@ void VUShared::ReflOpItIsImm5(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress,
 		nImm |= 0xFFE0;
 	}
 
-	sprintf(sText, "VI%i, VI%i, $%0.4X", nIT, nIS, nImm);
+	sprintf(sText, "VI%i, VI%i, $%04X", nIT, nIS, nImm);
 }
 
 void VUShared::ReflOpItFsf(INSTRUCTION* pInstr, CMIPS* pCtx, uint32 nAddress, uint32 nOpcode, char* sText, unsigned int nCount)

--- a/Source/ee/Vif.cpp
+++ b/Source/ee/Vif.cpp
@@ -263,7 +263,7 @@ uint32 CVif::ReceiveDMA(uint32 address, uint32 qwc, uint32 unused, bool tagInclu
 #endif
 
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, "vif%i : Processing packet @ 0x%0.8X, qwc = 0x%X, tagIncluded = %i\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "vif%i : Processing packet @ 0x%08X, qwc = 0x%X, tagIncluded = %i\r\n",
 		m_number, address, qwc, static_cast<int>(tagIncluded));
 #endif
 
@@ -1011,7 +1011,7 @@ void CVif::DisassembleGet(uint32 address)
 		LOG_GET(VIF1_R3)
 
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Reading unknown register 0x%0.8X.\r\n", address);
+		CLog::GetInstance().Print(LOG_NAME, "Reading unknown register 0x%08X.\r\n", address);
 		break;
 	}
 
@@ -1022,15 +1022,15 @@ void CVif::DisassembleSet(uint32 address, uint32 value)
 {
 	if((address >= VIF0_FIFO_START) && (address < VIF0_FIFO_END))
 	{
-		CLog::GetInstance().Print(LOG_NAME, "VIF0_FIFO(0x%0.3X) = 0x%0.8X.\r\n", address & 0xFFF, value);
+		CLog::GetInstance().Print(LOG_NAME, "VIF0_FIFO(0x%03X) = 0x%08X.\r\n", address & 0xFFF, value);
 	}
 	else if((address >= VIF1_FIFO_START) && (address < VIF1_FIFO_END))
 	{
-		CLog::GetInstance().Print(LOG_NAME, "VIF1_FIFO(0x%0.3X) = 0x%0.8X.\r\n", address & 0xFFF, value);
+		CLog::GetInstance().Print(LOG_NAME, "VIF1_FIFO(0x%03X) = 0x%08X.\r\n", address & 0xFFF, value);
 	}
 	else
 	{
-#define LOG_SET(registerId) case registerId: CLog::GetInstance().Print(LOG_NAME, #registerId " = 0x%0.8X.\r\n", value); break;
+#define LOG_SET(registerId) case registerId: CLog::GetInstance().Print(LOG_NAME, #registerId " = 0x%08X.\r\n", value); break;
 
 		switch(address)
 		{
@@ -1041,7 +1041,7 @@ void CVif::DisassembleSet(uint32 address, uint32 value)
 			LOG_SET(VIF1_MARK)
 
 		default:
-			CLog::GetInstance().Print(LOG_NAME, "Writing unknown register 0x%0.8X, 0x%0.8X.\r\n", address, value);
+			CLog::GetInstance().Print(LOG_NAME, "Writing unknown register 0x%08X, 0x%08X.\r\n", address, value);
 			break;
 		}
 

--- a/Source/ee/Vpu.cpp
+++ b/Source/ee/Vpu.cpp
@@ -151,7 +151,7 @@ CVif& CVpu::GetVif()
 
 void CVpu::ExecuteMicroProgram(uint32 nAddress)
 {
-	CLog::GetInstance().Print(LOG_NAME, "Starting microprogram execution at 0x%0.8X.\r\n", nAddress);
+	CLog::GetInstance().Print(LOG_NAME, "Starting microprogram execution at 0x%08X.\r\n", nAddress);
 
 	m_ctx->m_State.nPC = nAddress;
 	m_ctx->m_State.pipeTime = 0;

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL_Texture.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL_Texture.cpp
@@ -239,7 +239,7 @@ void CGSH_OpenGL::DumpTexture(unsigned int nWidth, unsigned int nHeight, uint32 
 	for(unsigned int i = 0; i < UINT_MAX; i++)
 	{
 		struct _stat Stat;
-		sprintf(sFilename, "./textures/tex_%0.8X_%0.8X.bmp", i, checksum);
+		sprintf(sFilename, "./textures/tex_%08X_%08X.bmp", i, checksum);
 		if(_stat(sFilename, &Stat) == -1) break;
 	}
 

--- a/Source/gs/GSHandler.cpp
+++ b/Source/gs/GSHandler.cpp
@@ -273,7 +273,7 @@ uint32 CGSHandler::ReadPrivRegister(uint32 nAddress)
 		R_REG(nAddress, nData, m_nSIGLBLID);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled priviledged register (0x%0.8X).\r\n", nAddress);
+		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled priviledged register (0x%08X).\r\n", nAddress);
 		nData = 0xCCCCCCCC;
 		break;
 	}
@@ -341,7 +341,7 @@ void CGSHandler::WritePrivRegister(uint32 nAddress, uint32 nData)
 		W_REG(nAddress, nData, m_nSIGLBLID);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Wrote to an unhandled priviledged register (0x%0.8X, 0x%0.8X).\r\n", nAddress, nData);
+		CLog::GetInstance().Print(LOG_NAME, "Wrote to an unhandled priviledged register (0x%08X, 0x%08X).\r\n", nAddress, nData);
 		break;
 	}
 
@@ -569,7 +569,7 @@ void CGSHandler::FeedImageDataImpl(const void* pData, uint32 nLength)
 			ProcessHostToLocalTransfer();
 
 #ifdef _DEBUG
-			CLog::GetInstance().Print(LOG_NAME, "Completed image transfer at 0x%0.8X (dirty = %d).\r\n", bltBuf.GetDstPtr(), m_trxCtx.nDirty);
+			CLog::GetInstance().Print(LOG_NAME, "Completed image transfer at 0x%08X (dirty = %d).\r\n", bltBuf.GetDstPtr(), m_trxCtx.nDirty);
 #endif
 		}
 	}
@@ -657,13 +657,13 @@ void CGSHandler::BeginTransfer()
 
 		if(trxDir == 0)
 		{
-			CLog::GetInstance().Print(LOG_NAME, "Starting transfer to 0x%0.8X, buffer size %d, psm: %d, size (%dx%d)\r\n",
+			CLog::GetInstance().Print(LOG_NAME, "Starting transfer to 0x%08X, buffer size %d, psm: %d, size (%dx%d)\r\n",
 				bltBuf.GetDstPtr(), bltBuf.GetDstWidth(), bltBuf.nDstPsm, trxReg.nRRW, trxReg.nRRH);
 		}
 		else if(trxDir == 1)
 		{
 			ProcessLocalToHostTransfer();
-			CLog::GetInstance().Print(LOG_NAME, "Starting transfer from 0x%0.8X, buffer size %d, psm: %d, size (%dx%d)\r\n",
+			CLog::GetInstance().Print(LOG_NAME, "Starting transfer from 0x%08X, buffer size %d, psm: %d, size (%dx%d)\r\n",
 				bltBuf.GetSrcPtr(), bltBuf.GetSrcWidth(), bltBuf.nSrcPsm, trxReg.nRRW, trxReg.nRRH);
 		}
 	}
@@ -1331,7 +1331,7 @@ std::string CGSHandler::DisassembleWrite(uint8 registerId, uint64 data)
 	case GS_REG_RGBAQ:
 		{
 			auto rgbaq = make_convertible<RGBAQ>(data);
-			result = string_format("RGBAQ(R: 0x%0.2X, G: 0x%0.2X, B: 0x%0.2X, A: 0x%0.2X, Q: %f)",
+			result = string_format("RGBAQ(R: 0x%02X, G: 0x%02X, B: 0x%02X, A: 0x%02X, Q: %f)",
 				rgbaq.nR, rgbaq.nG, rgbaq.nB, rgbaq.nA, rgbaq.nQ);
 		}
 		break;
@@ -1375,7 +1375,7 @@ std::string CGSHandler::DisassembleWrite(uint8 registerId, uint64 data)
 	case GS_REG_TEX0_2:
 		{
 			auto tex0 = make_convertible<TEX0>(data);
-			result = string_format("TEX0_%i(TBP: 0x%0.8X, TBW: %i, PSM: %i, TW: %i, TH: %i, TCC: %i, TFX: %i, CBP: 0x%0.8X, CPSM: %i, CSM: %i, CSA: %i, CLD: %i)",
+			result = string_format("TEX0_%i(TBP: 0x%08X, TBW: %i, PSM: %i, TW: %i, TH: %i, TCC: %i, TFX: %i, CBP: 0x%08X, CPSM: %i, CSM: %i, CSA: %i, CLD: %i)",
 				(registerId == GS_REG_TEX0_1) ? 1 : 2, tex0.GetBufPtr(), tex0.GetBufWidth(), tex0.nPsm, tex0.GetWidth(), tex0.GetHeight(), tex0.nColorComp,
 				tex0.nFunction, tex0.GetCLUTPtr(), tex0.nCPSM, tex0.nCSM, tex0.nCSA, tex0.nCLD);
 		}
@@ -1400,7 +1400,7 @@ std::string CGSHandler::DisassembleWrite(uint8 registerId, uint64 data)
 	case GS_REG_TEX2_2:
 		{
 			auto tex2 = make_convertible<TEX2>(data);
-			result = string_format("TEX2_%i(PSM: %i, CBP: 0x%0.8X, CPSM: %i, CSM: %i, CSA: %i, CLD: %i)",
+			result = string_format("TEX2_%i(PSM: %i, CBP: 0x%08X, CPSM: %i, CSM: %i, CSA: %i, CLD: %i)",
 				(registerId == GS_REG_TEX2_1) ? 1 : 2, tex2.nPsm, tex2.GetCLUTPtr(), tex2.nCPSM, tex2.nCSM, tex2.nCSA, tex2.nCLD);
 		}
 		break;
@@ -1430,7 +1430,7 @@ std::string CGSHandler::DisassembleWrite(uint8 registerId, uint64 data)
 	case GS_REG_MIPTBP1_2:
 		{
 			auto miptbp1 = make_convertible<MIPTBP1>(data);
-			result = string_format("MIPTBP1_%d(TBP1: 0x%0.8X, TBW1: %d, TBP2: 0x%0.8X, TBW2: %d, TBP3: 0x%0.8X, TBW3: %d)",
+			result = string_format("MIPTBP1_%d(TBP1: 0x%08X, TBW1: %d, TBP2: 0x%08X, TBW2: %d, TBP3: 0x%08X, TBW3: %d)",
 				(registerId == GS_REG_MIPTBP1_1) ? 1 : 2, 
 				miptbp1.GetTbp1(), miptbp1.GetTbw1(),
 				miptbp1.GetTbp2(), miptbp1.GetTbw2(),
@@ -1441,7 +1441,7 @@ std::string CGSHandler::DisassembleWrite(uint8 registerId, uint64 data)
 	case GS_REG_MIPTBP2_2:
 		{
 			auto miptbp2 = make_convertible<MIPTBP2>(data);
-			result = string_format("MIPTBP2_%d(TBP4: 0x%0.8X, TBW4: %d, TBP5: 0x%0.8X, TBW5: %d, TBP6: 0x%0.8X, TBW6: %d)",
+			result = string_format("MIPTBP2_%d(TBP4: 0x%08X, TBW4: %d, TBP5: 0x%08X, TBW5: %d, TBP6: 0x%08X, TBW6: %d)",
 				(registerId == GS_REG_MIPTBP2_1) ? 1 : 2, 
 				miptbp2.GetTbp4(), miptbp2.GetTbw4(),
 				miptbp2.GetTbp5(), miptbp2.GetTbw5(),
@@ -1451,14 +1451,14 @@ std::string CGSHandler::DisassembleWrite(uint8 registerId, uint64 data)
 	case GS_REG_TEXA:
 		{
 			auto texa = make_convertible<TEXA>(data);
-			result = string_format("TEXA(TA0: 0x%0.2X, AEM: %i, TA1: 0x%0.2X)",
+			result = string_format("TEXA(TA0: 0x%02X, AEM: %i, TA1: 0x%02X)",
 				texa.nTA0, texa.nAEM, texa.nTA1);
 		}
 		break;
 	case GS_REG_FOGCOL:
 		{
 			auto fogcol = make_convertible<FOGCOL>(data);
-			result = string_format("FOGCOL(R: 0x%0.2X, G: 0x%0.2X, B: 0x%0.2X)",
+			result = string_format("FOGCOL(R: 0x%02X, G: 0x%02X, B: 0x%02X)",
 				fogcol.nFCR, fogcol.nFCG, fogcol.nFCB);
 		}
 		break;
@@ -1469,7 +1469,7 @@ std::string CGSHandler::DisassembleWrite(uint8 registerId, uint64 data)
 	case GS_REG_ALPHA_2:
 		{
 			auto alpha = make_convertible<ALPHA>(data);
-			result = string_format("ALPHA_%i(A: %i, B: %i, C: %i, D: %i, FIX: 0x%0.2X)",
+			result = string_format("ALPHA_%i(A: %i, B: %i, C: %i, D: %i, FIX: 0x%02X)",
 				(registerId == GS_REG_ALPHA_1) ? 1 : 2, alpha.nA, alpha.nB, alpha.nC, alpha.nD, alpha.nFix);
 		}
 		break;
@@ -1485,7 +1485,7 @@ std::string CGSHandler::DisassembleWrite(uint8 registerId, uint64 data)
 	case GS_REG_TEST_2:
 		{
 			auto tst = make_convertible<TEST>(data);
-			result = string_format("TEST_%i(ATE: %i, ATST: %i, AREF: 0x%0.2X, AFAIL: %i, DATE: %i, DATM: %i, ZTE: %i, ZTST: %i)",
+			result = string_format("TEST_%i(ATE: %i, ATST: %i, AREF: 0x%02X, AFAIL: %i, DATE: %i, DATM: %i, ZTE: %i, ZTST: %i)",
 				(registerId == GS_REG_TEST_1) ? 1 : 2, tst.nAlphaEnabled, tst.nAlphaMethod, tst.nAlphaRef, tst.nAlphaFail,
 				tst.nDestAlphaEnabled, tst.nDestAlphaMode, tst.nDepthEnabled, tst.nDepthMethod);
 		}
@@ -1507,7 +1507,7 @@ std::string CGSHandler::DisassembleWrite(uint8 registerId, uint64 data)
 	case GS_REG_FRAME_2:
 		{
 			auto fr = make_convertible<FRAME>(data);
-			result = string_format("FRAME_%i(FBP: 0x%0.8X, FBW: %d, PSM: %d, FBMSK: 0x%0.8X)",
+			result = string_format("FRAME_%i(FBP: 0x%08X, FBW: %d, PSM: %d, FBMSK: 0x%08X)",
 				(registerId == GS_REG_FRAME_1) ? 1 : 2, fr.GetBasePtr(), fr.GetWidth(), fr.nPsm, fr.nMask);
 		}
 		break;
@@ -1515,14 +1515,14 @@ std::string CGSHandler::DisassembleWrite(uint8 registerId, uint64 data)
 	case GS_REG_ZBUF_2:
 		{
 			auto zbuf = make_convertible<ZBUF>(data);
-			result = string_format("ZBUF_%i(ZBP: 0x%0.8X, PSM: %i, ZMSK: %i)",
+			result = string_format("ZBUF_%i(ZBP: 0x%08X, PSM: %i, ZMSK: %i)",
 				(registerId == GS_REG_ZBUF_1) ? 1 : 2, zbuf.GetBasePtr(), zbuf.nPsm, zbuf.nMask);
 		}
 		break;
 	case GS_REG_BITBLTBUF:
 		{
 			auto buf = make_convertible<BITBLTBUF>(data);
-			result = string_format("BITBLTBUF(SBP: 0x%0.8X, SBW: %i, SPSM: %i, DBP: 0x%0.8X, DBW: %i, DPSM: %i)",
+			result = string_format("BITBLTBUF(SBP: 0x%08X, SBW: %i, SPSM: %i, DBP: 0x%08X, DBW: %i, DPSM: %i)",
 				buf.GetSrcPtr(), buf.GetSrcWidth(), buf.nSrcPsm, buf.GetDstPtr(), buf.GetDstWidth(), buf.nDstPsm);
 		}
 		break;
@@ -1546,7 +1546,7 @@ std::string CGSHandler::DisassembleWrite(uint8 registerId, uint64 data)
 	case GS_REG_SIGNAL:
 		{
 			auto signal = make_convertible<SIGNAL>(data);
-			result = string_format("SIGNAL(IDMSK: 0x%0.8X, ID: 0x%0.8X)",
+			result = string_format("SIGNAL(IDMSK: 0x%08X, ID: 0x%08X)",
 				signal.idmsk, signal.id);
 		}
 		break;
@@ -1556,12 +1556,12 @@ std::string CGSHandler::DisassembleWrite(uint8 registerId, uint64 data)
 	case GS_REG_LABEL:
 		{
 			auto label = make_convertible<LABEL>(data);
-			result = string_format("LABEL(IDMSK: 0x%0.8X, ID: 0x%0.8X)",
+			result = string_format("LABEL(IDMSK: 0x%08X, ID: 0x%08X)",
 				label.idmsk, label.id);
 		}
 		break;
 	default:
-		result = string_format("(Unknown register: 0x%0.2X)", registerId);
+		result = string_format("(Unknown register: 0x%02X)", registerId);
 		break;
 	}
 
@@ -1583,7 +1583,7 @@ void CGSHandler::LogPrivateWrite(uint32 address)
 	switch(regAddress)
 	{
 	case GS_PMODE:
-		CLog::GetInstance().Print(LOG_NAME, "PMODE(0x%0.8X);\r\n", m_nPMODE);
+		CLog::GetInstance().Print(LOG_NAME, "PMODE(0x%08X);\r\n", m_nPMODE);
 		break;
 	case GS_SMODE2:
 		{
@@ -1600,7 +1600,7 @@ void CGSHandler::LogPrivateWrite(uint32 address)
 		{
 			DISPFB dispfb;
 			dispfb <<= (regAddress == GS_DISPFB1) ? m_nDISPFB1.value.q : m_nDISPFB2.value.q;
-			CLog::GetInstance().Print(LOG_NAME, "DISPFB%d(FBP: 0x%0.8X, FBW: %d, PSM: %d, DBX: %d, DBY: %d);\r\n",
+			CLog::GetInstance().Print(LOG_NAME, "DISPFB%d(FBP: 0x%08X, FBW: %d, PSM: %d, DBX: %d, DBY: %d);\r\n",
 				(regAddress == GS_DISPFB1) ? 1 : 2,
 				dispfb.GetBufPtr(),
 				dispfb.GetBufWidth(),

--- a/Source/iop/IopBios.cpp
+++ b/Source/iop/IopBios.cpp
@@ -837,7 +837,7 @@ int32 CIopBios::GetCurrentThreadIdRaw() const
 uint32 CIopBios::CreateThread(uint32 threadProc, uint32 priority, uint32 stackSize, uint32 optionData, uint32 attributes)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: CreateThread(threadProc = 0x%0.8X, priority = %d, stackSize = 0x%0.8X);\r\n", 
+	CLog::GetInstance().Print(LOGNAME, "%d: CreateThread(threadProc = 0x%08X, priority = %d, stackSize = 0x%08X);\r\n", 
 		m_currentThreadId.Get(), threadProc, priority, stackSize);
 #endif
 
@@ -928,7 +928,7 @@ int32 CIopBios::DeleteThread(uint32 threadId)
 int32 CIopBios::StartThread(uint32 threadId, uint32 param)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%i: StartThread(threadId = %i, param = 0x%0.8X);\r\n", 
+	CLog::GetInstance().Print(LOGNAME, "%i: StartThread(threadId = %i, param = 0x%08X);\r\n", 
 		m_currentThreadId.Get(), threadId, param);
 #endif
 
@@ -962,7 +962,7 @@ int32 CIopBios::StartThread(uint32 threadId, uint32 param)
 int32 CIopBios::StartThreadArgs(uint32 threadId, uint32 args, uint32 argpPtr)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: StartThreadArgs(threadId = %d, args = %d, argp = 0x%0.8X);\r\n", 
+	CLog::GetInstance().Print(LOGNAME, "%d: StartThreadArgs(threadId = %d, args = %d, argp = 0x%08X);\r\n", 
 		m_currentThreadId.Get(), threadId, args, argpPtr);
 #endif
 
@@ -1181,7 +1181,7 @@ int32 CIopBios::ChangeThreadPriority(uint32 threadId, uint32 newPrio)
 uint32 CIopBios::ReferThreadStatus(uint32 threadId, uint32 statusPtr, bool inInterrupt)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: ReferThreadStatus(threadId = %d, statusPtr = 0x%0.8X, inInterrupt = %d);\r\n", 
+	CLog::GetInstance().Print(LOGNAME, "%d: ReferThreadStatus(threadId = %d, statusPtr = 0x%08X, inInterrupt = %d);\r\n", 
 		m_currentThreadId.Get(), threadId, statusPtr, inInterrupt);
 #endif
 
@@ -1714,7 +1714,7 @@ uint32 CIopBios::PollSemaphore(uint32 semaphoreId)
 
 uint32 CIopBios::ReferSemaphoreStatus(uint32 semaphoreId, uint32 statusPtr)
 {
-	CLog::GetInstance().Print(LOGNAME, "%d: ReferSemaphoreStatus(semaphoreId = %d, statusPtr = 0x%0.8X);\r\n", 
+	CLog::GetInstance().Print(LOGNAME, "%d: ReferSemaphoreStatus(semaphoreId = %d, statusPtr = 0x%08X);\r\n", 
 		m_currentThreadId.Get(), semaphoreId, statusPtr);
 
 	auto semaphore = m_semaphores[semaphoreId];
@@ -1737,7 +1737,7 @@ uint32 CIopBios::ReferSemaphoreStatus(uint32 semaphoreId, uint32 statusPtr)
 uint32 CIopBios::CreateEventFlag(uint32 attributes, uint32 options, uint32 initValue)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: CreateEventFlag(attr = 0x%0.8X, opt = 0x%0.8X, initValue = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOGNAME, "%d: CreateEventFlag(attr = 0x%08X, opt = 0x%08X, initValue = 0x%08X);\r\n",
 		m_currentThreadId.Get(), attributes, options, initValue);
 #endif
 
@@ -1781,7 +1781,7 @@ uint32 CIopBios::DeleteEventFlag(uint32 eventId)
 uint32 CIopBios::SetEventFlag(uint32 eventId, uint32 value, bool inInterrupt)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: SetEventFlag(eventId = %d, value = 0x%0.8X, inInterrupt = %d);\r\n",
+	CLog::GetInstance().Print(LOGNAME, "%d: SetEventFlag(eventId = %d, value = 0x%08X, inInterrupt = %d);\r\n",
 		m_currentThreadId.Get(), eventId, value, inInterrupt);
 #endif
 
@@ -1824,7 +1824,7 @@ uint32 CIopBios::SetEventFlag(uint32 eventId, uint32 value, bool inInterrupt)
 uint32 CIopBios::ClearEventFlag(uint32 eventId, uint32 value)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: ClearEventFlag(eventId = %d, value = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOGNAME, "%d: ClearEventFlag(eventId = %d, value = 0x%08X);\r\n",
 		m_currentThreadId.Get(), eventId, value);
 #endif
 
@@ -1842,7 +1842,7 @@ uint32 CIopBios::ClearEventFlag(uint32 eventId, uint32 value)
 uint32 CIopBios::WaitEventFlag(uint32 eventId, uint32 value, uint32 mode, uint32 resultPtr)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: WaitEventFlag(eventId = %d, value = 0x%0.8X, mode = 0x%0.2X, resultPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOGNAME, "%d: WaitEventFlag(eventId = %d, value = 0x%08X, mode = 0x%02X, resultPtr = 0x%08X);\r\n",
 		m_currentThreadId.Get(), eventId, value, mode, resultPtr);
 #endif
 
@@ -1872,7 +1872,7 @@ uint32 CIopBios::WaitEventFlag(uint32 eventId, uint32 value, uint32 mode, uint32
 uint32 CIopBios::PollEventFlag(uint32 eventId, uint32 value, uint32 mode, uint32 resultPtr)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: PollEventFlag(eventId = %d, value = 0x%0.8X, mode = 0x%0.2X, resultPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOGNAME, "%d: PollEventFlag(eventId = %d, value = 0x%08X, mode = 0x%02X, resultPtr = 0x%08X);\r\n",
 		m_currentThreadId.Get(), eventId, value, mode, resultPtr);
 #endif
 
@@ -1900,7 +1900,7 @@ uint32 CIopBios::PollEventFlag(uint32 eventId, uint32 value, uint32 mode, uint32
 uint32 CIopBios::ReferEventFlagStatus(uint32 eventId, uint32 infoPtr)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: ReferEventFlagStatus(eventId = %d, infoPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOGNAME, "%d: ReferEventFlagStatus(eventId = %d, infoPtr = 0x%08X);\r\n",
 		m_currentThreadId.Get(), eventId, infoPtr);
 #endif
 
@@ -1997,7 +1997,7 @@ uint32 CIopBios::DeleteMessageBox(uint32 boxId)
 uint32 CIopBios::SendMessageBox(uint32 boxId, uint32 messagePtr, bool inInterrupt)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: SendMessageBox(boxId = %d, messagePtr = 0x%0.8X, inInterrupt = %d);\r\n",
+	CLog::GetInstance().Print(LOGNAME, "%d: SendMessageBox(boxId = %d, messagePtr = 0x%08X, inInterrupt = %d);\r\n",
 		m_currentThreadId.Get(), boxId, messagePtr, inInterrupt);
 #endif
 
@@ -2056,7 +2056,7 @@ uint32 CIopBios::SendMessageBox(uint32 boxId, uint32 messagePtr, bool inInterrup
 uint32 CIopBios::ReceiveMessageBox(uint32 messagePtr, uint32 boxId)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: ReceiveMessageBox(messagePtr = 0x%0.8X, boxId = %d);\r\n",
+	CLog::GetInstance().Print(LOGNAME, "%d: ReceiveMessageBox(messagePtr = 0x%08X, boxId = %d);\r\n",
 		m_currentThreadId.Get(), messagePtr, boxId);
 #endif
 
@@ -2094,7 +2094,7 @@ uint32 CIopBios::ReceiveMessageBox(uint32 messagePtr, uint32 boxId)
 uint32 CIopBios::PollMessageBox(uint32 messagePtr, uint32 boxId)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: PollMessageBox(messagePtr = 0x%0.8X, boxId = %d);\r\n",
+	CLog::GetInstance().Print(LOGNAME, "%d: PollMessageBox(messagePtr = 0x%08X, boxId = %d);\r\n",
 		m_currentThreadId.Get(), messagePtr, boxId);
 #endif
 
@@ -2123,7 +2123,7 @@ uint32 CIopBios::PollMessageBox(uint32 messagePtr, uint32 boxId)
 uint32 CIopBios::ReferMessageBoxStatus(uint32 boxId, uint32 statusPtr)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, "%d: ReferMessageBox(boxId = %d, statusPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOGNAME, "%d: ReferMessageBox(boxId = %d, statusPtr = 0x%08X);\r\n",
 		m_currentThreadId.Get(), boxId, statusPtr);
 #endif
 
@@ -2592,7 +2592,7 @@ void CIopBios::HandleException()
 		else
 		{
 #ifdef _DEBUG
-			CLog::GetInstance().Print(LOGNAME, "%0.8X: Trying to call a function from non-existing module (%s, %d).\r\n", 
+			CLog::GetInstance().Print(LOGNAME, "%08X: Trying to call a function from non-existing module (%s, %d).\r\n", 
 				m_cpu.m_State.nPC, moduleName.c_str(), functionId);
 #endif
 		}
@@ -3135,7 +3135,7 @@ void CIopBios::PrepareModuleDebugInfo(CELF& elf, const ExecutableRange& moduleRa
 				else
 				{
 					char functionNameTemp[256];
-					sprintf(functionNameTemp, "unknown_%0.4X", functionId);
+					sprintf(functionNameTemp, "unknown_%04X", functionId);
 					functionName = functionNameTemp;
 				}
 				if(m_cpu.m_Functions.Find(address) == NULL)
@@ -3176,7 +3176,7 @@ void CIopBios::PrepareModuleDebugInfo(CELF& elf, const ExecutableRange& moduleRa
 		m_cpu.m_Functions.OnTagListChange();
 	}
 
-	CLog::GetInstance().Print(LOGNAME, "Loaded IOP module '%s' @ 0x%0.8X.\r\n", 
+	CLog::GetInstance().Print(LOGNAME, "Loaded IOP module '%s' @ 0x%08X.\r\n", 
 		modulePath.c_str(), moduleRange.first);
 }
 

--- a/Source/iop/Iop_Cdvdfsv.cpp
+++ b/Source/iop/Iop_Cdvdfsv.cpp
@@ -132,7 +132,7 @@ bool CCdvdfsv::Invoke592(uint32 method, uint32* args, uint32 argsSize, uint32* r
 		}
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X, 0x%0.8X).\r\n", 0x592, method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X, 0x%08X).\r\n", 0x592, method);
 		break;
 	}
 	return true;
@@ -202,7 +202,7 @@ bool CCdvdfsv::Invoke593(uint32 method, uint32* args, uint32 argsSize, uint32* r
 		break;
 
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X, 0x%0.8X).\r\n", 0x593, method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X, 0x%08X).\r\n", 0x593, method);
 		break;
 	}
 	return true;
@@ -223,7 +223,7 @@ bool CCdvdfsv::Invoke595(uint32 method, uint32* args, uint32 argsSize, uint32* r
 			assert(argsSize >= 4);
 			assert(retSize >= 4);
 			uint32 nBuffer = args[0x00];
-			CLog::GetInstance().Print(LOG_NAME, "GetToc(buffer = 0x%0.8X);\r\n", nBuffer);
+			CLog::GetInstance().Print(LOG_NAME, "GetToc(buffer = 0x%08X);\r\n", nBuffer);
 			ret[0x00] = 1;
 		}
 		break;
@@ -232,7 +232,7 @@ bool CCdvdfsv::Invoke595(uint32 method, uint32* args, uint32 argsSize, uint32* r
 		{
 			assert(argsSize >= 4);
 			uint32 seekSector = args[0];
-			CLog::GetInstance().Print(LOG_NAME, "Seek(sector = 0x%0.8X);\r\n", seekSector);
+			CLog::GetInstance().Print(LOG_NAME, "Seek(sector = 0x%08X);\r\n", seekSector);
 		}
 		break;
 
@@ -260,7 +260,7 @@ bool CCdvdfsv::Invoke595(uint32 method, uint32* args, uint32 argsSize, uint32* r
 		break;
 
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X, 0x%0.8X).\r\n", 0x595, method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X, 0x%08X).\r\n", 0x595, method);
 		break;
 	}
 	return true;
@@ -271,7 +271,7 @@ bool CCdvdfsv::Invoke596(uint32 method, uint32* args, uint32 argsSize, uint32* r
 	switch(method)
 	{
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X, 0x%0.8X).\r\n", 0x596, method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X, 0x%08X).\r\n", 0x596, method);
 		break;
 	}
 	return true;
@@ -285,7 +285,7 @@ bool CCdvdfsv::Invoke597(uint32 method, uint32* args, uint32 argsSize, uint32* r
 		SearchFile(args, argsSize, ret, retSize, ram);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X, 0x%0.8X).\r\n", 0x597, method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X, 0x%08X).\r\n", 0x597, method);
 		break;
 	}
 	return true;
@@ -311,7 +311,7 @@ bool CCdvdfsv::Invoke59C(uint32 method, uint32* args, uint32 argsSize, uint32* r
 		}
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X, 0x%0.8X).\r\n", 0x59C, method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X, 0x%08X).\r\n", 0x59C, method);
 		break;
 	}
 	return true;
@@ -324,7 +324,7 @@ void CCdvdfsv::Read(uint32* args, uint32 argsSize, uint32* ret, uint32 retSize, 
 	uint32 dstAddr	= args[0x02];
 	uint32 mode		= args[0x03];
 
-	CLog::GetInstance().Print(LOG_NAME, "Read(sector = 0x%0.8X, count = 0x%0.8X, addr = 0x%0.8X, mode = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "Read(sector = 0x%08X, count = 0x%08X, addr = 0x%08X, mode = 0x%08X);\r\n",
 		sector, count, dstAddr, mode);
 
 	//We write the result now, but ideally should be only written
@@ -348,7 +348,7 @@ void CCdvdfsv::ReadIopMem(uint32* args, uint32 argsSize, uint32* ret, uint32 ret
 	uint32 dstAddr	= args[0x02];
 	uint32 mode		= args[0x03];
 
-	CLog::GetInstance().Print(LOG_NAME, "ReadIopMem(sector = 0x%0.8X, count = 0x%0.8X, addr = 0x%0.8X, mode = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "ReadIopMem(sector = 0x%08X, count = 0x%08X, addr = 0x%08X, mode = 0x%08X);\r\n",
 		sector, count, dstAddr, mode);
 
 	if(retSize >= 4)
@@ -373,7 +373,7 @@ bool CCdvdfsv::StreamCmd(uint32* args, uint32 argsSize, uint32* ret, uint32 retS
 	uint32 cmd		= args[0x03];
 	uint32 mode		= args[0x04];
 
-	CLog::GetInstance().Print(LOG_NAME, "StreamCmd(sector = 0x%0.8X, count = 0x%0.8X, addr = 0x%0.8X, cmd = 0x%0.8X, mode = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "StreamCmd(sector = 0x%08X, count = 0x%08X, addr = 0x%08X, cmd = 0x%08X, mode = 0x%08X);\r\n",
 		sector, count, dstAddr, cmd, mode);
 
 	assert(m_pendingCommand == COMMAND_NONE);
@@ -384,7 +384,7 @@ bool CCdvdfsv::StreamCmd(uint32* args, uint32 argsSize, uint32* ret, uint32 retS
 		//Start
 		m_streamPos = sector;
 		ret[0] = 1;
-		CLog::GetInstance().Print(LOG_NAME, "StreamStart(pos = 0x%0.8X);\r\n", sector);
+		CLog::GetInstance().Print(LOG_NAME, "StreamStart(pos = 0x%08X);\r\n", sector);
 		m_streaming = true;
 		break;
 	case 2:
@@ -395,7 +395,7 @@ bool CCdvdfsv::StreamCmd(uint32* args, uint32 argsSize, uint32* ret, uint32 retS
 		m_pendingReadAddr   = dstAddr & (PS2::EE_RAM_SIZE - 1);
 		ret[0] = count;
 		immediateReply = false;
-		CLog::GetInstance().Print(LOG_NAME, "StreamRead(count = 0x%0.8X, dest = 0x%0.8X);\r\n",
+		CLog::GetInstance().Print(LOG_NAME, "StreamRead(count = 0x%08X, dest = 0x%08X);\r\n",
 			count, dstAddr);
 		break;
 	case 3:
@@ -407,7 +407,7 @@ bool CCdvdfsv::StreamCmd(uint32* args, uint32 argsSize, uint32* ret, uint32 retS
 	case 5:
 		//Init
 		ret[0] = 1;
-		CLog::GetInstance().Print(LOG_NAME, "StreamInit(bufsize = 0x%0.8X, numbuf = 0x%0.8X, buf = 0x%0.8X);\r\n",
+		CLog::GetInstance().Print(LOG_NAME, "StreamInit(bufsize = 0x%08X, numbuf = 0x%08X, buf = 0x%08X);\r\n",
 			sector, count, dstAddr);
 		m_streamBufferSize = sector;
 		break;
@@ -421,7 +421,7 @@ bool CCdvdfsv::StreamCmd(uint32* args, uint32 argsSize, uint32* ret, uint32 retS
 		//Seek
 		m_streamPos = sector;
 		ret[0] = 1;
-		CLog::GetInstance().Print(LOG_NAME, "StreamSeek(pos = 0x%0.8X);\r\n", sector);
+		CLog::GetInstance().Print(LOG_NAME, "StreamSeek(pos = 0x%08X);\r\n", sector);
 		break;
 	default:
 		CLog::GetInstance().Print(LOG_NAME, "Unknown stream command used.\r\n");

--- a/Source/iop/Iop_Cdvdman.cpp
+++ b/Source/iop/Iop_Cdvdman.cpp
@@ -287,7 +287,7 @@ uint32 CCdvdman::CdInit(uint32 mode)
 
 uint32 CCdvdman::CdRead(uint32 startSector, uint32 sectorCount, uint32 bufferPtr, uint32 modePtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDREAD "(startSector = 0x%X, sectorCount = 0x%X, bufferPtr = 0x%0.8X, modePtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDREAD "(startSector = 0x%X, sectorCount = 0x%X, bufferPtr = 0x%08X, modePtr = 0x%08X);\r\n",
 		startSector, sectorCount, bufferPtr, modePtr);
 	if(modePtr != 0)
 	{
@@ -354,7 +354,7 @@ uint32 CCdvdman::CdSearchFile(uint32 fileInfoPtr, uint32 namePtr)
 	}
 
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDSEARCHFILE "(fileInfo = 0x%0.8X, name = '%s');\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDSEARCHFILE "(fileInfo = 0x%08X, name = '%s');\r\n",
 		fileInfoPtr, name);
 #endif
 
@@ -416,7 +416,7 @@ uint32 CCdvdman::CdDiskReady(uint32 mode)
 
 uint32 CCdvdman::CdTrayReq(uint32 mode, uint32 trayCntPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDTRAYREQ "(mode = %d, trayCntPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDTRAYREQ "(mode = %d, trayCntPtr = 0x%08X);\r\n",
 		mode, trayCntPtr);
 
 	auto trayCnt = reinterpret_cast<uint32*>(m_ram + trayCntPtr);
@@ -427,7 +427,7 @@ uint32 CCdvdman::CdTrayReq(uint32 mode, uint32 trayCntPtr)
 
 uint32 CCdvdman::CdReadClock(uint32 clockPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDREADCLOCK "(clockPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDREADCLOCK "(clockPtr = 0x%08X);\r\n",
 		clockPtr);
 
 	auto clockBuffer = m_ram + clockPtr;
@@ -442,7 +442,7 @@ uint32 CCdvdman::CdStatus()
 
 uint32 CCdvdman::CdCallback(uint32 callbackPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDCALLBACK "(callbackPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDCALLBACK "(callbackPtr = 0x%08X);\r\n",
 		callbackPtr);
 
 	uint32 oldCallbackPtr = m_callbackPtr;
@@ -452,7 +452,7 @@ uint32 CCdvdman::CdCallback(uint32 callbackPtr)
 
 uint32 CCdvdman::CdStInit(uint32 bufMax, uint32 bankMax, uint32 bufPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDSTINIT "(bufMax = %d, bankMax = %d, bufPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDSTINIT "(bufMax = %d, bankMax = %d, bufPtr = 0x%08X);\r\n",
 		bufMax, bankMax, bufPtr);
 	m_streamPos = 0;
 	return 1;
@@ -460,7 +460,7 @@ uint32 CCdvdman::CdStInit(uint32 bufMax, uint32 bankMax, uint32 bufPtr)
 
 uint32 CCdvdman::CdStRead(uint32 sectors, uint32 bufPtr, uint32 mode, uint32 errPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDSTREAD "(sectors = %d, bufPtr = 0x%0.8X, mode = %d, errPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDSTREAD "(sectors = %d, bufPtr = 0x%08X, mode = %d, errPtr = 0x%08X);\r\n",
 		sectors, bufPtr, mode, errPtr);
 	auto fileSystem = m_opticalMedia->GetFileSystem();
 	for(unsigned int i = 0; i < sectors; i++)
@@ -478,7 +478,7 @@ uint32 CCdvdman::CdStRead(uint32 sectors, uint32 bufPtr, uint32 mode, uint32 err
 
 uint32 CCdvdman::CdStStart(uint32 sector, uint32 modePtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDSTSTART "(sector = %d, modePtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDSTSTART "(sector = %d, modePtr = 0x%08X);\r\n",
 		sector, modePtr);
 	m_streamPos = sector;
 	return 1;
@@ -506,7 +506,7 @@ uint32 CCdvdman::CdStSeekF(uint32 sector)
 
 uint32 CCdvdman::CdReadDvdDualInfo(uint32 onDualPtr, uint32 layer1StartPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDREADDVDDUALINFO "(onDualPtr = 0x%0.8X, layer1StartPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDREADDVDDUALINFO "(onDualPtr = 0x%08X, layer1StartPtr = 0x%08X);\r\n",
 		onDualPtr, layer1StartPtr);
 
 	auto onDual = reinterpret_cast<uint32*>(m_ram + onDualPtr);
@@ -519,7 +519,7 @@ uint32 CCdvdman::CdReadDvdDualInfo(uint32 onDualPtr, uint32 layer1StartPtr)
 
 uint32 CCdvdman::CdLayerSearchFile(uint32 fileInfoPtr, uint32 namePtr, uint32 layer)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDLAYERSEARCHFILE "(fileInfoPtr = 0x%0.8X, namePtr = 0x%0.8X, layer = %d);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CDLAYERSEARCHFILE "(fileInfoPtr = 0x%08X, namePtr = 0x%08X, layer = %d);\r\n",
 		fileInfoPtr, namePtr, layer);
 	assert(layer == 0);
 	return CdSearchFile(fileInfoPtr, namePtr);

--- a/Source/iop/Iop_Dmac.cpp
+++ b/Source/iop/Iop_Dmac.cpp
@@ -199,13 +199,13 @@ void CDmac::LogRead(uint32 address)
 			switch(registerId)
 			{
 			case CChannel::REG_MADR:
-				CLog::GetInstance().Print(LOG_NAME, "ch%0.2d: = MADR.\r\n", channelId);
+				CLog::GetInstance().Print(LOG_NAME, "ch%02d: = MADR.\r\n", channelId);
 				break;
 			case CChannel::REG_CHCR:
-				CLog::GetInstance().Print(LOG_NAME, "ch%0.2d: = CHCR.\r\n", channelId);
+				CLog::GetInstance().Print(LOG_NAME, "ch%02d: = CHCR.\r\n", channelId);
 				break;
 			default:
-				CLog::GetInstance().Print(LOG_NAME, "Read an unknown register 0x%0.8X.\r\n",
+				CLog::GetInstance().Print(LOG_NAME, "Read an unknown register 0x%08X.\r\n",
 					address);
 				break;
 			}
@@ -219,10 +219,10 @@ void CDmac::LogWrite(uint32 address, uint32 value)
 	switch(address)
 	{
 	case DPCR:
-		CLog::GetInstance().Print(LOG_NAME, "DPCR = 0x%0.8X.\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "DPCR = 0x%08X.\r\n", value);
 		break;
 	case DICR:
-		CLog::GetInstance().Print(LOG_NAME, "DICR = 0x%0.8X.\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "DICR = 0x%08X.\r\n", value);
 		break;
 	default:
 		{
@@ -231,19 +231,19 @@ void CDmac::LogWrite(uint32 address, uint32 value)
 			switch(registerId)
 			{
 			case CChannel::REG_MADR:
-				CLog::GetInstance().Print(LOG_NAME, "ch%0.2d: MADR = 0x%0.8X.\r\n", channelId, value);
+				CLog::GetInstance().Print(LOG_NAME, "ch%02d: MADR = 0x%08X.\r\n", channelId, value);
 				break;
 			case CChannel::REG_BCR:
-				CLog::GetInstance().Print(LOG_NAME, "ch%0.2d: BCR = 0x%0.8X.\r\n", channelId, value);
+				CLog::GetInstance().Print(LOG_NAME, "ch%02d: BCR = 0x%08X.\r\n", channelId, value);
 				break;
 			case CChannel::REG_BCR + 2:
-				CLog::GetInstance().Print(LOG_NAME, "ch%0.2d: BCR.ba = 0x%0.8X.\r\n", channelId, value);
+				CLog::GetInstance().Print(LOG_NAME, "ch%02d: BCR.ba = 0x%08X.\r\n", channelId, value);
 				break;
 			case CChannel::REG_CHCR:
-				CLog::GetInstance().Print(LOG_NAME, "ch%0.2d: CHCR = 0x%0.8X.\r\n", channelId, value);
+				CLog::GetInstance().Print(LOG_NAME, "ch%02d: CHCR = 0x%08X.\r\n", channelId, value);
 				break;
 			default:
-				CLog::GetInstance().Print(LOG_NAME, "Wrote 0x%0.8X to unknown register 0x%0.8X.\r\n",
+				CLog::GetInstance().Print(LOG_NAME, "Wrote 0x%08X to unknown register 0x%08X.\r\n",
 					value, address);
 				break;
 			}

--- a/Source/iop/Iop_Dynamic.cpp
+++ b/Source/iop/Iop_Dynamic.cpp
@@ -26,7 +26,7 @@ std::string CDynamic::GetId() const
 std::string CDynamic::GetFunctionName(unsigned int functionId) const
 {
 	char functionName[256];
-	sprintf(functionName, "unknown_%0.4X", functionId);
+	sprintf(functionName, "unknown_%04X", functionId);
 	return functionName;
 }
 

--- a/Source/iop/Iop_FileIoHandler2240.cpp
+++ b/Source/iop/Iop_FileIoHandler2240.cpp
@@ -337,7 +337,7 @@ uint32 CFileIoHandler2240::InvokeDevctl(uint32* args, uint32 argsSize, uint32* r
 		output[0] = 2;	//Disk ready
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "DevCtl -> Unknown(cmd = %0.8X);\r\n", command->cmdId);
+		CLog::GetInstance().Print(LOG_NAME, "DevCtl -> Unknown(cmd = %08X);\r\n", command->cmdId);
 		break;
 	}
 

--- a/Source/iop/Iop_Heaplib.cpp
+++ b/Source/iop/Iop_Heaplib.cpp
@@ -72,14 +72,14 @@ void CHeaplib::Invoke(CMIPS& context, unsigned int functionId)
 
 int32 CHeaplib::CreateHeap(uint32 heapSize, uint32 flags)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CREATEHEAP "(heapSize = 0x%0.8X, flags = %d);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CREATEHEAP "(heapSize = 0x%08X, flags = %d);\r\n",
 		heapSize, flags);
 	return HEAP_PTR;
 }
 
 int32 CHeaplib::AllocHeapMemory(uint32 heapPtr, uint32 size)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_ALLOCHEAPMEMORY "(heapPtr = 0x%0.8X, size = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_ALLOCHEAPMEMORY "(heapPtr = 0x%08X, size = 0x%08X);\r\n",
 		heapPtr, size);
 	assert(heapPtr == HEAP_PTR);
 	return m_sysMem.AllocateMemory(size, 0, 0);
@@ -87,7 +87,7 @@ int32 CHeaplib::AllocHeapMemory(uint32 heapPtr, uint32 size)
 
 int32 CHeaplib::FreeHeapMemory(uint32 heapPtr, uint32 allocPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_FREEHEAPMEMORY "(heapPtr = 0x%0.8X, allocPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_FREEHEAPMEMORY "(heapPtr = 0x%08X, allocPtr = 0x%08X);\r\n",
 		heapPtr, allocPtr);
 	assert(heapPtr == HEAP_PTR);
 	m_sysMem.FreeMemory(allocPtr);

--- a/Source/iop/Iop_Intrman.cpp
+++ b/Source/iop/Iop_Intrman.cpp
@@ -130,7 +130,7 @@ void CIntrman::Invoke(CMIPS& context, unsigned int functionId)
 			));
 		break;
 	default:
-		CLog::GetInstance().Print(LOGNAME, "%0.8X: Unknown function (%d) called.\r\n", context.m_State.nPC, functionId);
+		CLog::GetInstance().Print(LOGNAME, "%08X: Unknown function (%d) called.\r\n", context.m_State.nPC, functionId);
 		break;
 	}
 }
@@ -138,7 +138,7 @@ void CIntrman::Invoke(CMIPS& context, unsigned int functionId)
 uint32 CIntrman::RegisterIntrHandler(uint32 line, uint32 mode, uint32 handler, uint32 arg)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, FUNCTION_REGISTERINTRHANDLER "(line = %d, mode = %d, handler = 0x%0.8X, arg = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOGNAME, FUNCTION_REGISTERINTRHANDLER "(line = %d, mode = %d, handler = 0x%08X, arg = 0x%08X);\r\n",
 		line, mode, handler, arg);
 #endif
 	return m_bios.RegisterIntrHandler(line, mode, handler, arg);
@@ -171,7 +171,7 @@ uint32 CIntrman::EnableIntrLine(CMIPS& context, uint32 line)
 uint32 CIntrman::DisableIntrLine(CMIPS& context, uint32 line, uint32 res)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, FUNCTION_DISABLEINTRLINE "(line = %d, res = %0.8X);\r\n",
+	CLog::GetInstance().Print(LOGNAME, FUNCTION_DISABLEINTRLINE "(line = %d, res = %08X);\r\n",
 		line, res);
 #endif
 	UNION64_32 mask(
@@ -208,7 +208,7 @@ uint32 CIntrman::DisableInterrupts(CMIPS& context)
 uint32 CIntrman::SuspendInterrupts(CMIPS& context, uint32 statePtr)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOGNAME, FUNCTION_SUSPENDINTERRUPTS "(statePtr = 0x%0.8X);\r\n", 
+	CLog::GetInstance().Print(LOGNAME, FUNCTION_SUSPENDINTERRUPTS "(statePtr = 0x%08X);\r\n", 
 		statePtr);
 #endif
 	uint32& statusRegister = context.m_State.nCOP0[CCOP_SCU::STATUS];

--- a/Source/iop/Iop_Ioman.cpp
+++ b/Source/iop/Iop_Ioman.cpp
@@ -94,7 +94,7 @@ void CIoman::RegisterDevice(const char* name, const DevicePtr& device)
 
 uint32 CIoman::Open(uint32 flags, const char* path)
 {
-	CLog::GetInstance().Print(LOG_NAME, "Open(flags = 0x%0.8X, path = '%s');\r\n", flags, path);
+	CLog::GetInstance().Print(LOG_NAME, "Open(flags = 0x%08X, path = '%s');\r\n", flags, path);
 
 	if(flags == 0)
 	{
@@ -251,7 +251,7 @@ uint32 CIoman::GetStat(const char* path, STAT* stat)
 
 uint32 CIoman::AddDrv(uint32 drvPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_ADDDRV "(drvPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_ADDDRV "(drvPtr = 0x%08X);\r\n",
 		drvPtr);
 	return -1;
 }
@@ -332,7 +332,7 @@ void CIoman::Invoke(CMIPS& context, unsigned int functionId)
 		));
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "%s(%0.8X): Unknown function (%d) called.\r\n", __FUNCTION__, context.m_State.nPC, functionId);
+		CLog::GetInstance().Print(LOG_NAME, "%s(%08X): Unknown function (%d) called.\r\n", __FUNCTION__, context.m_State.nPC, functionId);
 		break;
 	}
 }

--- a/Source/iop/Iop_LibSd.cpp
+++ b/Source/iop/Iop_LibSd.cpp
@@ -102,7 +102,7 @@ std::string DecodeSwitch(uint16 switchId)
 		result = "ENDX";
 		break;
 	default:
-		result = string_format("unknown (0x%0.2X)", switchId >> 8);
+		result = string_format("unknown (0x%02X)", switchId >> 8);
 		break;
 	}
 	result += string_format(", CORE%d", switchId & 1);
@@ -118,64 +118,64 @@ void CLibSd::TraceCall(CMIPS& context, unsigned int functionId)
 			context.m_State.nGPR[CMIPS::A0].nV0);
 		break;
 	case 5:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETPARAM "(entry = 0x%0.4X, value = 0x%0.4X);\r\n", 
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETPARAM "(entry = 0x%04X, value = 0x%04X);\r\n", 
 			context.m_State.nGPR[CMIPS::A0].nV0, context.m_State.nGPR[CMIPS::A1].nV0);
 		break;
 	case 6:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_GETPARAM "(entry = 0x%0.4X);\r\n", 
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_GETPARAM "(entry = 0x%04X);\r\n", 
 			context.m_State.nGPR[CMIPS::A0].nV0);
 		break;
 	case 7:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETSWITCH "(entry = 0x%0.4X, value = 0x%0.8X); //(%s)\r\n",
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETSWITCH "(entry = 0x%04X, value = 0x%08X); //(%s)\r\n",
 			context.m_State.nGPR[CMIPS::A0].nV0, context.m_State.nGPR[CMIPS::A1].nV0,
 			DecodeSwitch(static_cast<uint16>(context.m_State.nGPR[CMIPS::A0].nV0)).c_str());
 		break;
 	case 8:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_GETSWITCH "(entry = 0x%0.4X); //(%s)\r\n", 
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_GETSWITCH "(entry = 0x%04X); //(%s)\r\n", 
 			context.m_State.nGPR[CMIPS::A0].nV0, 
 			DecodeSwitch(static_cast<uint16>(context.m_State.nGPR[CMIPS::A0].nV0)).c_str());
 		break;
 	case 9:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETADDR "(entry = 0x%0.4X, value = 0x%0.8X);\r\n", 
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETADDR "(entry = 0x%04X, value = 0x%08X);\r\n", 
 			context.m_State.nGPR[CMIPS::A0].nV0, context.m_State.nGPR[CMIPS::A1].nV0);
 		break;
 	case 10:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_GETADDR "(entry = 0x%0.4X);\r\n", context.m_State.nGPR[CMIPS::A0].nV0);
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_GETADDR "(entry = 0x%04X);\r\n", context.m_State.nGPR[CMIPS::A0].nV0);
 		break;
 	case 11:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETCOREATTR "(entry = 0x%0.4X, value = 0x%0.4X);\r\n",
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETCOREATTR "(entry = 0x%04X, value = 0x%04X);\r\n",
 			context.m_State.nGPR[CMIPS::A0].nV0, context.m_State.nGPR[CMIPS::A1].nV0);
 		break;
 	case 17:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_VOICETRANS "(channel = 0x%0.4X, mode = 0x%0.4X, maddr = 0x%0.8X, saddr = 0x%0.8X, size = 0x%0.8X);\r\n",
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_VOICETRANS "(channel = 0x%04X, mode = 0x%04X, maddr = 0x%08X, saddr = 0x%08X, size = 0x%08X);\r\n",
 			context.m_State.nGPR[CMIPS::A0].nV0, context.m_State.nGPR[CMIPS::A1].nV0, 
 			context.m_State.nGPR[CMIPS::A2].nV0, context.m_State.nGPR[CMIPS::A3].nV0, 
 			context.m_State.nGPR[CMIPS::T0].nV0);
 		break;
 	case 18:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_BLOCKTRANS "(channel = 0x%0.4X, mode = 0x%0.4X, maddr = 0x%0.8X, size = 0x%0.8X);\r\n",
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_BLOCKTRANS "(channel = 0x%04X, mode = 0x%04X, maddr = 0x%08X, size = 0x%08X);\r\n",
 			context.m_State.nGPR[CMIPS::A0].nV0, context.m_State.nGPR[CMIPS::A1].nV0, 
 			context.m_State.nGPR[CMIPS::A2].nV0, context.m_State.nGPR[CMIPS::A3].nV0);
 		break;
 	case 19:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_VOICETRANSSTATUS "(channel = 0x%0.4X, flag = 0x%0.4X);\r\n",
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_VOICETRANSSTATUS "(channel = 0x%04X, flag = 0x%04X);\r\n",
 			context.m_State.nGPR[CMIPS::A0].nV0, context.m_State.nGPR[CMIPS::A1].nV0);
 		break;
 	case 20:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_BLOCKTRANSSTATUS "(channel = 0x%0.4X, flag = 0x%0.4X);\r\n",
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_BLOCKTRANSSTATUS "(channel = 0x%04X, flag = 0x%04X);\r\n",
 			context.m_State.nGPR[CMIPS::A0].nV0, context.m_State.nGPR[CMIPS::A1].nV0);
 		break;
 	case 21:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETTRANSCALLBACK "(channel = 0x%0.4X, function = 0x%0.8X);\r\n",
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETTRANSCALLBACK "(channel = 0x%04X, function = 0x%08X);\r\n",
 			context.m_State.nGPR[CMIPS::A0].nV0, context.m_State.nGPR[CMIPS::A1].nV0);
 		break;
 	case 26:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETTRANSINTRHANDLER "(channel = 0x%0.4X, function = 0x%0.8X, arg = 0x%0.8X);\r\n",
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETTRANSINTRHANDLER "(channel = 0x%04X, function = 0x%08X, arg = 0x%08X);\r\n",
 			context.m_State.nGPR[CMIPS::A0].nV0, context.m_State.nGPR[CMIPS::A1].nV0,
 			context.m_State.nGPR[CMIPS::A2].nV0);
 		break;
 	case 27:
-		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETSPU2INTRHANDLER "(function = 0x%0.8X, arg = 0x%0.8X);\r\n",
+		CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETSPU2INTRHANDLER "(function = 0x%08X, arg = 0x%08X);\r\n",
 			context.m_State.nGPR[CMIPS::A0].nV0, context.m_State.nGPR[CMIPS::A1].nV0);
 		break;
 	default:

--- a/Source/iop/Iop_Loadcore.cpp
+++ b/Source/iop/Iop_Loadcore.cpp
@@ -82,7 +82,7 @@ void CLoadcore::Invoke(CMIPS& context, unsigned int functionId)
 			));
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called (PC: 0x%0.8X).\r\n", 
+		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called (PC: 0x%08X).\r\n", 
 			functionId, context.m_State.nPC);
 		break;
 	}
@@ -142,7 +142,7 @@ void CLoadcore::SetLoadExecutableHandler(const LoadExecutableHandler& loadExecut
 
 uint32 CLoadcore::RegisterLibraryEntries(uint32 exportTablePtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_REGISTERLIBRARYENTRIES "(exportTable = 0x%0.8X);\r\n", exportTablePtr);
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_REGISTERLIBRARYENTRIES "(exportTable = 0x%08X);\r\n", exportTablePtr);
 	uint32* exportTable = reinterpret_cast<uint32*>(&m_ram[exportTablePtr]);
 	auto module = std::make_shared<CDynamic>(exportTable);
 	bool registered = m_bios.RegisterModule(module);
@@ -158,7 +158,7 @@ uint32 CLoadcore::QueryBootMode(uint32 param)
 
 uint32 CLoadcore::SetRebootTimeLibraryHandlingMode(uint32 libAddr, uint32 mode)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETREBOOTTIMELIBHANDLINGMODE "(libAddr = 0x%0.8X, mode = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETREBOOTTIMELIBHANDLINGMODE "(libAddr = 0x%08X, mode = 0x%08X);\r\n",
 		libAddr, mode);
 	return 0;
 }
@@ -232,7 +232,7 @@ void CLoadcore::LoadModuleFromMemory(uint32* args, uint32 argsSize, uint32* ret,
 {
 	const char* moduleArgs = reinterpret_cast<const char*>(args) + 8 + PATH_MAX_SIZE;
 	uint32 moduleArgsSize = args[1];
-	CLog::GetInstance().Print(LOG_NAME, "Request to load module at 0x%0.8X received with %d bytes arguments payload.\r\n", args[0], moduleArgsSize);
+	CLog::GetInstance().Print(LOG_NAME, "Request to load module at 0x%08X received with %d bytes arguments payload.\r\n", args[0], moduleArgsSize);
 	auto moduleId = m_bios.LoadModule(args[0]);
 	if(moduleId >= 0)
 	{
@@ -253,7 +253,7 @@ bool CLoadcore::StopModule(uint32* args, uint32 argsSize, uint32* ret, uint32 re
 
 	memcpy(moduleArgs, reinterpret_cast<const char*>(args) + 8 + PATH_MAX_SIZE, ARGS_MAX_SIZE);
 
-	CLog::GetInstance().Print(LOG_NAME, "StopModule(moduleId = %d, args, argsSize = 0x%0.8X);\r\n", 
+	CLog::GetInstance().Print(LOG_NAME, "StopModule(moduleId = %d, args, argsSize = 0x%08X);\r\n", 
 		moduleId, moduleArgsSize);
 
 	auto result = m_bios.StopModule(moduleId);

--- a/Source/iop/Iop_McServ.cpp
+++ b/Source/iop/Iop_McServ.cpp
@@ -88,7 +88,7 @@ bool CMcServ::Invoke(uint32 method, uint32* args, uint32 argsSize, uint32* ret, 
 		GetVersionInformation(args, argsSize, ret, retSize, ram);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X).\r\n", method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X).\r\n", method);
 		break;
 	}
 	return true;
@@ -107,7 +107,7 @@ void CMcServ::GetInfo(uint32* args, uint32 argsSize, uint32* ret, uint32 retSize
 	bool wantType		= args[5] != 0;
 	uint32* retBuffer	= reinterpret_cast<uint32*>(&ram[args[7]]);
 
-	CLog::GetInstance().Print(LOG_NAME, "GetInfo(port = %i, slot = %i, wantType = %i, wantFreeSpace = %i, wantFormatted = %i, retBuffer = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "GetInfo(port = %i, slot = %i, wantType = %i, wantFreeSpace = %i, wantFormatted = %i, retBuffer = 0x%08X);\r\n",
 		port, slot, wantType, wantFreeSpace, wantFormatted, args[7]);
 
 	if(wantType)
@@ -247,7 +247,7 @@ void CMcServ::Seek(uint32* args, uint32 argsSize, uint32* ret, uint32 retSize, u
 {
 	FILECMD* cmd = reinterpret_cast<FILECMD*>(args);
 
-	CLog::GetInstance().Print(LOG_NAME, "Seek(handle = %i, offset = 0x%0.8X, origin = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "Seek(handle = %i, offset = 0x%08X, origin = 0x%08X);\r\n",
 		cmd->handle, cmd->offset, cmd->origin);
 
 	auto file = GetFileFromHandle(cmd->handle);
@@ -283,7 +283,7 @@ void CMcServ::Read(uint32* args, uint32 argsSize, uint32* ret, uint32 retSize, u
 {
 	FILECMD* cmd = reinterpret_cast<FILECMD*>(args);
 
-	CLog::GetInstance().Print(LOG_NAME, "Read(handle = %i, size = 0x%0.8X, bufferAddress = 0x%0.8X, paramAddress = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "Read(handle = %i, size = 0x%08X, bufferAddress = 0x%08X, paramAddress = 0x%08X);\r\n",
 		cmd->handle, cmd->size, cmd->bufferAddress, cmd->paramAddress);
 
 	auto file = GetFileFromHandle(cmd->handle);
@@ -311,7 +311,7 @@ void CMcServ::Write(uint32* args, uint32 argsSize, uint32* ret, uint32 retSize, 
 {
 	FILECMD* cmd = reinterpret_cast<FILECMD*>(args);
 
-	CLog::GetInstance().Print(LOG_NAME, "Write(handle = %i, nSize = 0x%0.8X, bufferAddress = 0x%0.8X, origin = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "Write(handle = %i, nSize = 0x%08X, bufferAddress = 0x%08X, origin = 0x%08X);\r\n",
 		cmd->handle, cmd->size, cmd->bufferAddress, cmd->origin);
 
 	auto file = GetFileFromHandle(cmd->handle);
@@ -360,7 +360,7 @@ void CMcServ::ChDir(uint32* args, uint32 argsSize, uint32* ret, uint32 retSize, 
 	assert(argsSize >= 0x414);
 	CMD* cmd = reinterpret_cast<CMD*>(args);
 
-	CLog::GetInstance().Print(LOG_NAME, "ChDir(port = %i, slot = %i, tableAddress = 0x%0.8X, name = %s);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "ChDir(port = %i, slot = %i, tableAddress = 0x%08X, name = %s);\r\n",
 							  cmd->port, cmd->slot, cmd->tableAddress, cmd->name);
 
 	uint32 result = -1;
@@ -416,7 +416,7 @@ void CMcServ::GetDir(uint32* args, uint32 argsSize, uint32* ret, uint32 retSize,
 
 	auto cmd = reinterpret_cast<const CMD*>(args);
 
-	CLog::GetInstance().Print(LOG_NAME, "GetDir(port = %i, slot = %i, flags = %i, maxEntries = %i, tableAddress = 0x%0.8X, name = %s);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "GetDir(port = %i, slot = %i, flags = %i, maxEntries = %i, tableAddress = 0x%08X, name = %s);\r\n",
 		cmd->port, cmd->slot, cmd->flags, cmd->maxEntries, cmd->tableAddress, cmd->name);
 
 	if(cmd->port > 1)

--- a/Source/iop/Iop_Modload.cpp
+++ b/Source/iop/Iop_Modload.cpp
@@ -101,7 +101,7 @@ void CModload::Invoke(CMIPS& context, unsigned int functionId)
 		);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "(%0.8X): Unknown function (%d) called.\r\n", 
+		CLog::GetInstance().Print(LOG_NAME, "(%08X): Unknown function (%d) called.\r\n", 
 			context.m_State.nPC, functionId);
 		break;
 	}
@@ -132,7 +132,7 @@ uint32 CModload::StartModule(uint32 moduleId, uint32 pathPtr, uint32 argsLength,
 {
 	const char* path = reinterpret_cast<const char*>(m_ram + pathPtr);
 	const char* args = reinterpret_cast<const char*>(m_ram + argsPtr);
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_STARTMODULE "(moduleId = %d, path = '%s', argsLength = %d, argsPtr = 0x%0.8X, resultPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_STARTMODULE "(moduleId = %d, path = '%s', argsLength = %d, argsPtr = 0x%08X, resultPtr = 0x%08X);\r\n",
 		moduleId, path, argsLength, argsPtr, resultPtr);
 	auto result = m_bios.StartModule(moduleId, path, args, argsLength);
 	return result;
@@ -140,7 +140,7 @@ uint32 CModload::StartModule(uint32 moduleId, uint32 pathPtr, uint32 argsLength,
 
 uint32 CModload::LoadModuleBuffer(uint32 modBufPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_LOADMODULEBUFFER "(modBufPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_LOADMODULEBUFFER "(modBufPtr = 0x%08X);\r\n",
 		modBufPtr);
 	assert((modBufPtr & 0x03) == 0);
 	auto result = m_bios.LoadModule(modBufPtr);
@@ -149,7 +149,7 @@ uint32 CModload::LoadModuleBuffer(uint32 modBufPtr)
 
 uint32 CModload::GetModuleIdList(uint32 readBufPtr, uint32 readBufSize, uint32 moduleCountPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_GETMODULEIDLIST "(readBufPtr = 0x%0.8X, readBufSize = 0x%0.8X, moduleCountPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_GETMODULEIDLIST "(readBufPtr = 0x%08X, readBufSize = 0x%08X, moduleCountPtr = 0x%08X);\r\n",
 		readBufPtr, readBufSize, moduleCountPtr);
 	auto moduleCount = (moduleCountPtr != 0) ? reinterpret_cast<uint32*>(m_ram + moduleCountPtr) : nullptr;
 	if(moduleCount)
@@ -161,7 +161,7 @@ uint32 CModload::GetModuleIdList(uint32 readBufPtr, uint32 readBufSize, uint32 m
 
 int32 CModload::ReferModuleStatus(uint32 moduleId, uint32 moduleStatusPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_REFERMODULESTATUS "(moduleId = %d, moduleStatusPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_REFERMODULESTATUS "(moduleId = %d, moduleStatusPtr = 0x%08X);\r\n",
 		moduleId, moduleStatusPtr);
 	return KERNEL_RESULT_ERROR_UNKNOWN_MODULE;
 }

--- a/Source/iop/Iop_Module.cpp
+++ b/Source/iop/Iop_Module.cpp
@@ -5,7 +5,7 @@ using namespace Iop;
 
 std::string CModule::PrintStringParameter(const uint8* ram, uint32 stringPtr)
 {
-	auto result = string_format("0x%0.8X", stringPtr);
+	auto result = string_format("0x%08X", stringPtr);
 	if(stringPtr != 0)
 	{
 		auto string = reinterpret_cast<const char*>(ram + stringPtr);

--- a/Source/iop/Iop_MtapMan.cpp
+++ b/Source/iop/Iop_MtapMan.cpp
@@ -46,7 +46,7 @@ bool CMtapMan::Invoke901(uint32 method, uint32* args, uint32 argsSize, uint32* r
 		ret[1] = PortOpen(args[0]);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X, 0x%0.8X).\r\n", 0x901, method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X, 0x%08X).\r\n", 0x901, method);
 		break;
 	}
 	return true;
@@ -57,7 +57,7 @@ bool CMtapMan::Invoke902(uint32 method, uint32* args, uint32 argsSize, uint32* r
 	switch(method)
 	{
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X, 0x%0.8X).\r\n", 0x902, method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X, 0x%08X).\r\n", 0x902, method);
 		break;
 	}
 	return true;
@@ -68,7 +68,7 @@ bool CMtapMan::Invoke903(uint32 method, uint32* args, uint32 argsSize, uint32* r
 	switch(method)
 	{
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X, 0x%0.8X).\r\n", 0x903, method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X, 0x%08X).\r\n", 0x903, method);
 		break;
 	}
 	return true;

--- a/Source/iop/Iop_Naplink.cpp
+++ b/Source/iop/Iop_Naplink.cpp
@@ -42,7 +42,7 @@ bool CNaplink::Invoke(uint32 method, uint32* args, uint32 argsSize, uint32* ret,
 		}
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X).\r\n", method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X).\r\n", method);
 		break;
 	}
 	return true;

--- a/Source/iop/Iop_PadMan.cpp
+++ b/Source/iop/Iop_PadMan.cpp
@@ -67,7 +67,7 @@ bool CPadMan::Invoke(uint32 method, uint32* args, uint32 argsSize, uint32* ret, 
 		GetModuleVersion(args, argsSize, ret, retSize, ram);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X).\r\n", method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X).\r\n", method);
 		break;
 	}
 	return true;

--- a/Source/iop/Iop_RootCounters.cpp
+++ b/Source/iop/Iop_RootCounters.cpp
@@ -247,7 +247,7 @@ void CRootCounters::DisassembleRead(uint32 address)
 		CLog::GetInstance().Print(LOG_NAME, "CNT%d: = TARGET\r\n", counterId);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Reading an unknown register (0x%0.8X).\r\n", address);
+		CLog::GetInstance().Print(LOG_NAME, "Reading an unknown register (0x%08X).\r\n", address);
 		break;
 	}
 }
@@ -259,16 +259,16 @@ void CRootCounters::DisassembleWrite(uint32 address, uint32 value)
 	switch(registerId)
 	{
 	case CNT_COUNT:
-		CLog::GetInstance().Print(LOG_NAME, "CNT%d: COUNT = 0x%0.4X\r\n", counterId, value);
+		CLog::GetInstance().Print(LOG_NAME, "CNT%d: COUNT = 0x%04X\r\n", counterId, value);
 		break;
 	case CNT_MODE:
-		CLog::GetInstance().Print(LOG_NAME, "CNT%d: MODE = 0x%0.8X\r\n", counterId, value);
+		CLog::GetInstance().Print(LOG_NAME, "CNT%d: MODE = 0x%08X\r\n", counterId, value);
 		break;
 	case CNT_TARGET:
-		CLog::GetInstance().Print(LOG_NAME, "CNT%d: TARGET = 0x%0.4X\r\n", counterId, value);
+		CLog::GetInstance().Print(LOG_NAME, "CNT%d: TARGET = 0x%04X\r\n", counterId, value);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Writing to an unknown register (0x%0.8X, 0x%0.8X).\r\n", address, value);
+		CLog::GetInstance().Print(LOG_NAME, "Writing to an unknown register (0x%08X, 0x%08X).\r\n", address, value);
 		break;
 	}
 }

--- a/Source/iop/Iop_SifCmd.cpp
+++ b/Source/iop/Iop_SifCmd.cpp
@@ -624,7 +624,7 @@ void CSifCmd::ProcessNextDynamicCommand()
 	{
 		const auto& cmdDataEntry = reinterpret_cast<SIFCMDDATA*>(m_ram + cmdBufferAddr)[cmd];
 
-		CLog::GetInstance().Print(LOG_NAME, "Calling SIF command handler for command 0x%0.8X at 0x%0.8X with data 0x%0.8X.\r\n", 
+		CLog::GetInstance().Print(LOG_NAME, "Calling SIF command handler for command 0x%08X at 0x%08X with data 0x%08X.\r\n", 
 			commandHeader->commandId, cmdDataEntry.sifCmdHandler, cmdDataEntry.data);
 
 		assert(cmdDataEntry.sifCmdHandler != 0);
@@ -664,7 +664,7 @@ int32 CSifCmd::SifGetSreg(uint32 regIndex)
 
 uint32 CSifCmd::SifSetCmdBuffer(uint32 cmdBufferAddr, uint32 length)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFSETCMDBUFFER "(cmdBufferAddr = 0x%0.8X, length = %d);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFSETCMDBUFFER "(cmdBufferAddr = 0x%08X, length = %d);\r\n",
 		cmdBufferAddr, length);
 
 	auto moduleData = reinterpret_cast<MODULEDATA*>(m_ram + m_moduleDataAddr);
@@ -677,7 +677,7 @@ uint32 CSifCmd::SifSetCmdBuffer(uint32 cmdBufferAddr, uint32 length)
 
 void CSifCmd::SifAddCmdHandler(uint32 pos, uint32 handler, uint32 data)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFADDCMDHANDLER "(pos = 0x%0.8X, handler = 0x%0.8X, data = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFADDCMDHANDLER "(pos = 0x%08X, handler = 0x%08X, data = 0x%08X);\r\n",
 		pos, handler, data);
 
 	auto moduleData = reinterpret_cast<const MODULEDATA*>(m_ram + m_moduleDataAddr);
@@ -700,7 +700,7 @@ void CSifCmd::SifAddCmdHandler(uint32 pos, uint32 handler, uint32 data)
 
 uint32 CSifCmd::SifSendCmd(uint32 commandId, uint32 packetPtr, uint32 packetSize, uint32 srcExtraPtr, uint32 dstExtraPtr, uint32 sizeExtra)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFSENDCMD "(commandId = 0x%0.8X, packetPtr = 0x%0.8X, packetSize = 0x%0.8X, srcExtraPtr = 0x%0.8X, dstExtraPtr = 0x%0.8X, sizeExtra = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFSENDCMD "(commandId = 0x%08X, packetPtr = 0x%08X, packetSize = 0x%08X, srcExtraPtr = 0x%08X, dstExtraPtr = 0x%08X, sizeExtra = 0x%08X);\r\n",
 		commandId, packetPtr, packetSize, srcExtraPtr, dstExtraPtr, sizeExtra);
 
 	assert(packetSize >= 0x10);
@@ -737,7 +737,7 @@ void CSifCmd::SifBindRpc(CMIPS& context)
 	uint32 serverId       = context.m_State.nGPR[CMIPS::A1].nV0;
 	uint32 mode           = context.m_State.nGPR[CMIPS::A2].nV0;
 
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFBINDRPC "(clientDataAddr = 0x%0.8X, serverId = 0x%0.8X, mode = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFBINDRPC "(clientDataAddr = 0x%08X, serverId = 0x%08X, mode = 0x%08X);\r\n",
 		clientDataAddr, serverId, mode);
 
 	//Could be in non waiting mode
@@ -761,8 +761,8 @@ void CSifCmd::SifCallRpc(CMIPS& context)
 	assert(mode == 0);
 
 	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFCALLRPC 
-		"(clientDataAddr = 0x%0.8X, rpcNumber = 0x%0.8X, mode = 0x%0.8X, sendAddr = 0x%0.8X, sendSize = 0x%0.8X, "
-		"recvAddr = 0x%0.8X, recvSize = 0x%0.8X, endFctAddr = 0x%0.8X, endParam = 0x%0.8X);\r\n",
+		"(clientDataAddr = 0x%08X, rpcNumber = 0x%08X, mode = 0x%08X, sendAddr = 0x%08X, sendSize = 0x%08X, "
+		"recvAddr = 0x%08X, recvSize = 0x%08X, endFctAddr = 0x%08X, endParam = 0x%08X);\r\n",
 		clientDataAddr, rpcNumber, mode, sendAddr, sendSize, recvAddr, recvSize, endFctAddr, endParam);
 
 	auto clientData = reinterpret_cast<SIFRPCCLIENTDATA*>(m_ram + clientDataAddr);
@@ -813,7 +813,7 @@ void CSifCmd::SifRegisterRpc(CMIPS& context)
 	uint32 cbuffer			= context.m_pMemoryMap->GetWord(context.m_State.nGPR[CMIPS::SP].nV0 + 0x14);
 	uint32 queueAddr		= context.m_pMemoryMap->GetWord(context.m_State.nGPR[CMIPS::SP].nV0 + 0x18);
 
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFREGISTERRPC "(serverData = 0x%0.8X, serverId = 0x%0.8X, function = 0x%0.8X, buffer = 0x%0.8X, cfunction = 0x%0.8X, cbuffer = 0x%0.8X, queue = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFREGISTERRPC "(serverData = 0x%08X, serverId = 0x%08X, function = 0x%08X, buffer = 0x%08X, cfunction = 0x%08X, cbuffer = 0x%08X, queue = 0x%08X);\r\n",
 		serverDataAddr, serverId, function, buffer, cfunction, cbuffer, queueAddr);
 
 	bool moduleRegistered = m_sifMan.IsModuleRegistered(serverId);
@@ -847,7 +847,7 @@ void CSifCmd::SifRegisterRpc(CMIPS& context)
 
 void CSifCmd::SifSetRpcQueue(uint32 queueDataAddr, uint32 threadId)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFSETRPCQUEUE "(queueData = 0x%0.8X, threadId = %d);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFSETRPCQUEUE "(queueData = 0x%08X, threadId = %d);\r\n",
 		queueDataAddr, threadId);
 
 	if(queueDataAddr != 0)
@@ -859,7 +859,7 @@ void CSifCmd::SifSetRpcQueue(uint32 queueDataAddr, uint32 threadId)
 
 uint32 CSifCmd::SifGetNextRequest(uint32 queueDataAddr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFGETNEXTREQUEST "(queueData = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFGETNEXTREQUEST "(queueData = 0x%08X);\r\n",
 		queueDataAddr);
 
 	uint32 result = 0;
@@ -875,14 +875,14 @@ uint32 CSifCmd::SifGetNextRequest(uint32 queueDataAddr)
 void CSifCmd::SifExecRequest(CMIPS& context)
 {
 	uint32 serverDataAddr = context.m_State.nGPR[CMIPS::A0].nV0;
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFEXECREQUEST "(serverData = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFEXECREQUEST "(serverData = 0x%08X);\r\n",
 		serverDataAddr);
 	context.m_State.nPC = m_sifExecRequestAddr;
 }
 
 uint32 CSifCmd::SifCheckStatRpc(uint32 clientDataAddress)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFCHECKSTATRPC "(clientData = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFCHECKSTATRPC "(clientData = 0x%08X);\r\n",
 		clientDataAddress);
 	return 0;
 }
@@ -890,14 +890,14 @@ uint32 CSifCmd::SifCheckStatRpc(uint32 clientDataAddress)
 void CSifCmd::SifRpcLoop(CMIPS& context)
 {
 	uint32 queueAddr = context.m_State.nGPR[CMIPS::A0].nV0;
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFRPCLOOP "(queue = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFRPCLOOP "(queue = 0x%08X);\r\n",
 		queueAddr);
 	context.m_State.nPC = m_sifRpcLoopAddr;
 }
 
 uint32 CSifCmd::SifGetOtherData(uint32 packetPtr, uint32 src, uint32 dst, uint32 size, uint32 mode)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFGETOTHERDATA "(packetPtr = 0x%0.8X, src = 0x%0.8X, dst = 0x%0.8X, size = 0x%0.8X, mode = %d);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFGETOTHERDATA "(packetPtr = 0x%08X, src = 0x%08X, dst = 0x%08X, size = 0x%08X, mode = %d);\r\n",
 		packetPtr, src, dst, size, mode);
 	m_sifMan.GetOtherData(dst, src, size);
 	return 0;

--- a/Source/iop/Iop_SifMan.cpp
+++ b/Source/iop/Iop_SifMan.cpp
@@ -75,7 +75,7 @@ void CSifMan::Invoke(CMIPS& context, unsigned int functionId)
 			));
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "%0.8X: Unknown function (%d) called.\r\n", context.m_State.nPC, functionId);
+		CLog::GetInstance().Print(LOG_NAME, "%08X: Unknown function (%d) called.\r\n", context.m_State.nPC, functionId);
 		break;
 	}
 }
@@ -109,7 +109,7 @@ void CSifMan::GenerateHandlers(uint8* ram, CSysmem& sysMem)
 
 uint32 CSifMan::SifSetDma(uint32 structAddr, uint32 count)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFSETDMA "(structAddr = 0x%0.8X, count = %d);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFSETDMA "(structAddr = 0x%08X, count = %d);\r\n",
 		structAddr, count);
 	return count;
 }
@@ -123,7 +123,7 @@ uint32 CSifMan::SifDmaStat(uint32 transferId)
 
 uint32 CSifMan::SifSetDmaCallback(CMIPS& context, uint32 structAddr, uint32 count, uint32 callbackPtr, uint32 callbackParam)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFSETDMACALLBACK "(structAddr = 0x%0.8X, count = %d, callbackPtr = 0x%0.8X, callbackParam = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SIFSETDMACALLBACK "(structAddr = 0x%08X, count = %d, callbackPtr = 0x%08X, callbackParam = 0x%08X);\r\n",
 		structAddr, count, callbackPtr, callbackParam);
 
 	//Modify context so we can execute the callback function

--- a/Source/iop/Iop_Sio2.cpp
+++ b/Source/iop/Iop_Sio2.cpp
@@ -410,11 +410,11 @@ void CSio2::ProcessController(unsigned int portId, size_t outputOffset, uint32 d
 			padState.pollMask[0] = m_inputBuffer[3];
 			padState.pollMask[1] = m_inputBuffer[4];
 			padState.pollMask[2] = m_inputBuffer[5];
-			CLog::GetInstance().Print(LOG_NAME, "Pad %d: SetPollMask(mask = { 0x%0.2X, 0x%0.2X, 0x%0.2X });\r\n", 
+			CLog::GetInstance().Print(LOG_NAME, "Pad %d: SetPollMask(mask = { 0x%02X, 0x%02X, 0x%02X });\r\n", 
 				padId, padState.pollMask[0], padState.pollMask[1], padState.pollMask[2]);
 			break;
 		default:
-			CLog::GetInstance().Print(LOG_NAME, "Pad %d: Unknown command received (0x%0.2X).\r\n", padId, cmd);
+			CLog::GetInstance().Print(LOG_NAME, "Pad %d: Unknown command received (0x%02X).\r\n", padId, cmd);
 			break;
 		}
 	}
@@ -449,13 +449,13 @@ void CSio2::DisassembleRead(uint32 address, uint32 value)
 	switch(address)
 	{
 	case REG_DATA_IN:
-		CLog::GetInstance().Print(LOG_NAME, "= DATA_IN = 0x%0.8X\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "= DATA_IN = 0x%08X\r\n", value);
 		break;
 	case REG_CTRL:
-		CLog::GetInstance().Print(LOG_NAME, "= REG_CTRL = 0x%0.8X\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "= REG_CTRL = 0x%08X\r\n", value);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Read an unknown register 0x%0.8X.\r\n", address);
+		CLog::GetInstance().Print(LOG_NAME, "Read an unknown register 0x%08X.\r\n", address);
 		break;
 	}
 }
@@ -465,37 +465,37 @@ void CSio2::DisassembleWrite(uint32 address, uint32 value)
 	switch(address)
 	{
 	case REG_PORT0_CTRL1:
-		CLog::GetInstance().Print(LOG_NAME, "REG_PORT0_CTRL1 = 0x%0.8X\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "REG_PORT0_CTRL1 = 0x%08X\r\n", value);
 		break;
 	case REG_PORT0_CTRL2:
-		CLog::GetInstance().Print(LOG_NAME, "REG_PORT0_CTRL2 = 0x%0.8X\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "REG_PORT0_CTRL2 = 0x%08X\r\n", value);
 		break;
 	case REG_PORT1_CTRL1:
-		CLog::GetInstance().Print(LOG_NAME, "REG_PORT1_CTRL1 = 0x%0.8X\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "REG_PORT1_CTRL1 = 0x%08X\r\n", value);
 		break;
 	case REG_PORT1_CTRL2:
-		CLog::GetInstance().Print(LOG_NAME, "REG_PORT1_CTRL2 = 0x%0.8X\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "REG_PORT1_CTRL2 = 0x%08X\r\n", value);
 		break;
 	case REG_PORT2_CTRL1:
-		CLog::GetInstance().Print(LOG_NAME, "REG_PORT2_CTRL1 = 0x%0.8X\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "REG_PORT2_CTRL1 = 0x%08X\r\n", value);
 		break;
 	case REG_PORT2_CTRL2:
-		CLog::GetInstance().Print(LOG_NAME, "REG_PORT2_CTRL2 = 0x%0.8X\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "REG_PORT2_CTRL2 = 0x%08X\r\n", value);
 		break;
 	case REG_PORT3_CTRL1:
-		CLog::GetInstance().Print(LOG_NAME, "REG_PORT3_CTRL1 = 0x%0.8X\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "REG_PORT3_CTRL1 = 0x%08X\r\n", value);
 		break;
 	case REG_PORT3_CTRL2:
-		CLog::GetInstance().Print(LOG_NAME, "REG_PORT3_CTRL2 = 0x%0.8X\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "REG_PORT3_CTRL2 = 0x%08X\r\n", value);
 		break;
 	case REG_DATA_OUT:
-		CLog::GetInstance().Print(LOG_NAME, "DATA_OUT = 0x%0.8X\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "DATA_OUT = 0x%08X\r\n", value);
 		break;
 	case REG_CTRL:
-		CLog::GetInstance().Print(LOG_NAME, "CTRL = 0x%0.8X\r\n", value);
+		CLog::GetInstance().Print(LOG_NAME, "CTRL = 0x%08X\r\n", value);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Write 0x%0.8X to an unknown register 0x%0.8X.\r\n", value, address);
+		CLog::GetInstance().Print(LOG_NAME, "Write 0x%08X to an unknown register 0x%08X.\r\n", value, address);
 		break;
 	}
 }

--- a/Source/iop/Iop_Spu.cpp
+++ b/Source/iop/Iop_Spu.cpp
@@ -254,7 +254,7 @@ void CSpu::DisassembleRead(uint32 address)
 		unsigned int registerId = (address - SPU_GENERAL_BASE) / 2;
 		if(invalid || registerId >= MAX_GENERAL_REG_NAME)
 		{
-			CLog::GetInstance().Print(LOG_NAME, "Read an unknown register (0x%0.8X).\r\n", address);
+			CLog::GetInstance().Print(LOG_NAME, "Read an unknown register (0x%08X).\r\n", address);
 		}
 		else
 		{
@@ -286,11 +286,11 @@ void CSpu::DisassembleWrite(uint32 address, uint16 value)
 		unsigned int registerId = (address - SPU_GENERAL_BASE) / 2;
 		if(invalid || registerId >= MAX_GENERAL_REG_NAME)
 		{
-			CLog::GetInstance().Print(LOG_NAME, "Wrote to an unknown register (0x%0.8X, 0x%0.4X).\r\n", address, value);
+			CLog::GetInstance().Print(LOG_NAME, "Wrote to an unknown register (0x%08X, 0x%04X).\r\n", address, value);
 		}
 		else
 		{
-			CLog::GetInstance().Print(LOG_NAME, "%s = 0x%0.4X\r\n",
+			CLog::GetInstance().Print(LOG_NAME, "%s = 0x%04X\r\n",
 				g_generalRegisterName[registerId], value);
 		}
 	}
@@ -300,12 +300,12 @@ void CSpu::DisassembleWrite(uint32 address, uint16 value)
 		unsigned int registerId = address & 0x0F;
 		if(address & 0x1)
 		{
-			CLog::GetInstance().Print(LOG_NAME, "CH%i : Wrote to an unknown register (0x%X, 0x%0.4X).\r\n", 
+			CLog::GetInstance().Print(LOG_NAME, "CH%i : Wrote to an unknown register (0x%X, 0x%04X).\r\n", 
 				channel, registerId, value);
 		}
 		else
 		{
-			CLog::GetInstance().Print(LOG_NAME, "CH%i : %s = 0x%0.4X\r\n", 
+			CLog::GetInstance().Print(LOG_NAME, "CH%i : %s = 0x%04X\r\n", 
 				channel, g_channelRegisterName[registerId / 2], value);
 		}
 	}

--- a/Source/iop/Iop_Spu2.cpp
+++ b/Source/iop/Iop_Spu2.cpp
@@ -109,7 +109,7 @@ void CSpu2::LogRead(uint32 address)
 		CLog::GetInstance().Print(LOG_NAME, " = C_IRQINFO\r\n");
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Read an unknown register 0x%0.8X.\r\n", address);
+		CLog::GetInstance().Print(LOG_NAME, "Read an unknown register 0x%08X.\r\n", address);
 		break;
 	}
 }
@@ -119,7 +119,7 @@ void CSpu2::LogWrite(uint32 address, uint32 value)
 	switch(address)
 	{
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Wrote 0x%0.8X to unknown register 0x%0.8X.\r\n", value, address);
+		CLog::GetInstance().Print(LOG_NAME, "Wrote 0x%08X to unknown register 0x%08X.\r\n", value, address);
 		break;
 	}
 }

--- a/Source/iop/Iop_Spu2_Core.cpp
+++ b/Source/iop/Iop_Spu2_Core.cpp
@@ -383,7 +383,7 @@ uint32 CCore::WriteRegisterChannel(unsigned int channelId, uint32 address, uint3
 void CCore::LogRead(uint32 address, uint32 value)
 {
 	auto logName = m_logName.c_str();
-#define LOG_GET(registerId) case registerId: CLog::GetInstance().Print(logName, "= " #registerId " = 0x%0.4X\r\n", value); break;
+#define LOG_GET(registerId) case registerId: CLog::GetInstance().Print(logName, "= " #registerId " = 0x%04X\r\n", value); break;
 
 	switch(address)
 	{
@@ -412,7 +412,7 @@ void CCore::LogRead(uint32 address, uint32 value)
 		LOG_GET(A_EEA_LO)
 
 	default:
-		CLog::GetInstance().Print(logName, "Read an unknown register 0x%0.4X.\r\n", address);
+		CLog::GetInstance().Print(logName, "Read an unknown register 0x%04X.\r\n", address);
 		break;
 	}
 
@@ -422,7 +422,7 @@ void CCore::LogRead(uint32 address, uint32 value)
 void CCore::LogWrite(uint32 address, uint32 value)
 {
 	auto logName = m_logName.c_str();
-#define LOG_SET(registerId) case registerId: CLog::GetInstance().Print(logName, #registerId " = 0x%0.4X\r\n", value); break;
+#define LOG_SET(registerId) case registerId: CLog::GetInstance().Print(logName, #registerId " = 0x%04X\r\n", value); break;
 
 	switch(address)
 	{
@@ -464,7 +464,7 @@ void CCore::LogWrite(uint32 address, uint32 value)
 		LOG_SET(P_BVOLR)
 
 	default:
-		CLog::GetInstance().Print(logName, "Write 0x%0.4X to an unknown register 0x%0.4X.\r\n", value, address);
+		CLog::GetInstance().Print(logName, "Write 0x%04X to an unknown register 0x%04X.\r\n", value, address);
 		break;
 	}
 
@@ -474,7 +474,7 @@ void CCore::LogWrite(uint32 address, uint32 value)
 void CCore::LogChannelRead(unsigned int channelId, uint32 address, uint32 value)
 {
 	auto logName = m_logName.c_str();
-#define LOG_GET(registerId) case registerId: CLog::GetInstance().Print(logName, "ch%0.2d: = " #registerId " = 0x%0.4X\r\n", channelId, value); break;
+#define LOG_GET(registerId) case registerId: CLog::GetInstance().Print(logName, "ch%02d: = " #registerId " = 0x%04X\r\n", channelId, value); break;
 
 	switch(address)
 	{
@@ -494,7 +494,7 @@ void CCore::LogChannelRead(unsigned int channelId, uint32 address, uint32 value)
 		LOG_GET(VA_NAX_LO)
 
 	default:
-		CLog::GetInstance().Print(logName, "ch%0.2d: Read an unknown register 0x%0.4X.\r\n", 
+		CLog::GetInstance().Print(logName, "ch%02d: Read an unknown register 0x%04X.\r\n", 
 			channelId, address);
 		break;
 	}
@@ -505,7 +505,7 @@ void CCore::LogChannelRead(unsigned int channelId, uint32 address, uint32 value)
 void CCore::LogChannelWrite(unsigned int channelId, uint32 address, uint32 value)
 {
 	auto logName = m_logName.c_str();
-#define LOG_SET(registerId) case registerId: CLog::GetInstance().Print(logName, "ch%0.2d: " #registerId " = 0x%0.4X\r\n", channelId, value); break;
+#define LOG_SET(registerId) case registerId: CLog::GetInstance().Print(logName, "ch%02d: " #registerId " = 0x%04X\r\n", channelId, value); break;
 
 	switch(address)
 	{
@@ -523,7 +523,7 @@ void CCore::LogChannelWrite(unsigned int channelId, uint32 address, uint32 value
 		LOG_SET(VA_LSAX_LO)
 
 	default:
-		CLog::GetInstance().Print(logName, "ch%0.2d: Wrote %0.4X to an unknown register 0x%0.4X.\r\n", 
+		CLog::GetInstance().Print(logName, "ch%02d: Wrote %04X to an unknown register 0x%04X.\r\n", 
 			channelId, value, address);
 		break;
 	}

--- a/Source/iop/Iop_SpuBase.cpp
+++ b/Source/iop/Iop_SpuBase.cpp
@@ -459,7 +459,7 @@ void CSpuBase::SetReverbCurrentAddress(uint32 address)
 uint32 CSpuBase::ReceiveDma(uint8* buffer, uint32 blockSize, uint32 blockAmount)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, "Receiving DMA transfer to 0x%0.8X. Size = 0x%0.8X bytes.\r\n", 
+	CLog::GetInstance().Print(LOG_NAME, "Receiving DMA transfer to 0x%08X. Size = 0x%08X bytes.\r\n", 
 		m_transferAddr, blockSize * blockAmount);
 #endif
 	if(m_transferMode == TRANSFER_MODE_VOICE)

--- a/Source/iop/Iop_Stdio.cpp
+++ b/Source/iop/Iop_Stdio.cpp
@@ -49,7 +49,7 @@ void CStdio::Invoke(CMIPS& context, unsigned int functionId)
 		__printf(context);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called. PC = (%0.8X).", 
+		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called. PC = (%08X).", 
 			functionId, context.m_State.nPC);
 		break;
 	}

--- a/Source/iop/Iop_SubSystem.cpp
+++ b/Source/iop/Iop_SubSystem.cpp
@@ -194,7 +194,7 @@ uint32 CSubSystem::ReadIoRegister(uint32 address)
 	}
 	else
 	{
-		CLog::GetInstance().Print(LOG_NAME, "Reading an unknown hardware register (0x%0.8X).\r\n", address);
+		CLog::GetInstance().Print(LOG_NAME, "Reading an unknown hardware register (0x%08X).\r\n", address);
 	}
 	return 0;
 }
@@ -236,7 +236,7 @@ uint32 CSubSystem::WriteIoRegister(uint32 address, uint32 value)
 	}
 	else
 	{
-		CLog::GetInstance().Print(LOG_NAME, "Writing to an unknown hardware register (0x%0.8X, 0x%0.8X).\r\n", address, value);
+		CLog::GetInstance().Print(LOG_NAME, "Writing to an unknown hardware register (0x%08X, 0x%08X).\r\n", address, value);
 	}
 
 	if(

--- a/Source/iop/Iop_Sysclib.cpp
+++ b/Source/iop/Iop_Sysclib.cpp
@@ -265,7 +265,7 @@ void CSysclib::Invoke(CMIPS& context, unsigned int functionId)
 			));
 		break;
 	default:
-		printf("%s(%0.8X): Unknown function (%d) called.\r\n", __FUNCTION__, context.m_State.nPC, functionId);
+		printf("%s(%08X): Unknown function (%d) called.\r\n", __FUNCTION__, context.m_State.nPC, functionId);
 		assert(0);
 		break;
 	}

--- a/Source/iop/Iop_Sysmem.cpp
+++ b/Source/iop/Iop_Sysmem.cpp
@@ -95,7 +95,7 @@ void CSysmem::Invoke(CMIPS& context, unsigned int functionId)
 		m_stdio.__printf(context);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "%s(%0.8X): Unknown function (%d) called.\r\n", __FUNCTION__, context.m_State.nPC, functionId);
+		CLog::GetInstance().Print(LOG_NAME, "%s(%08X): Unknown function (%d) called.\r\n", __FUNCTION__, context.m_State.nPC, functionId);
 		break;
 	}
 }
@@ -128,7 +128,7 @@ bool CSysmem::Invoke(uint32 method, uint32* args, uint32 argsSize, uint32* ret, 
 		ret[0] = QueryMaxFreeMemSize();
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%0.8X).\r\n", method);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown method invoked (0x%08X).\r\n", method);
 		break;
 	}
 	return true;
@@ -156,7 +156,7 @@ uint32 CSysmem::QueryMaxFreeMemSize()
 
 uint32 CSysmem::AllocateMemory(uint32 size, uint32 flags, uint32 wantedAddress)
 {
-	CLog::GetInstance().Print(LOG_NAME, "AllocateMemory(size = 0x%0.8X, flags = 0x%0.8X, wantedAddress = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "AllocateMemory(size = 0x%08X, flags = 0x%08X, wantedAddress = 0x%08X);\r\n",
 		size, flags, wantedAddress);
 
 	const uint32 blockSize = MIN_BLOCK_SIZE;
@@ -258,7 +258,7 @@ uint32 CSysmem::AllocateMemory(uint32 size, uint32 flags, uint32 wantedAddress)
 
 uint32 CSysmem::FreeMemory(uint32 address)
 {
-	CLog::GetInstance().Print(LOG_NAME, "FreeMemory(address = 0x%0.8X);\r\n", address);
+	CLog::GetInstance().Print(LOG_NAME, "FreeMemory(address = 0x%08X);\r\n", address);
 
 	address -= m_memoryBegin;
 	//Search for block pointing at the address
@@ -281,7 +281,7 @@ uint32 CSysmem::FreeMemory(uint32 address)
 	}
 	else
 	{
-		CLog::GetInstance().Print(LOG_NAME, "%s: Trying to unallocate an unexisting memory block (0x%0.8X).\r\n", __FUNCTION__, address);
+		CLog::GetInstance().Print(LOG_NAME, "%s: Trying to unallocate an unexisting memory block (0x%08X).\r\n", __FUNCTION__, address);
 	}
 	return 0;
 }
@@ -289,7 +289,7 @@ uint32 CSysmem::FreeMemory(uint32 address)
 uint32 CSysmem::SifAllocate(uint32 nSize)
 {
 	uint32 result = AllocateMemory(nSize, 0, 0); 
-	CLog::GetInstance().Print(LOG_NAME, "result = 0x%0.8X = Allocate(size = 0x%0.8X);\r\n", 
+	CLog::GetInstance().Print(LOG_NAME, "result = 0x%08X = Allocate(size = 0x%08X);\r\n", 
 		result, nSize);
 	return result;
 }
@@ -297,14 +297,14 @@ uint32 CSysmem::SifAllocate(uint32 nSize)
 uint32 CSysmem::SifAllocateSystemMemory(uint32 nSize, uint32 nFlags, uint32 nPtr)
 {
 	uint32 result = AllocateMemory(nSize, nFlags, nPtr);
-	CLog::GetInstance().Print(LOG_NAME, "result = 0x%0.8X = AllocateSystemMemory(flags = 0x%0.8X, size = 0x%0.8X, ptr = 0x%0.8X);\r\n", 
+	CLog::GetInstance().Print(LOG_NAME, "result = 0x%08X = AllocateSystemMemory(flags = 0x%08X, size = 0x%08X, ptr = 0x%08X);\r\n", 
 		result, nFlags, nSize, nPtr);
 	return result;
 }
 
 uint32 CSysmem::SifLoadMemory(uint32 address, const char* filePath)
 {
-	CLog::GetInstance().Print(LOG_NAME, "LoadMemory(address = 0x%0.8X, filePath = '%s');\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "LoadMemory(address = 0x%08X, filePath = '%s');\r\n",
 		address, filePath);
 
 	auto fd = m_ioman.Open(Ioman::CDevice::OPEN_FLAG_RDONLY, filePath);
@@ -321,7 +321,7 @@ uint32 CSysmem::SifLoadMemory(uint32 address, const char* filePath)
 
 uint32 CSysmem::SifFreeMemory(uint32 address)
 {
-	CLog::GetInstance().Print(LOG_NAME, "FreeMemory(address = 0x%0.8X);\r\n", address);
+	CLog::GetInstance().Print(LOG_NAME, "FreeMemory(address = 0x%08X);\r\n", address);
 	FreeMemory(address);
 	return 0;
 }

--- a/Source/iop/Iop_Thbase.cpp
+++ b/Source/iop/Iop_Thbase.cpp
@@ -259,7 +259,7 @@ void CThbase::Invoke(CMIPS& context, unsigned int functionId)
 		context.m_State.nGPR[CMIPS::V0].nD0 = static_cast<int32>(GetSystemTimeLow());
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called at (%0.8X).\r\n", functionId, context.m_State.nPC);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called at (%08X).\r\n", functionId, context.m_State.nPC);
 		break;
 	}
 }
@@ -358,7 +358,7 @@ uint32 CThbase::DelayThread(uint32 delay)
 uint32 CThbase::GetSystemTime(uint32 resultPtr)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, "%d : " FUNCTION_GETSYSTEMTIME "(resultPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "%d : " FUNCTION_GETSYSTEMTIME "(resultPtr = 0x%08X);\r\n",
 		m_bios.GetCurrentThreadIdRaw(), resultPtr);
 #endif
 	uint64* result = nullptr;
@@ -385,7 +385,7 @@ uint32 CThbase::GetSystemTimeLow()
 uint32 CThbase::SetAlarm(uint32 timePtr, uint32 alarmFunction, uint32 param)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, "%d : SetAlarm(timePtr = 0x%0.8X, alarmFunction = 0x%0.8X, param = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "%d : SetAlarm(timePtr = 0x%08X, alarmFunction = 0x%08X, param = 0x%08X);\r\n",
 		m_bios.GetCurrentThreadIdRaw(), timePtr, alarmFunction, param);
 #endif
 	return m_bios.SetAlarm(timePtr, alarmFunction, param);
@@ -394,7 +394,7 @@ uint32 CThbase::SetAlarm(uint32 timePtr, uint32 alarmFunction, uint32 param)
 uint32 CThbase::CancelAlarm(uint32 alarmFunction, uint32 param)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, "%d : CancelAlarm(alarmFunction = 0x%0.8X, param = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "%d : CancelAlarm(alarmFunction = 0x%08X, param = 0x%08X);\r\n",
 		m_bios.GetCurrentThreadIdRaw(), alarmFunction, param);
 #endif
 	return m_bios.CancelAlarm(alarmFunction, param);
@@ -403,7 +403,7 @@ uint32 CThbase::CancelAlarm(uint32 alarmFunction, uint32 param)
 void CThbase::USecToSysClock(uint32 usec, uint32 timePtr)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, "%d : USecToSysClock(usec = 0x%0.8X, timePtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "%d : USecToSysClock(usec = 0x%08X, timePtr = 0x%08X);\r\n",
 		m_bios.GetCurrentThreadIdRaw(), usec, timePtr);
 #endif
 	uint64* time = (timePtr != 0) ? reinterpret_cast<uint64*>(&m_ram[timePtr]) : NULL;
@@ -416,7 +416,7 @@ void CThbase::USecToSysClock(uint32 usec, uint32 timePtr)
 void CThbase::SysClockToUSec(uint32 timePtr, uint32 secPtr, uint32 usecPtr)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, "%d : SysClockToUSec(time = 0x%0.8X, sec = 0x%0.8X, usec = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, "%d : SysClockToUSec(time = 0x%08X, sec = 0x%08X, usec = 0x%08X);\r\n",
 		m_bios.GetCurrentThreadIdRaw(), timePtr, secPtr, usecPtr);
 #endif
 	uint64* time = (timePtr != 0) ? reinterpret_cast<uint64*>(&m_ram[timePtr]) : NULL;

--- a/Source/iop/Iop_Thevent.cpp
+++ b/Source/iop/Iop_Thevent.cpp
@@ -131,7 +131,7 @@ void CThevent::Invoke(CMIPS& context, unsigned int functionId)
 			));
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called (%0.8X).\r\n", functionId, context.m_State.nPC);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called (%08X).\r\n", functionId, context.m_State.nPC);
 		break;
 	}
 }

--- a/Source/iop/Iop_Thmsgbx.cpp
+++ b/Source/iop/Iop_Thmsgbx.cpp
@@ -107,7 +107,7 @@ void CThmsgbx::Invoke(CMIPS& context, unsigned int functionId)
 			);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called at (%0.8X).\r\n", functionId, context.m_State.nPC);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called at (%08X).\r\n", functionId, context.m_State.nPC);
 		break;
 	}
 }

--- a/Source/iop/Iop_Thsema.cpp
+++ b/Source/iop/Iop_Thsema.cpp
@@ -103,7 +103,7 @@ void CThsema::Invoke(CMIPS& context, unsigned int functionId)
 			));
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called at (%0.8X).\r\n", functionId, context.m_State.nPC);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called at (%08X).\r\n", functionId, context.m_State.nPC);
 		break;
 	}
 }

--- a/Source/iop/Iop_Thvpool.cpp
+++ b/Source/iop/Iop_Thvpool.cpp
@@ -80,14 +80,14 @@ void CThvpool::Invoke(CMIPS& context, unsigned int functionId)
 			));
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called at (%0.8X).\r\n", functionId, context.m_State.nPC);
+		CLog::GetInstance().Print(LOG_NAME, "Unknown function (%d) called at (%08X).\r\n", functionId, context.m_State.nPC);
 		break;
 	}
 }
 
 uint32 CThvpool::CreateVpl(uint32 paramPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CREATEVPL "(paramPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_CREATEVPL "(paramPtr = 0x%08X);\r\n",
 		paramPtr);
 	return m_bios.CreateVpl(paramPtr);
 }
@@ -101,21 +101,21 @@ uint32 CThvpool::DeleteVpl(uint32 vplId)
 
 uint32 CThvpool::pAllocateVpl(uint32 vplId, uint32 size)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_PALLOCATEVPL "(vplId = %d, size = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_PALLOCATEVPL "(vplId = %d, size = 0x%08X);\r\n",
 		vplId, size);
 	return m_bios.pAllocateVpl(vplId, size);
 }
 
 uint32 CThvpool::FreeVpl(uint32 vplId, uint32 ptr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_FREEVPL "(vplId = %d, ptr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_FREEVPL "(vplId = %d, ptr = 0x%08X);\r\n",
 		vplId, ptr);
 	return m_bios.FreeVpl(vplId, ptr);
 }
 
 uint32 CThvpool::ReferVplStatus(uint32 vplId, uint32 statPtr)
 {
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_REFERVPLSTATUS "(vplId = %d, statPtr = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_REFERVPLSTATUS "(vplId = %d, statPtr = 0x%08X);\r\n",
 		vplId, statPtr);
 	return m_bios.ReferVplStatus(vplId, statPtr);
 }

--- a/Source/iop/Iop_Timrman.cpp
+++ b/Source/iop/Iop_Timrman.cpp
@@ -157,7 +157,7 @@ void CTimrman::Invoke(CMIPS& context, unsigned int functionId)
 			);
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "(%0.8X): Unknown function (%d) called.\r\n", 
+		CLog::GetInstance().Print(LOG_NAME, "(%08X): Unknown function (%d) called.\r\n", 
 			context.m_State.nPC, functionId);
 		break;
 	}
@@ -204,7 +204,7 @@ int CTimrman::AllocHardTimer(CMIPS& context, uint32 source, uint32 size, uint32 
 int CTimrman::ReferHardTimer(uint32 source, uint32 size, uint32 mode, uint32 modeMask)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_REFERHARDTIMER "(source = %d, size = %d, mode = 0x%0.8X, mask = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_REFERHARDTIMER "(source = %d, size = %d, mode = 0x%08X, mask = 0x%08X);\r\n",
 		source, size, mode, modeMask);
 #endif
 	return 0;
@@ -213,7 +213,7 @@ int CTimrman::ReferHardTimer(uint32 source, uint32 size, uint32 mode, uint32 mod
 void CTimrman::SetTimerMode(CMIPS& context, uint32 timerId, uint32 mode)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETTIMERMODE "(timerId = %d, mode = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETTIMERMODE "(timerId = %d, mode = 0x%08X);\r\n",
 		timerId, mode);
 #endif
 	if(timerId == 0) return;
@@ -246,7 +246,7 @@ int CTimrman::GetTimerCounter(CMIPS& context, uint32 timerId)
 void CTimrman::SetTimerCompare(CMIPS& context, uint32 timerId, uint32 compare)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETTIMERCOMPARE "(timerId = %d, compare = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETTIMERCOMPARE "(timerId = %d, compare = 0x%08X);\r\n",
 		timerId, compare);
 #endif
 	if(timerId == 0) return;
@@ -269,7 +269,7 @@ int CTimrman::GetHardTimerIntrCode(uint32 timerId)
 int CTimrman::SetTimerCallback(CMIPS& context, int timerId, uint32 target, uint32 handler, uint32 arg)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETTIMERCALLBACK "(timerId = %d, target = %d, handler = 0x%0.8X, arg = 0x%0.8X);\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_SETTIMERCALLBACK "(timerId = %d, target = %d, handler = 0x%08X, arg = 0x%08X);\r\n",
 		timerId, target, handler, arg);
 #endif
 	if(timerId == 0) return 0;

--- a/Source/iop/Iop_Vblank.cpp
+++ b/Source/iop/Iop_Vblank.cpp
@@ -103,7 +103,7 @@ int32 CVblank::WaitVblank()
 int32 CVblank::RegisterVblankHandler(CMIPS& context, uint32 startEnd, uint32 priority, uint32 handlerPtr, uint32 handlerParam)
 {
 #ifdef _DEBUG
-	CLog::GetInstance().Print(LOG_NAME, FUNCTION_REGISTERVBLANKHANDLER "(startEnd = %d, priority = %d, handler = 0x%0.8X, arg = 0x%0.8X).\r\n",
+	CLog::GetInstance().Print(LOG_NAME, FUNCTION_REGISTERVBLANKHANDLER "(startEnd = %d, priority = %d, handler = 0x%08X, arg = 0x%08X).\r\n",
 		startEnd, priority, handlerPtr, handlerParam);
 #endif
 	uint32 intrLine = startEnd ? CIntc::LINE_EVBLANK : CIntc::LINE_VBLANK;

--- a/Source/ui_ios/SettingsViewController.mm
+++ b/Source/ui_ios/SettingsViewController.mm
@@ -16,7 +16,7 @@
 	
 	[enableAudioOutput setOn: CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_AUDIO_ENABLEOUTPUT)];
 
-	NSString* versionString = [NSString stringWithFormat: @"0.%0.2d - %s", APP_VERSION, __DATE__];
+	NSString* versionString = [NSString stringWithFormat: @"0.%02d - %s", APP_VERSION, __DATE__];
 	versionInfoLabel.text = versionString;
 }
 

--- a/Source/ui_win32/Debugger.cpp
+++ b/Source/ui_win32/Debugger.cpp
@@ -293,7 +293,7 @@ void CDebugger::ReanalyzeEe()
 		[this] (const TCHAR* prompt, uint32& address)
 		{
 			Framework::Win32::CInputBox addressInputBox(_T("Analyze EE"), prompt, 
-				string_format(_T("0x%0.8X"), address).c_str());
+				string_format(_T("0x%08X"), address).c_str());
 			auto addrValue = addressInputBox.GetValue(m_hWnd);
 			if(addrValue == nullptr) return false;
 			uint32 addrValueTemp = 0;
@@ -839,12 +839,12 @@ void CDebugger::OnFindCallersRequested(uint32 address)
 			auto functionName = context->m_Functions.Find(address);
 			if(functionName)
 			{
-				return string_format(_T("Find Callers For '%s' (0x%0.8X)"), 
+				return string_format(_T("Find Callers For '%s' (0x%08X)"), 
 					string_cast<std::tstring>(functionName).c_str(), address);
 			}
 			else
 			{
-				return string_format(_T("Find Callers For 0x%0.8X"), address);
+				return string_format(_T("Find Callers For 0x%08X"), address);
 			}
 		}();
 

--- a/Source/ui_win32/DisAsm.cpp
+++ b/Source/ui_win32/DisAsm.cpp
@@ -418,7 +418,7 @@ long CDisAsm::OnRightButtonUp(int nX, int nY)
 		{
 			TCHAR sTemp[256];
 			uint32 nAddress = m_ctx->m_pArch->GetInstructionEffectiveAddress(m_ctx, m_selected, nOpcode);
-			_sntprintf(sTemp, countof(sTemp), _T("Go to 0x%0.8X"), nAddress);
+			_sntprintf(sTemp, countof(sTemp), _T("Go to 0x%08X"), nAddress);
 			InsertMenu(hMenu, position++, MF_BYPOSITION, ID_DISASM_GOTOEA, sTemp);
 		}
 	}
@@ -426,14 +426,14 @@ long CDisAsm::OnRightButtonUp(int nX, int nY)
 	if(HistoryHasPrevious())
 	{
 		TCHAR sTemp[256];
-		_sntprintf(sTemp, countof(sTemp), _T("Go back (0x%0.8X)"), HistoryGetPrevious());
+		_sntprintf(sTemp, countof(sTemp), _T("Go back (0x%08X)"), HistoryGetPrevious());
 		InsertMenu(hMenu, position++, MF_BYPOSITION, ID_DISASM_GOTOPREV, sTemp);
 	}
 
 	if(HistoryHasNext())
 	{
 		TCHAR sTemp[256];
-		_sntprintf(sTemp, countof(sTemp), _T("Go forward (0x%0.8X)"), HistoryGetNext());
+		_sntprintf(sTemp, countof(sTemp), _T("Go forward (0x%08X)"), HistoryGetNext());
 		InsertMenu(hMenu, position++, MF_BYPOSITION, ID_DISASM_GOTONEXT, sTemp);
 	}
 
@@ -730,7 +730,7 @@ void CDisAsm::Paint(HDC hDC)
 
 		//Draw address
 		deviceContext.TextOut(m_renderMetrics.xtextStart, y + textOffset, 
-			string_format(_T("%0.8X"), address).c_str());
+			string_format(_T("%08X"), address).c_str());
 		
 		//Draw function boundaries
 		const auto* sub = m_ctx->m_analysis->FindSubroutine(address);

--- a/Source/ui_win32/ELFProgramView.cpp
+++ b/Source/ui_win32/ELFProgramView.cpp
@@ -103,30 +103,30 @@ void CELFProgramView::FillInformation()
 		_tcscpy(sTemp, _T("PT_PHDR"));
 		break;
 	default:
-		_sntprintf(sTemp, countof(sTemp), _T("Unknown (0x%0.8X)"), pH->nType);
+		_sntprintf(sTemp, countof(sTemp), _T("Unknown (0x%08X)"), pH->nType);
 		break;
 	}
 	m_pType->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nOffset);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nOffset);
 	m_pOffset->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nVAddress);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nVAddress);
 	m_pVAddr->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nPAddress);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nPAddress);
 	m_pPAddr->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nFileSize);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nFileSize);
 	m_pFileSize->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nMemorySize);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nMemorySize);
 	m_pMemSize->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nFlags);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nFlags);
 	m_pFlags->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nAlignment);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nAlignment);
 	m_pAlign->SetText(sTemp);
 }
 

--- a/Source/ui_win32/ELFSectionView.cpp
+++ b/Source/ui_win32/ELFSectionView.cpp
@@ -171,12 +171,12 @@ void CELFSectionView::FillInformation()
 		_tcscpy(sTemp, _T("SHT_DYNSYM"));
 		break;
 	default:
-		_sntprintf(sTemp, countof(sTemp), _T("Unknown (0x%0.8X)"), pH->nType);
+		_sntprintf(sTemp, countof(sTemp), _T("Unknown (0x%08X)"), pH->nType);
 		break;
 	}
 	m_pType->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nFlags);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nFlags);
 	if(pH->nFlags & 0x7)
 	{
 		_tcscat(sTemp, _T(" ("));
@@ -204,13 +204,13 @@ void CELFSectionView::FillInformation()
 	}
 	m_pFlags->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nStart);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nStart);
 	m_pAddress->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nOffset);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nOffset);
 	m_pOffset->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nSize);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nSize);
 	m_pSize->SetText(sTemp);
 
 	_sntprintf(sTemp, countof(sTemp), _T("%i"), pH->nIndex);
@@ -219,10 +219,10 @@ void CELFSectionView::FillInformation()
 	_sntprintf(sTemp, countof(sTemp), _T("%i"), pH->nInfo);
 	m_pInfo->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nAlignment);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nAlignment);
 	m_pAlignment->SetText(sTemp);
 
-	_sntprintf(sTemp, countof(sTemp), _T("0x%0.8X"), pH->nOther);
+	_sntprintf(sTemp, countof(sTemp), _T("0x%08X"), pH->nOther);
 	m_pEntrySize->SetText(sTemp);
 
 	if(pH->nType == CELF::SHT_DYNAMIC)
@@ -290,23 +290,23 @@ void CELFSectionView::FillDynamicSectionListView()
 			break;
 		case CELF::DT_PLTRELSZ:
 			_tcscpy(tempTag, _T("DT_PLTRELSZ"));
-			_sntprintf(tempVal, countof(tempVal), _T("0x%0.8X"), value);
+			_sntprintf(tempVal, countof(tempVal), _T("0x%08X"), value);
 			break;
 		case CELF::DT_PLTGOT:
 			_tcscpy(tempTag, _T("DT_PLTGOT"));
-			_sntprintf(tempVal, countof(tempVal), _T("0x%0.8X"), value);
+			_sntprintf(tempVal, countof(tempVal), _T("0x%08X"), value);
 			break;
 		case CELF::DT_HASH:
 			_tcscpy(tempTag, _T("DT_HASH"));
-			_sntprintf(tempVal, countof(tempVal), _T("0x%0.8X"), value);
+			_sntprintf(tempVal, countof(tempVal), _T("0x%08X"), value);
 			break;
 		case CELF::DT_STRTAB:
 			_tcscpy(tempTag, _T("DT_STRTAB"));
-			_sntprintf(tempVal, countof(tempVal), _T("0x%0.8X"), value);
+			_sntprintf(tempVal, countof(tempVal), _T("0x%08X"), value);
 			break;
 		case CELF::DT_SYMTAB:
 			_tcscpy(tempTag, _T("DT_SYMTAB"));
-			_sntprintf(tempVal, countof(tempVal), _T("0x%0.8X"), value);
+			_sntprintf(tempVal, countof(tempVal), _T("0x%08X"), value);
 			break;
 		case CELF::DT_SONAME:
 			_tcscpy(tempTag, _T("DT_SONAME"));
@@ -317,8 +317,8 @@ void CELFSectionView::FillDynamicSectionListView()
 			_tcscpy(tempVal, _T(""));
 			break;
 		default:
-			_sntprintf(tempTag, countof(tempTag), _T("Unknown (0x%0.8X)"), tag);
-			_sntprintf(tempVal, countof(tempVal), _T("0x%0.8X"), value);
+			_sntprintf(tempTag, countof(tempTag), _T("Unknown (0x%08X)"), tag);
+			_sntprintf(tempVal, countof(tempVal), _T("0x%08X"), value);
 			break;
 		}
 

--- a/Source/ui_win32/FrameDebugger/GifPacketView.cpp
+++ b/Source/ui_win32/FrameDebugger/GifPacketView.cpp
@@ -163,7 +163,7 @@ void CGifPacketView::SetPacket(uint8* packet, uint32 packetSize)
 	for(unsigned int i = 0; i < registerWrites.size(); i++)
 	{
 		const auto& registerWrite(registerWrites[i]);
-		result += string_format("%0.4X: %s\r\n", i, CGSHandler::DisassembleWrite(registerWrite.first, registerWrite.second).c_str());
+		result += string_format("%04X: %s\r\n", i, CGSHandler::DisassembleWrite(registerWrite.first, registerWrite.second).c_str());
 	}
 
 	SetDisplayText(result.c_str());

--- a/Source/ui_win32/FrameDebugger/GsPacketListView.cpp
+++ b/Source/ui_win32/FrameDebugger/GsPacketListView.cpp
@@ -74,7 +74,7 @@ void CGsPacketListView::SetFrameDump(CFrameDump* frameDump)
 		}
 		else
 		{
-			packetDescription = string_cast<std::tstring>(string_format("Image Packet (Size: 0x%0.8X)", 
+			packetDescription = string_cast<std::tstring>(string_format("Image Packet (Size: 0x%08X)", 
 				packet.imageData.size()));
 		}
 
@@ -238,7 +238,7 @@ void CGsPacketListView::OnPacketsTreeViewItemExpanding(NMTREEVIEW* treeView)
 		for(const auto& registerWrite : packet.registerWrites)
 		{
 			auto packetWriteDescription = CGSHandler::DisassembleWrite(registerWrite.first, registerWrite.second);
-			auto treeItemText = string_format("%0.4X: %s", cmdIndex - packetInfo.cmdIndexStart, packetWriteDescription.c_str());
+			auto treeItemText = string_format("%04X: %s", cmdIndex - packetInfo.cmdIndexStart, packetWriteDescription.c_str());
 			HTREEITEM newItem = m_packetsTreeView->InsertItem(treeView->itemNew.hItem, string_cast<std::tstring>(treeItemText).c_str());
 
 			auto& writeInfo = m_writeInfos[cmdIndex];

--- a/Source/ui_win32/FrameDebugger/GsStateUtils.cpp
+++ b/Source/ui_win32/FrameDebugger/GsStateUtils.cpp
@@ -186,7 +186,7 @@ std::string CGsStateUtils::GetInputState(CGSHandler* gs)
 		float posX = static_cast<float>((vertex.nPosition >>  0) & 0xFFFF) / 16;
 		float posY = static_cast<float>((vertex.nPosition >> 16) & 0xFFFF) / 16;
 		uint32 posZ = static_cast<uint32>(vertex.nPosition >> 32);
-		result += string_format("\tVertex %i:  %+10.4f  %+10.4f  0x%0.8X  %+10.4f  %+10.4f\r\n", 
+		result += string_format("\tVertex %i:  %+10.4f  %+10.4f  0x%08X  %+10.4f  %+10.4f\r\n", 
 			i, posX, posY, posZ, posX - xyOffset.GetX(), posY - xyOffset.GetY());
 	}
 
@@ -214,7 +214,7 @@ std::string CGsStateUtils::GetInputState(CGSHandler* gs)
 		auto vertex = vertices[i];
 		CGSHandler::RGBAQ rgbaq;
 		rgbaq <<= vertex.nRGBAQ;
-		result += string_format("\tVertex %i:        0x%0.2X        0x%0.2X        0x%0.2X        0x%0.2X\r\n", 
+		result += string_format("\tVertex %i:        0x%02X        0x%02X        0x%02X        0x%02X\r\n", 
 			i, rgbaq.nR, rgbaq.nG, rgbaq.nB, rgbaq.nA);
 	}
 
@@ -223,7 +223,7 @@ std::string CGsStateUtils::GetInputState(CGSHandler* gs)
 	for(unsigned int i = 0; i < 3; i++)
 	{
 		auto vertex = vertices[i];
-		result += string_format("\tVertex %i:        0x%0.2X\r\n", 
+		result += string_format("\tVertex %i:        0x%02X\r\n", 
 			i, vertex.nFog);
 	}
 
@@ -237,16 +237,16 @@ std::string CGsStateUtils::GetContextState(CGSHandler* gs, unsigned int contextI
 	{
 		auto frame = make_convertible<CGSHandler::FRAME>(gs->GetRegisters()[GS_REG_FRAME_1 + contextId]);
 		result += string_format("Frame Buffer:\r\n");
-		result += string_format("\tPtr: 0x%0.8X\r\n", frame.GetBasePtr());
+		result += string_format("\tPtr: 0x%08X\r\n", frame.GetBasePtr());
 		result += string_format("\tWidth: %d\r\n", frame.GetWidth());
 		result += string_format("\tFormat: %s\r\n", g_pixelFormats[frame.nPsm]);
-		result += string_format("\tWrite Mask: 0x%0.8X\r\n", ~frame.nMask);
+		result += string_format("\tWrite Mask: 0x%08X\r\n", ~frame.nMask);
 	}
 
 	{
 		auto zbuf = make_convertible<CGSHandler::ZBUF>(gs->GetRegisters()[GS_REG_ZBUF_1 + contextId]);
 		result += string_format("Depth Buffer:\r\n");
-		result += string_format("\tPtr: 0x%0.8X\r\n", zbuf.GetBasePtr());
+		result += string_format("\tPtr: 0x%08X\r\n", zbuf.GetBasePtr());
 		result += string_format("\tFormat: %s\r\n", g_pixelFormats[zbuf.nPsm | 0x30]);
 		result += string_format("\tWrite Enabled: %s\r\n", g_yesNoString[(zbuf.nMask == 0)]);
 	}
@@ -255,14 +255,14 @@ std::string CGsStateUtils::GetContextState(CGSHandler* gs, unsigned int contextI
 		auto tex0 = make_convertible<CGSHandler::TEX0>(gs->GetRegisters()[GS_REG_TEX0_1 + contextId]);
 		auto tex1 = make_convertible<CGSHandler::TEX1>(gs->GetRegisters()[GS_REG_TEX1_1 + contextId]);
 		result += string_format("Texture:\r\n");
-		result += string_format("\tPtr: 0x%0.8X\r\n", tex0.GetBufPtr());
+		result += string_format("\tPtr: 0x%08X\r\n", tex0.GetBufPtr());
 		result += string_format("\tBuffer Width: %d\r\n", tex0.GetBufWidth());
 		result += string_format("\tFormat: %s\r\n", g_pixelFormats[tex0.nPsm]);
 		result += string_format("\tWidth: %d\r\n", tex0.GetWidth());
 		result += string_format("\tHeight: %d\r\n", tex0.GetHeight());
 		result += string_format("\tHas Alpha Component: %s\r\n", g_yesNoString[tex0.nColorComp]);
 		result += string_format("\tFunction: %s\r\n", g_textureFunctionString[tex0.nFunction]);
-		result += string_format("\tCLUT Ptr: 0x%0.8X\r\n", tex0.GetCLUTPtr());
+		result += string_format("\tCLUT Ptr: 0x%08X\r\n", tex0.GetCLUTPtr());
 		result += string_format("\tCLUT Format: %s\r\n", g_pixelFormats[tex0.nCPSM]);
 		result += string_format("\tCLUT Storage Mode: %d\r\n", tex0.nCSM + 1);
 		result += string_format("\tCLUT Entry Offset: %d\r\n", tex0.nCSA * 16);
@@ -280,19 +280,19 @@ std::string CGsStateUtils::GetContextState(CGSHandler* gs, unsigned int contextI
 		auto miptbp1 = make_convertible<CGSHandler::MIPTBP1>(gs->GetRegisters()[GS_REG_MIPTBP1_1 + contextId]);
 		auto miptbp2 = make_convertible<CGSHandler::MIPTBP2>(gs->GetRegisters()[GS_REG_MIPTBP2_1 + contextId]);
 		result += string_format("Mipmap:\r\n");
-		result += string_format("\tLevel 1: 0x%0.8X, %d\r\n", miptbp1.GetTbp1(), miptbp1.GetTbw1());
-		result += string_format("\tLevel 2: 0x%0.8X, %d\r\n", miptbp1.GetTbp2(), miptbp1.GetTbw2());
-		result += string_format("\tLevel 3: 0x%0.8X, %d\r\n", miptbp1.GetTbp3(), miptbp1.GetTbw3());
-		result += string_format("\tLevel 4: 0x%0.8X, %d\r\n", miptbp2.GetTbp4(), miptbp2.GetTbw4());
-		result += string_format("\tLevel 5: 0x%0.8X, %d\r\n", miptbp2.GetTbp5(), miptbp2.GetTbw5());
-		result += string_format("\tLevel 6: 0x%0.8X, %d\r\n", miptbp2.GetTbp6(), miptbp2.GetTbw6());
+		result += string_format("\tLevel 1: 0x%08X, %d\r\n", miptbp1.GetTbp1(), miptbp1.GetTbw1());
+		result += string_format("\tLevel 2: 0x%08X, %d\r\n", miptbp1.GetTbp2(), miptbp1.GetTbw2());
+		result += string_format("\tLevel 3: 0x%08X, %d\r\n", miptbp1.GetTbp3(), miptbp1.GetTbw3());
+		result += string_format("\tLevel 4: 0x%08X, %d\r\n", miptbp2.GetTbp4(), miptbp2.GetTbw4());
+		result += string_format("\tLevel 5: 0x%08X, %d\r\n", miptbp2.GetTbp5(), miptbp2.GetTbw5());
+		result += string_format("\tLevel 6: 0x%08X, %d\r\n", miptbp2.GetTbp6(), miptbp2.GetTbw6());
 	}
 
 	{
 		auto texA = make_convertible<CGSHandler::TEXA>(gs->GetRegisters()[GS_REG_TEXA]);
 		result += string_format("Texture Alpha:\r\n");
-		result += string_format("\tAlpha 0: 0x%0.2X\r\n", texA.nTA0);
-		result += string_format("\tAlpha 1: 0x%0.2X\r\n", texA.nTA1);
+		result += string_format("\tAlpha 0: 0x%02X\r\n", texA.nTA0);
+		result += string_format("\tAlpha 1: 0x%02X\r\n", texA.nTA1);
 		result += string_format("\tBlack Is Transparent: %s\r\n", g_yesNoString[texA.nAEM]);
 	}
 
@@ -317,7 +317,7 @@ std::string CGsStateUtils::GetContextState(CGSHandler* gs, unsigned int contextI
 		result += string_format("Alpha Testing:\r\n");
 		result += string_format("\tEnabled: %s\r\n", g_yesNoString[test.nAlphaEnabled]);
 		result += string_format("\tFunction: %s\r\n", g_alphaTestFunctionString[test.nAlphaMethod]);
-		result += string_format("\tRef Value: 0x%0.2X\r\n", test.nAlphaRef);
+		result += string_format("\tRef Value: 0x%02X\r\n", test.nAlphaRef);
 		result += string_format("\tFail Op: %s\r\n", g_alphaTestFailOpString[test.nAlphaFail]);
 	}
 
@@ -328,7 +328,7 @@ std::string CGsStateUtils::GetContextState(CGSHandler* gs, unsigned int contextI
 		result += string_format("\tFormula: (%s - %s) * %s + %s\r\n", 
 			g_alphaBlendAbdCoefString[alpha.nA], g_alphaBlendAbdCoefString[alpha.nB],
 			g_alphaBlendCCoefString[alpha.nC], g_alphaBlendAbdCoefString[alpha.nD]);
-		result += string_format("\tFixed Value: 0x%0.2X\r\n", alpha.nFix);
+		result += string_format("\tFixed Value: 0x%02X\r\n", alpha.nFix);
 	}
 
 	result += "\r\n";

--- a/Source/ui_win32/FrameDebugger/Vu1Vm.cpp
+++ b/Source/ui_win32/FrameDebugger/Vu1Vm.cpp
@@ -106,7 +106,7 @@ uint32 CVu1Vm::Vu1IoPortReadHandler(uint32 address)
 		result = m_vpu1_TOP;
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled VU1 IO port (0x%0.8X).\r\n", address);
+		CLog::GetInstance().Print(LOG_NAME, "Read an unhandled VU1 IO port (0x%08X).\r\n", address);
 		break;
 	}
 	return result;
@@ -119,7 +119,7 @@ uint32 CVu1Vm::Vu1IoPortWriteHandler(uint32 address, uint32 value)
 	case CVpu::VU_XGKICK:
 		break;
 	default:
-		CLog::GetInstance().Print(LOG_NAME, "Wrote an unhandled VU1 IO port (0x%0.8X, 0x%0.8X).\r\n", 
+		CLog::GetInstance().Print(LOG_NAME, "Wrote an unhandled VU1 IO port (0x%08X, 0x%08X).\r\n", 
 			address, value);
 		break;
 	}

--- a/Source/ui_win32/MainWindow.cpp
+++ b/Source/ui_win32/MainWindow.cpp
@@ -503,7 +503,7 @@ void CMainWindow::DumpNextFrame()
 				Framework::PathUtils::EnsurePathExists(frameDumpDirectoryPath);
 				for(unsigned int i = 0; i < UINT_MAX; i++)
 				{
-					auto frameDumpFileName = string_format("framedump_%0.8d.dmp.zip", i);
+					auto frameDumpFileName = string_format("framedump_%08d.dmp.zip", i);
 					auto frameDumpPath = frameDumpDirectoryPath / boost::filesystem::path(frameDumpFileName);
 					if(!boost::filesystem::exists(frameDumpPath))
 					{

--- a/Source/ui_win32/MemoryViewMIPS.cpp
+++ b/Source/ui_win32/MemoryViewMIPS.cpp
@@ -55,7 +55,7 @@ HMENU CMemoryViewMIPS::CreateContextualMenu()
 		if((selection & 0x03) == 0)
 		{
 			uint32 valueAtSelection = m_context->m_pMemoryMap->GetWord(GetSelection());
-			auto followPointerText = string_format(_T("Follow Pointer (0x%0.8X)"), valueAtSelection);
+			auto followPointerText = string_format(_T("Follow Pointer (0x%08X)"), valueAtSelection);
 			AppendMenu(menu, MF_STRING, ID_MEMORYVIEWMIPS_FOLLOWPOINTER, followPointerText.c_str());
 		}
 	}

--- a/Source/ui_win32/MemoryViewMIPSWnd.cpp
+++ b/Source/ui_win32/MemoryViewMIPSWnd.cpp
@@ -56,7 +56,7 @@ long CMemoryViewMIPSWnd::OnSysCommand(unsigned int nCmd, LPARAM lParam)
 
 void CMemoryViewMIPSWnd::UpdateStatusBar()
 {
-	auto caption = string_format(_T("Address : 0x%0.8X"), m_memoryView->GetSelection());
+	auto caption = string_format(_T("Address : 0x%08X"), m_memoryView->GetSelection());
 	m_addressEdit->SetText(caption.c_str());
 }
 

--- a/Source/ui_win32/RegViewFPU.cpp
+++ b/Source/ui_win32/RegViewFPU.cpp
@@ -45,7 +45,7 @@ std::string CRegViewFPU::RenderFCSR()
 	char sText[256];
 	std::string result;
 
-	sprintf(sText, "FCSR: 0x%0.8X\r\n", m_pCtx->m_State.nFCSR);
+	sprintf(sText, "FCSR: 0x%08X\r\n", m_pCtx->m_State.nFCSR);
 	result += sText;
 
 	sprintf(sText, "CC  : %i%i%i%i%i%i%i%ib\r\n", \
@@ -83,7 +83,7 @@ std::string CRegViewFPU::RenderWord()
 
 		uint32 nData = ((uint32*)s->nCOP1)[i];
 
-		sprintf(sText, "%s: 0x%0.8X\r\n", sReg, nData);
+		sprintf(sText, "%s: 0x%08X\r\n", sReg, nData);
 		result += sText;
 	}
 

--- a/Source/ui_win32/RegViewGeneral.cpp
+++ b/Source/ui_win32/RegViewGeneral.cpp
@@ -31,23 +31,23 @@ std::string CRegViewGeneral::GetDisplayText()
 
 	for(unsigned int i = 0; i < 32; i++)
 	{
-		sprintf(sTemp, "%s : 0x%0.8X%0.8X%0.8X%0.8X\r\n", CMIPS::m_sGPRName[i], s->nGPR[i].nV[3], s->nGPR[i].nV[2], s->nGPR[i].nV[1], s->nGPR[i].nV[0]);
+		sprintf(sTemp, "%s : 0x%08X%08X%08X%08X\r\n", CMIPS::m_sGPRName[i], s->nGPR[i].nV[3], s->nGPR[i].nV[2], s->nGPR[i].nV[1], s->nGPR[i].nV[0]);
 		displayText += sTemp;
 	}
 
-	sprintf(sTemp, "LO : 0x%0.8X%0.8X\r\n", s->nLO[1], s->nLO[0]);
+	sprintf(sTemp, "LO : 0x%08X%08X\r\n", s->nLO[1], s->nLO[0]);
 	displayText += sTemp;
 
-	sprintf(sTemp, "HI : 0x%0.8X%0.8X\r\n", s->nHI[1], s->nHI[0]);
+	sprintf(sTemp, "HI : 0x%08X%08X\r\n", s->nHI[1], s->nHI[0]);
 	displayText += sTemp;
 
-	sprintf(sTemp, "LO1: 0x%0.8X%0.8X\r\n", s->nLO1[1], s->nLO1[0]);
+	sprintf(sTemp, "LO1: 0x%08X%08X\r\n", s->nLO1[1], s->nLO1[0]);
 	displayText += sTemp;
 
-	sprintf(sTemp, "HI1: 0x%0.8X%0.8X\r\n", s->nHI1[1], s->nHI1[0]);
+	sprintf(sTemp, "HI1: 0x%08X%08X\r\n", s->nHI1[1], s->nHI1[0]);
 	displayText += sTemp;
 
-	sprintf(sTemp, "SA : 0x%0.8X\r\n", s->nSA);
+	sprintf(sTemp, "SA : 0x%08X\r\n", s->nSA);
 	displayText += sTemp;
 
 	return displayText;

--- a/Source/ui_win32/RegViewSCU.cpp
+++ b/Source/ui_win32/RegViewSCU.cpp
@@ -30,7 +30,7 @@ std::string CRegViewSCU::GetDisplayText()
 	for(unsigned int i = 0; i < 32; i++)
 	{
 		char sTemp[256];
-		sprintf(sTemp, "%10s : 0x%0.8X\r\n", CCOP_SCU::m_sRegName[i], s->nCOP0[i]);
+		sprintf(sTemp, "%10s : 0x%08X\r\n", CCOP_SCU::m_sRegName[i], s->nCOP0[i]);
 		result += sTemp;
 	}
 

--- a/Source/ui_win32/RegViewVU.cpp
+++ b/Source/ui_win32/RegViewVU.cpp
@@ -47,7 +47,7 @@ std::string CRegViewVU::GetDisplayText()
 
 		if(m_viewMode == VIEWMODE_WORD)
 		{
-			sprintf(sLine, "%s:    0x%0.8X      0x%0.8X\r\n          0x%0.8X      0x%0.8X\r\n", sReg1,
+			sprintf(sLine, "%s:    0x%08X      0x%08X\r\n          0x%08X      0x%08X\r\n", sReg1,
 				state.nCOP2[i].nV0, state.nCOP2[i].nV1,
 				state.nCOP2[i].nV2, state.nCOP2[i].nV3
 			);
@@ -71,7 +71,7 @@ std::string CRegViewVU::GetDisplayText()
 
 	if(m_viewMode == VIEWMODE_WORD)
 	{
-		sprintf(sLine, "ACC  :    0x%0.8X      0x%0.8X\r\n          0x%0.8X      0x%0.8X\r\n",
+		sprintf(sLine, "ACC  :    0x%08X      0x%08X\r\n          0x%08X      0x%08X\r\n",
 			state.nCOP2A.nV0, state.nCOP2A.nV1,
 			state.nCOP2A.nV2, state.nCOP2A.nV3
 		);
@@ -94,13 +94,13 @@ std::string CRegViewVU::GetDisplayText()
 
 	if(m_viewMode == VIEWMODE_WORD)
 	{
-		sprintf(sLine, "Q    : 0x%0.8X\r\n", state.nCOP2Q);
+		sprintf(sLine, "Q    : 0x%08X\r\n", state.nCOP2Q);
 		result += sLine;
 
-		sprintf(sLine, "I    : 0x%0.8X\r\n", state.nCOP2I);
+		sprintf(sLine, "I    : 0x%08X\r\n", state.nCOP2I);
 		result += sLine;
 
-		sprintf(sLine, "P    : 0x%0.8X\r\n", state.nCOP2P);
+		sprintf(sLine, "P    : 0x%08X\r\n", state.nCOP2P);
 		result += sLine;
 	}
 	else if(m_viewMode == VIEWMODE_SINGLE)
@@ -119,22 +119,22 @@ std::string CRegViewVU::GetDisplayText()
 		assert(false);
 	}
 
-	sprintf(sLine, "R    : %+.7e (0x%0.8X)\r\n", *reinterpret_cast<const float*>(&state.nCOP2R), state.nCOP2R);
+	sprintf(sLine, "R    : %+.7e (0x%08X)\r\n", *reinterpret_cast<const float*>(&state.nCOP2R), state.nCOP2R);
 	result += sLine;
 
-	sprintf(sLine, "MACF : 0x%0.4X\r\n", state.nCOP2MF);
+	sprintf(sLine, "MACF : 0x%04X\r\n", state.nCOP2MF);
 	result += sLine;
 
-	sprintf(sLine, "STKF : 0x%0.4X\r\n", state.nCOP2SF);
+	sprintf(sLine, "STKF : 0x%04X\r\n", state.nCOP2SF);
 	result += sLine;
 
-	sprintf(sLine, "CLIP : 0x%0.6X\r\n", state.nCOP2CF & CLIP_FLAG_MASK);
+	sprintf(sLine, "CLIP : 0x%06X\r\n", state.nCOP2CF & CLIP_FLAG_MASK);
 	result += sLine;
 
-	sprintf(sLine, "PIPE : 0x%0.4X\r\n", state.pipeTime);
+	sprintf(sLine, "PIPE : 0x%04X\r\n", state.pipeTime);
 	result += sLine;
 
-	sprintf(sLine, "PIPEQ: 0x%0.4X - %+.7e\r\n", state.pipeQ.counter, *reinterpret_cast<const float*>(&state.pipeQ.heldValue));
+	sprintf(sLine, "PIPEQ: 0x%04X - %+.7e\r\n", state.pipeQ.counter, *reinterpret_cast<const float*>(&state.pipeQ.heldValue));
 	result += sLine;
 
 	result += PrintPipeline("PIPEM:", state.pipeMac);
@@ -156,7 +156,7 @@ std::string CRegViewVU::GetDisplayText()
 			sprintf(sReg2, "VI%i ", i + 1);
 		}
 
-		sprintf(sLine, "%s: 0x%0.4X    %s: 0x%0.4X\r\n", sReg1, state.nCOP2VI[i] & 0xFFFF, sReg2, state.nCOP2VI[i + 1] & 0xFFFF);
+		sprintf(sLine, "%s: 0x%04X    %s: 0x%04X\r\n", sReg1, state.nCOP2VI[i] & 0xFFFF, sReg2, state.nCOP2VI[i + 1] & 0xFFFF);
 		result += sLine;
 	}
 
@@ -184,7 +184,7 @@ std::string CRegViewVU::PrintPipeline(const char* title, const FLAG_PIPELINE& pi
 	for(unsigned int i = 0; i < (FLAG_PIPELINE_SLOTS / 2); i++)
 	{
 		const char* front = (i == 0) ? title : "      ";
-		result += string_format("%s 0x%0.4X:0x%0.6X, 0x%0.4X:0x%0.6X\r\n", front,
+		result += string_format("%s 0x%04X:0x%06X, 0x%04X:0x%06X\r\n", front,
 			pipeTimes[(i * 2) + 0], pipeValues[(i * 2) + 0],
 			pipeTimes[(i * 2) + 1], pipeValues[(i * 2) + 1]);
 	}


### PR DESCRIPTION
Silence:"warning: '0' flag ignored with precision and ‘%X’ gnu_printf format"
more specifically on ubuntu builds.

I've kept the 2 Cleanup PR separate since this is warning silencing, while the other one is potential optimisation, if you'd like them to be the one PR, i can do that.

edit:
```
   grep -lR "%0.*X" . | awk '{print $1}' | sort -u | xargs sed -i '' -e "s/%0\.4X/%04X/g"
   grep -lR "%0.*X" . | awk '{print $1}' | sort -u | xargs sed -i '' -e "s/%0\.8X/%08X/g"
   grep -lR "%0.*X" . | awk '{print $1}' | sort -u | xargs sed -i '' -e "s/%0\.2X/%02X/g"
   grep -lR "%0.*X" . | awk '{print $1}' | sort -u | xargs sed -i '' -e "s/%0\.6X/%06X/g"
   grep -lR "%0.*X" . | awk '{print $1}' | sort -u | xargs sed -i '' -e "s/%0\.3X/%03X/g"
   grep -lR "%0.*i" . | awk '{print $1}' | sort -u | xargs sed -i '' -e "s/%0\.2i/%02i/g"
   grep -lR "%0.*d" . | awk '{print $1}' | sort -u | xargs sed -i '' -e "s/%0\.2d/%02d/g"
   grep -lR "%0.*d" . | awk '{print $1}' | sort -u | xargs sed -i '' -e "s/%0\.8d/%08d/g"
```
just wanted to update this post with how I went about replacing/removing the zero's. 