### PR TITLE
Android cleanup

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/GameInfoEditActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GameInfoEditActivity.java
@@ -69,10 +69,9 @@ public class GameInfoEditActivity extends AppCompatActivity {
 
             @Override
             public void onClick(View view) {
-                gi.removeBitmapFromMemCache(intent.getStringExtra("gameid"));
-                gi.setCoverImage(intent.getStringExtra("gameid"), viewHolder, intent.getStringExtra("cover"), false, 0);
+                gi.removeBitmapFromMemCache(intent.getStringExtra("indexid"));
+                gi.setCoverImage(intent.getStringExtra("indexid"), viewHolder, intent.getStringExtra("cover"), false, 0);
                 default_cover = true;
-
             }
         });
     }
@@ -80,7 +79,7 @@ public class GameInfoEditActivity extends AppCompatActivity {
     private void setupView() {
         ((TextView)findViewById(R.id.editText)).setText(intent.getStringExtra("title"));
         ((TextView)findViewById(R.id.editText2)).setText(intent.getStringExtra("overview"));
-        gi.setCoverImage(intent.getStringExtra("gameid"), viewHolder, intent.getStringExtra("cover"), 0);
+        gi.setCoverImage(intent.getStringExtra("indexid"), viewHolder, intent.getStringExtra("cover"), 0);
         selectedImage = null;
         default_cover =  false;
     }
@@ -152,17 +151,17 @@ public class GameInfoEditActivity extends AppCompatActivity {
                 ContentValues values = new ContentValues();
                 values.put(IndexingDB.KEY_GAMETITLE, ((TextView) findViewById(R.id.editText)).getText().toString());
                 values.put(IndexingDB.KEY_OVERVIEW, ((TextView) findViewById(R.id.editText2)).getText().toString());
-                GI.updateIndex(values, IndexingDB.KEY_ID + "=?", new String[]{intent.getStringExtra("indexid")});
-                GI.close();
                 if (intent.getStringExtra("cover") == null || intent.getStringExtra("cover").equals("404")){
                     values.put(IndexingDB.KEY_IMAGE, "200");
                 }
-                gi.removeBitmapFromMemCache(intent.getStringExtra("gameid"));
+                GI.updateIndex(values, IndexingDB.KEY_ID + "=?", new String[]{intent.getStringExtra("indexid")});
+                GI.close();
+                gi.removeBitmapFromMemCache(intent.getStringExtra("indexid"));
                 if (!default_cover && selectedImage != null){
-                    gi.removeBitmapFromMemCache(intent.getStringExtra("gameid"));
-                    gi.saveImage(intent.getStringExtra("gameid") , "-custom", selectedImage);
+                    gi.removeBitmapFromMemCache(intent.getStringExtra("indexid"));
+                    gi.saveImage(intent.getStringExtra("indexid") , "-custom", selectedImage);
                 } else if (default_cover) {
-                    gi.deleteImage(intent.getStringExtra("gameid") , "-custom");
+                    gi.deleteImage(intent.getStringExtra("indexid") , "-custom");
                 }
                 setResult(RESULT_OK, intent);
                 finish();

--- a/Source/ui_android/java/com/virtualapplications/play/GameInfoEditActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GameInfoEditActivity.java
@@ -27,7 +27,7 @@ public class GameInfoEditActivity extends AppCompatActivity {
     private Bitmap selectedImage;
     private GameInfo gi;
     private boolean default_cover;
-
+    private GamesAdapter.CoverViewHolder viewHolder;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -39,9 +39,10 @@ public class GameInfoEditActivity extends AppCompatActivity {
         intent = getIntent();
         gi = new GameInfo(this);
 
+        viewHolder = new GamesAdapter.CoverViewHolder(findViewById(R.id.coverlayout));
         setupView();
 
-        View cover = findViewById(R.id.game_icon);
+        View cover = viewHolder.gameImageView;
         cover.setOnClickListener(new View.OnClickListener() {
 
             @Override
@@ -69,7 +70,7 @@ public class GameInfoEditActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 gi.removeBitmapFromMemCache(intent.getStringExtra("gameid"));
-                gi.setCoverImage(intent.getStringExtra("gameid"), findViewById(R.id.coverlayout), intent.getStringExtra("cover"), false, 0);
+                gi.setCoverImage(intent.getStringExtra("gameid"), viewHolder, intent.getStringExtra("cover"), false, 0);
                 default_cover = true;
 
             }
@@ -79,7 +80,7 @@ public class GameInfoEditActivity extends AppCompatActivity {
     private void setupView() {
         ((TextView)findViewById(R.id.editText)).setText(intent.getStringExtra("title"));
         ((TextView)findViewById(R.id.editText2)).setText(intent.getStringExtra("overview"));
-        gi.setCoverImage(intent.getStringExtra("gameid"), findViewById(R.id.coverlayout), intent.getStringExtra("cover"), 0);
+        gi.setCoverImage(intent.getStringExtra("gameid"), viewHolder, intent.getStringExtra("cover"), 0);
         selectedImage = null;
         default_cover =  false;
     }
@@ -101,7 +102,7 @@ public class GameInfoEditActivity extends AppCompatActivity {
                         options.inJustDecodeBounds = false;
                         selectedImage = BitmapFactory.decodeStream(getContentResolver().openInputStream(imageUri), null, options);
                         default_cover = false;
-                        ((ImageView)findViewById(R.id.game_icon)).setImageBitmap(selectedImage);
+                        viewHolder.gameImageView.setImageBitmap(selectedImage);
                     } catch (FileNotFoundException e) {
                         e.printStackTrace();
                     }
@@ -115,8 +116,8 @@ public class GameInfoEditActivity extends AppCompatActivity {
         final int width = options.outWidth;
         View v = LayoutInflater.from(this).inflate(R.layout.game_list_item, null, false);
         v.measure(0, 0);
-        int reqWidth = v.findViewById(R.id.game_icon).getMeasuredWidth();
-        int reqHeight = v.findViewById(R.id.game_icon).getMeasuredHeight();
+        int reqWidth = viewHolder.gameImageView.getMeasuredWidth();
+        int reqHeight = viewHolder.gameImageView.getMeasuredHeight();
 
         // TODO: Find a calculated width and height without ImageView
         int inSampleSize = 1;

--- a/Source/ui_android/java/com/virtualapplications/play/GameInfoEditActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GameInfoEditActivity.java
@@ -69,7 +69,7 @@ public class GameInfoEditActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 gi.removeBitmapFromMemCache(intent.getStringExtra("gameid"));
-                gi.getImage(intent.getStringExtra("gameid"), findViewById(R.id.coverlayout), intent.getStringExtra("cover"), false);
+                gi.getImage(intent.getStringExtra("gameid"), findViewById(R.id.coverlayout), intent.getStringExtra("cover"), false, 0);
                 default_cover = true;
 
             }
@@ -79,7 +79,7 @@ public class GameInfoEditActivity extends AppCompatActivity {
     private void setupView() {
         ((TextView)findViewById(R.id.editText)).setText(intent.getStringExtra("title"));
         ((TextView)findViewById(R.id.editText2)).setText(intent.getStringExtra("overview"));
-        gi.getImage(intent.getStringExtra("gameid"), findViewById(R.id.coverlayout), intent.getStringExtra("cover"));
+        gi.getImage(intent.getStringExtra("gameid"), findViewById(R.id.coverlayout), intent.getStringExtra("cover"), 0);
         selectedImage = null;
         default_cover =  false;
     }

--- a/Source/ui_android/java/com/virtualapplications/play/GameInfoEditActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GameInfoEditActivity.java
@@ -69,7 +69,7 @@ public class GameInfoEditActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 gi.removeBitmapFromMemCache(intent.getStringExtra("gameid"));
-                gi.getImage(intent.getStringExtra("gameid"), findViewById(R.id.coverlayout), intent.getStringExtra("cover"), false, 0);
+                gi.setCoverImage(intent.getStringExtra("gameid"), findViewById(R.id.coverlayout), intent.getStringExtra("cover"), false, 0);
                 default_cover = true;
 
             }
@@ -79,7 +79,7 @@ public class GameInfoEditActivity extends AppCompatActivity {
     private void setupView() {
         ((TextView)findViewById(R.id.editText)).setText(intent.getStringExtra("title"));
         ((TextView)findViewById(R.id.editText2)).setText(intent.getStringExtra("overview"));
-        gi.getImage(intent.getStringExtra("gameid"), findViewById(R.id.coverlayout), intent.getStringExtra("cover"), 0);
+        gi.setCoverImage(intent.getStringExtra("gameid"), findViewById(R.id.coverlayout), intent.getStringExtra("cover"), 0);
         selectedImage = null;
         default_cover =  false;
     }

--- a/Source/ui_android/java/com/virtualapplications/play/GameInfoStruct.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GameInfoStruct.java
@@ -14,6 +14,7 @@ import java.util.Comparator;
 import java.util.List;
 
 public class GameInfoStruct {
+    private String m_Serial;
     private String m_TitleName;
     private String m_ID;
     //private final String m_Serial;
@@ -23,7 +24,7 @@ public class GameInfoStruct {
     private String m_indexID;
     private long m_lastplayed;
 
-    public GameInfoStruct(String indexid, String m_id, String m_titlename, String overview, String m_frontLink, long last_played, File file) {
+    public GameInfoStruct(String indexid, String m_id, String m_titlename, String overview, String m_frontLink, long last_played, File file, String serial) {
         m_TitleName = m_titlename;
         m_ID = m_id;
         m_Overview = overview;
@@ -31,6 +32,7 @@ public class GameInfoStruct {
         m_indexID = indexid;
         m_lastplayed = last_played;
         m_File = file;
+        m_Serial = serial;
     }
 
     public GameInfoStruct(File file) {
@@ -162,5 +164,9 @@ public class GameInfoStruct {
             GI.deleteIndex(IndexingDB.KEY_ID + "=?", new String[]{m_indexID});
             GI.close();
         }
+    }
+
+    public String getSerial() {
+        return m_Serial;
     }
 }

--- a/Source/ui_android/java/com/virtualapplications/play/GameInfoStruct.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GameInfoStruct.java
@@ -3,25 +3,19 @@ package com.virtualapplications.play;
 
 import android.content.ContentValues;
 import android.content.Context;
-import android.graphics.Bitmap;
 
-import com.virtualapplications.play.database.GameIndexer;
 import com.virtualapplications.play.database.IndexingDB;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
 
 public class GameInfoStruct {
     private String m_Serial;
     private String m_TitleName;
     private String m_ID;
-    //private final String m_Serial;
     private String m_FrontLink;
     private String m_Overview;
     private File m_File;
-    private String m_indexID;
+    private final String m_indexID;
     private long m_lastplayed;
 
     public GameInfoStruct(String indexid, String m_id, String m_titlename, String overview, String m_frontLink, long last_played, File file, String serial) {
@@ -35,10 +29,15 @@ public class GameInfoStruct {
         m_Serial = serial;
     }
 
-    public GameInfoStruct(File file) {
-        m_File = file;
-        m_TitleName = file.getName();
+    public void setTitleName(String title, Context mContext){
+        m_TitleName = title;
+        if (mContext != null){
+            IndexingDB GI = new IndexingDB(mContext);
 
+            ContentValues values = new ContentValues();
+            values.put(IndexingDB.KEY_GAMETITLE, title);
+            GI.updateIndex(values, IndexingDB.KEY_ID + "=?", new String[]{m_indexID});
+        }
     }
 
     public String getTitleName(){
@@ -55,23 +54,34 @@ public class GameInfoStruct {
         return m_TitleName == null || m_TitleName.isEmpty();
     }
 
-    public void setTitleName(String title, Context mContext){
-        m_TitleName = title;
+    //If this method is called, then IndexDB is missing GameID, so update it to reflect that
+    public void setGameID(String id, Context mContext) {
+        this.m_ID = id;
         if (mContext != null){
             IndexingDB GI = new IndexingDB(mContext);
 
             ContentValues values = new ContentValues();
-            values.put(IndexingDB.KEY_GAMETITLE, title);
+            values.put(IndexingDB.KEY_GAMEID, id);
             GI.updateIndex(values, IndexingDB.KEY_ID + "=?", new String[]{m_indexID});
+            GI.close();
         }
     }
 
     public String getGameID(){
         return m_ID;
     }
-    /*public String getSerial(){
-        return m_Serial;
-    }*/
+
+    public void setFrontLink(String frontLink, Context mContext) {
+        this.m_FrontLink = frontLink;
+        if (mContext != null){
+            IndexingDB GI = new IndexingDB(mContext);
+
+            ContentValues values = new ContentValues();
+            values.put(IndexingDB.KEY_IMAGE, frontLink);
+            GI.updateIndex(values, IndexingDB.KEY_ID + "=?", new String[]{m_indexID});
+            GI.close();
+        }
+    }
 
     public String getFrontLink() {
         return m_FrontLink;
@@ -109,9 +119,6 @@ public class GameInfoStruct {
         return m_Overview == null || m_Overview.isEmpty();
     }
 
-    public void setIndexID(String indexID) {
-        this.m_indexID = indexID;
-    }
     public void setlastplayed(Context mContext) {
         this.m_lastplayed = System.currentTimeMillis();
         if (mContext != null){
@@ -126,31 +133,6 @@ public class GameInfoStruct {
 
     public long getlastplayed() {
         return m_lastplayed;
-    }
-
-    public void setFrontLink(String frontLink, Context mContext) {
-        this.m_FrontLink = frontLink;
-        if (mContext != null){
-            IndexingDB GI = new IndexingDB(mContext);
-
-            ContentValues values = new ContentValues();
-            values.put(IndexingDB.KEY_IMAGE, frontLink);
-            GI.updateIndex(values, IndexingDB.KEY_ID + "=?", new String[]{m_indexID});
-            GI.close();
-        }
-    }
-
-    //If this method is called, then IndexDB is missing GameID, so update it to reflect that
-    public void setGameID(String id, Context mContext) {
-        this.m_ID = id;
-        if (mContext != null){
-            IndexingDB GI = new IndexingDB(mContext);
-
-            ContentValues values = new ContentValues();
-            values.put(IndexingDB.KEY_GAMEID, id);
-            GI.updateIndex(values, IndexingDB.KEY_ID + "=?", new String[]{m_indexID});
-            GI.close();
-        }
     }
 
     public String getIndexID() {

--- a/Source/ui_android/java/com/virtualapplications/play/GamesAdapter.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GamesAdapter.java
@@ -13,7 +13,6 @@ import com.virtualapplications.play.database.GameInfo;
 import java.util.List;
 
 import static com.virtualapplications.play.MainActivity.launchGame;
-import static com.virtualapplications.play.R.id.childview;
 
 public class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
 
@@ -42,7 +41,6 @@ public class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
     }
 
     public int getCount() {
-        //return mThumbIds.length;
         return games.size();
     }
 
@@ -60,7 +58,7 @@ public class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
         if (v == null) {
             LayoutInflater vi = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
             v = vi.inflate(layoutid, null);
-            viewHolder = new CoverViewHolder(v.findViewById(childview));
+            viewHolder = new CoverViewHolder(v.findViewById(R.id.childview));
             v.setTag(viewHolder);
         }
         else
@@ -99,10 +97,8 @@ public class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
             viewHolder.childview.setOnLongClickListener(null);
             viewHolder.gameImageView.setImageResource(R.drawable.boxart);
             // passing game, as to pass and use (if) any user defined values
-            gameInfo.loadGameInfo(game.getFile(), viewHolder, game, pos);
+            gameInfo.loadGameInfo(viewHolder, game, pos);
         }
-
-
 
         viewHolder.childview.setOnClickListener(new View.OnClickListener() {
             public void onClick(View view) {

--- a/Source/ui_android/java/com/virtualapplications/play/GamesAdapter.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GamesAdapter.java
@@ -97,20 +97,9 @@ public class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
             viewHolder.childview.setOnLongClickListener(null);
         } else {
             viewHolder.childview.setOnLongClickListener(null);
+            viewHolder.gameImageView.setImageResource(R.drawable.boxart);
             // passing game, as to pass and use (if) any user defined values
-            final GameInfoStruct gameStats = gameInfo.getGameInfo(game.getFile(), viewHolder, game, pos);
-
-            if (gameStats != null) {
-                games.set(pos, gameStats);
-                viewHolder.childview.setOnLongClickListener(
-                        gameInfo.configureLongClick(gameStats));
-
-                if (gameStats.getFrontLink() != null && !gameStats.getFrontLink().equals("404")) {
-                    gameInfo.setCoverImage(gameStats.getGameID(), viewHolder, gameStats.getFrontLink(), pos);
-                }
-            } else {
-                viewHolder.gameImageView.setImageResource(R.drawable.boxart);
-            }
+            gameInfo.loadGameInfo(game.getFile(), viewHolder, game, pos);
         }
 
 

--- a/Source/ui_android/java/com/virtualapplications/play/GamesAdapter.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GamesAdapter.java
@@ -1,0 +1,116 @@
+package com.virtualapplications.play;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.virtualapplications.play.database.GameInfo;
+
+import java.util.List;
+
+import static com.virtualapplications.play.MainActivity.launchGame;
+
+class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
+
+    private final int layoutid;
+    private List<GameInfoStruct> games;
+    private GameInfo gameInfo;
+
+    public GamesAdapter(Context context, int ResourceId, List<GameInfoStruct> images, GameInfo gameInfo) {
+        super(context, ResourceId, images);
+        this.games = images;
+        this.layoutid = ResourceId;
+        this.gameInfo = gameInfo;
+    }
+
+    public int getCount() {
+        //return mThumbIds.length;
+        return games.size();
+    }
+
+    public GameInfoStruct getItem(int position) {
+        return games.get(position);
+    }
+
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        View v = convertView;
+        if (v == null) {
+            LayoutInflater vi = (LayoutInflater) this.getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            v = vi.inflate(layoutid, null);
+        }
+        else
+        {
+            ((TextView) v.findViewById(R.id.game_text)).setText("");
+            ((TextView) v.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
+            ImageView preview = (ImageView) v.findViewById(R.id.game_icon);
+            preview.setImageResource(R.drawable.boxart);
+
+        }
+
+        ((TextView) v.findViewById(R.id.currentPosition)).setText(String.valueOf(position));
+
+        final GameInfoStruct game = games.get(position);
+        if (game != null) {
+            createListItem(game, v, position);
+        }
+        return v;
+    }
+
+    private View createListItem(final GameInfoStruct game, final View childview, int pos) {
+        ((TextView) childview.findViewById(R.id.game_text)).setText(game.getTitleName());
+        //If user has set values, then read them, if not read from database
+        if (!game.isDescriptionEmptyNull() && game.getFrontLink() != null && !game.getFrontLink().equals("")) {
+            childview.findViewById(R.id.childview).setOnLongClickListener(
+                    gameInfo.configureLongClick(game));
+
+            if (!game.getFrontLink().equals("404")) {
+                gameInfo.setCoverImage(game.getGameID(), childview, game.getFrontLink(), pos);
+            } else {
+                ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
+                preview.setImageResource(R.drawable.boxart);
+            }
+        } else if (VirtualMachineManager.IsLoadableExecutableFileName(game.getFile().getName())) {
+            ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
+            preview.setImageResource(R.drawable.boxart);
+            childview.findViewById(R.id.childview).setOnLongClickListener(null);
+        } else {
+            childview.findViewById(R.id.childview).setOnLongClickListener(null);
+            // passing game, as to pass and use (if) any user defined values
+            final GameInfoStruct gameStats = gameInfo.getGameInfo(game.getFile(), childview, game, pos);
+
+            if (gameStats != null) {
+                games.set(pos, gameStats);
+                childview.findViewById(R.id.childview).setOnLongClickListener(
+                        gameInfo.configureLongClick(gameStats));
+
+                if (gameStats.getFrontLink() != null && !gameStats.getFrontLink().equals("404")) {
+                    gameInfo.setCoverImage(gameStats.getGameID(), childview, gameStats.getFrontLink(), pos);
+                }
+            } else {
+                ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
+                preview.setImageResource(R.drawable.boxart);
+            }
+        }
+
+
+
+        childview.findViewById(R.id.childview).setOnClickListener(new View.OnClickListener() {
+            public void onClick(View view) {
+                launchGame(game, getContext());
+                return;
+            }
+        });
+        return childview;
+
+    }
+
+}

--- a/Source/ui_android/java/com/virtualapplications/play/GamesAdapter.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GamesAdapter.java
@@ -13,13 +13,27 @@ import com.virtualapplications.play.database.GameInfo;
 import java.util.List;
 
 import static com.virtualapplications.play.MainActivity.launchGame;
+import static com.virtualapplications.play.R.id.childview;
 
-class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
+public class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
 
     private final int layoutid;
     private List<GameInfoStruct> games;
     private GameInfo gameInfo;
 
+    public static class CoverViewHolder{
+        CoverViewHolder(View v)
+        {
+            this.childview = v;
+            this.gameImageView = (ImageView) v.findViewById(R.id.game_icon);
+            this.gameTextView = (TextView) v.findViewById(R.id.game_text);
+            this.currentPositionView = (TextView) v.findViewById(R.id.currentPosition);
+        }
+        public View childview;
+        public ImageView gameImageView;
+        public TextView gameTextView;
+        public TextView currentPositionView;
+    }
     public GamesAdapter(Context context, int ResourceId, List<GameInfoStruct> images, GameInfo gameInfo) {
         super(context, ResourceId, images);
         this.games = images;
@@ -41,76 +55,72 @@ class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
     }
 
     @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
-        View v = convertView;
+    public View getView(int position, View v, ViewGroup parent) {
+        CoverViewHolder viewHolder;
         if (v == null) {
-            LayoutInflater vi = (LayoutInflater) this.getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            LayoutInflater vi = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
             v = vi.inflate(layoutid, null);
+            viewHolder = new CoverViewHolder(v.findViewById(childview));
+            v.setTag(viewHolder);
         }
         else
         {
-            ((TextView) v.findViewById(R.id.game_text)).setText("");
-            ((TextView) v.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
-            ImageView preview = (ImageView) v.findViewById(R.id.game_icon);
-            preview.setImageResource(R.drawable.boxart);
-
+            viewHolder = (CoverViewHolder) v.getTag();
+            viewHolder.gameTextView.setText("");
+            viewHolder.gameTextView.setVisibility(View.VISIBLE);
+            viewHolder.gameImageView.setImageResource(R.drawable.boxart);
         }
 
-        ((TextView) v.findViewById(R.id.currentPosition)).setText(String.valueOf(position));
+        viewHolder.currentPositionView.setText(String.valueOf(position));
 
         final GameInfoStruct game = games.get(position);
         if (game != null) {
-            createListItem(game, v, position);
+            createListItem(game, viewHolder, position);
         }
         return v;
     }
 
-    private View createListItem(final GameInfoStruct game, final View childview, int pos) {
-        ((TextView) childview.findViewById(R.id.game_text)).setText(game.getTitleName());
+    private void createListItem(final GameInfoStruct game, final CoverViewHolder viewHolder, int pos) {
+        viewHolder.gameTextView.setText(game.getTitleName());
         //If user has set values, then read them, if not read from database
         if (!game.isDescriptionEmptyNull() && game.getFrontLink() != null && !game.getFrontLink().equals("")) {
-            childview.findViewById(R.id.childview).setOnLongClickListener(
+            viewHolder.childview.setOnLongClickListener(
                     gameInfo.configureLongClick(game));
 
             if (!game.getFrontLink().equals("404")) {
-                gameInfo.setCoverImage(game.getGameID(), childview, game.getFrontLink(), pos);
+                gameInfo.setCoverImage(game.getGameID(), viewHolder, game.getFrontLink(), pos);
             } else {
-                ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-                preview.setImageResource(R.drawable.boxart);
+                viewHolder.gameImageView.setImageResource(R.drawable.boxart);
             }
         } else if (VirtualMachineManager.IsLoadableExecutableFileName(game.getFile().getName())) {
-            ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-            preview.setImageResource(R.drawable.boxart);
-            childview.findViewById(R.id.childview).setOnLongClickListener(null);
+            viewHolder.gameImageView.setImageResource(R.drawable.boxart);
+            viewHolder.childview.setOnLongClickListener(null);
         } else {
-            childview.findViewById(R.id.childview).setOnLongClickListener(null);
+            viewHolder.childview.setOnLongClickListener(null);
             // passing game, as to pass and use (if) any user defined values
-            final GameInfoStruct gameStats = gameInfo.getGameInfo(game.getFile(), childview, game, pos);
+            final GameInfoStruct gameStats = gameInfo.getGameInfo(game.getFile(), viewHolder, game, pos);
 
             if (gameStats != null) {
                 games.set(pos, gameStats);
-                childview.findViewById(R.id.childview).setOnLongClickListener(
+                viewHolder.childview.setOnLongClickListener(
                         gameInfo.configureLongClick(gameStats));
 
                 if (gameStats.getFrontLink() != null && !gameStats.getFrontLink().equals("404")) {
-                    gameInfo.setCoverImage(gameStats.getGameID(), childview, gameStats.getFrontLink(), pos);
+                    gameInfo.setCoverImage(gameStats.getGameID(), viewHolder, gameStats.getFrontLink(), pos);
                 }
             } else {
-                ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-                preview.setImageResource(R.drawable.boxart);
+                viewHolder.gameImageView.setImageResource(R.drawable.boxart);
             }
         }
 
 
 
-        childview.findViewById(R.id.childview).setOnClickListener(new View.OnClickListener() {
+        viewHolder.childview.setOnClickListener(new View.OnClickListener() {
             public void onClick(View view) {
                 launchGame(game, getContext());
                 return;
             }
         });
-        return childview;
-
     }
 
 }

--- a/Source/ui_android/java/com/virtualapplications/play/GamesAdapter.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GamesAdapter.java
@@ -88,7 +88,7 @@ public class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
                     gameInfo.configureLongClick(game));
 
             if (!game.getFrontLink().equals("404")) {
-                gameInfo.setCoverImage(game.getGameID(), viewHolder, game.getFrontLink(), pos);
+                gameInfo.setCoverImage(game.getIndexID(), viewHolder, game.getFrontLink(), pos);
             } else {
                 viewHolder.gameImageView.setImageResource(R.drawable.boxart);
             }

--- a/Source/ui_android/java/com/virtualapplications/play/GamesAdapter.java
+++ b/Source/ui_android/java/com/virtualapplications/play/GamesAdapter.java
@@ -1,6 +1,7 @@
 package com.virtualapplications.play;
 
 import android.content.Context;
+import android.support.v7.app.AppCompatActivity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,15 +11,15 @@ import android.widget.TextView;
 
 import com.virtualapplications.play.database.GameInfo;
 
+import java.lang.ref.WeakReference;
 import java.util.List;
-
-import static com.virtualapplications.play.MainActivity.launchGame;
 
 public class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
 
     private final int layoutid;
     private List<GameInfoStruct> games;
     private GameInfo gameInfo;
+    private final WeakReference<AppCompatActivity> _activity;
 
     public static class CoverViewHolder{
         CoverViewHolder(View v)
@@ -33,11 +34,12 @@ public class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
         public TextView gameTextView;
         public TextView currentPositionView;
     }
-    public GamesAdapter(Context context, int ResourceId, List<GameInfoStruct> images, GameInfo gameInfo) {
-        super(context, ResourceId, images);
+    public GamesAdapter(AppCompatActivity activity, int ResourceId, List<GameInfoStruct> images, GameInfo gameInfo) {
+        super(activity, ResourceId, images);
         this.games = images;
         this.layoutid = ResourceId;
         this.gameInfo = gameInfo;
+        this._activity = new WeakReference<AppCompatActivity>(activity);
     }
 
     public int getCount() {
@@ -102,7 +104,13 @@ public class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
 
         viewHolder.childview.setOnClickListener(new View.OnClickListener() {
             public void onClick(View view) {
-                launchGame(game, getContext());
+                if(_activity.get() != null)
+                {
+                    if(_activity.get() instanceof MainActivity)
+                    {
+                        ((MainActivity)_activity.get()).launchGame(game);
+                    }
+                }
                 return;
             }
         });

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -478,20 +478,17 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 			//If user has set values, then read them, if not read from database
 			if (!game.isDescriptionEmptyNull() && game.getFrontLink() != null && !game.getFrontLink().equals("")) {
 				childview.findViewById(R.id.childview).setOnLongClickListener(
-						gameInfo.configureLongClick(game.getTitleName(), game.getDescription(), game));
+						gameInfo.configureLongClick(game));
 
 				if (!game.getFrontLink().equals("404")) {
 					gameInfo.setCoverImage(game.getGameID(), childview, game.getFrontLink(), pos);
-					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 				} else {
 					ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
 					preview.setImageResource(R.drawable.boxart);
-					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
 				}
 			} else if (VirtualMachineManager.IsLoadableExecutableFileName(game.getFile().getName())) {
 				ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
 				preview.setImageResource(R.drawable.boxart);
-				((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
 				childview.findViewById(R.id.childview).setOnLongClickListener(null);
 			} else {
 				childview.findViewById(R.id.childview).setOnLongClickListener(null);
@@ -501,16 +498,14 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 				if (gameStats != null) {
 					games.set(pos, gameStats);
 					childview.findViewById(R.id.childview).setOnLongClickListener(
-							gameInfo.configureLongClick(gameStats.getTitleName(), gameStats.getDescription(), game));
+							gameInfo.configureLongClick(gameStats));
 
 					if (gameStats.getFrontLink() != null && !gameStats.getFrontLink().equals("404")) {
 						gameInfo.setCoverImage(gameStats.getGameID(), childview, gameStats.getFrontLink(), pos);
-						((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 					}
 				} else {
 					ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
 					preview.setImageResource(R.drawable.boxart);
-					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
 				}
 			}
 

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -166,9 +166,9 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 		));
 	}
 
-	private static void displaySimpleMessage(String title, String message, Context context)
+	private void displaySimpleMessage(String title, String message)
 	{
-		AlertDialog.Builder builder = new AlertDialog.Builder(context);
+		AlertDialog.Builder builder = new AlertDialog.Builder(this);
 
 		builder.setTitle(title);
 		builder.setMessage(message);
@@ -186,9 +186,9 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 		dialog.show();
 	}
 
-	private static void displayGameNotFound(final GameInfoStruct game, final Context context)
+	private void displayGameNotFound(final GameInfoStruct game)
 	{
-		AlertDialog.Builder builder = new AlertDialog.Builder(context);
+		AlertDialog.Builder builder = new AlertDialog.Builder(this);
 
 		builder.setTitle(R.string.not_found);
 		builder.setMessage(R.string.game_unavailable);
@@ -197,7 +197,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 				new DialogInterface.OnClickListener() {
 					@Override
 					public void onClick(DialogInterface dialog, int id) {
-						game.removeIndex(context);
+						game.removeIndex(MainActivity.this);
 						prepareFileListView(false);
 					}
 				}
@@ -245,7 +245,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 		String timestamp = buildDateString.substring(11, buildDateString.length()).startsWith("0:") 
 				? buildDateString.replace("0:", "12:") : buildDateString;
 		String aboutMessage = String.format("Build Date: %s", timestamp);
-		displaySimpleMessage("About Play!", aboutMessage, this);
+		displaySimpleMessage("About Play!", aboutMessage);
 	}
 
 	@Override
@@ -422,16 +422,16 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 		}
 	}
 
-	public static void launchGame(GameInfoStruct game, Context context) {
+	public void launchGame(GameInfoStruct game) {
 		if (game.getFile().exists()){
-			game.setlastplayed(context);
+			game.setlastplayed(this);
 			try {
-				VirtualMachineManager.launchDisk(context, game.getFile());
+				VirtualMachineManager.launchDisk(this, game.getFile());
 			} catch (Exception e) {
-				displaySimpleMessage("Error", e.getMessage(), context);
+				displaySimpleMessage("Error", e.getMessage());
 			}
 		} else {
-			displayGameNotFound(game, context);
+			displayGameNotFound(game);
 		}
 	}
 

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -38,7 +38,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 {
 	static Activity mActivity;
 	private int currentOrientation;
-	private GameInfo gameInfo;
+	private static GameInfo gameInfo;
 	protected NavigationDrawerFragment mNavigationDrawerFragment;
 
 	private List<GameInfoStruct> currentGames = new ArrayList<>();
@@ -168,9 +168,9 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 		));
 	}
 
-	private void displaySimpleMessage(String title, String message)
+	private static void displaySimpleMessage(String title, String message, Context context)
 	{
-		AlertDialog.Builder builder = new AlertDialog.Builder(this);
+		AlertDialog.Builder builder = new AlertDialog.Builder(context);
 
 		builder.setTitle(title);
 		builder.setMessage(message);
@@ -188,9 +188,9 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 		dialog.show();
 	}
 
-	private void displayGameNotFound(final GameInfoStruct game)
+	private static void displayGameNotFound(final GameInfoStruct game, final Context context)
 	{
-		AlertDialog.Builder builder = new AlertDialog.Builder(this);
+		AlertDialog.Builder builder = new AlertDialog.Builder(context);
 
 		builder.setTitle(R.string.not_found);
 		builder.setMessage(R.string.game_unavailable);
@@ -199,7 +199,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 				new DialogInterface.OnClickListener() {
 					@Override
 					public void onClick(DialogInterface dialog, int id) {
-						game.removeIndex(getBaseContext());
+						game.removeIndex(context);
 						prepareFileListView(false);
 					}
 				}
@@ -247,7 +247,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 		String timestamp = buildDateString.substring(11, buildDateString.length()).startsWith("0:") 
 				? buildDateString.replace("0:", "12:") : buildDateString;
 		String aboutMessage = String.format("Build Date: %s", timestamp);
-		displaySimpleMessage("About Play!", aboutMessage);
+		displaySimpleMessage("About Play!", aboutMessage, this);
 	}
 
 	@Override
@@ -411,7 +411,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 				gameGrid.setNumColumns(1);
 				gameGrid.setAdapter(adapter);
 			} else {
-				GamesAdapter adapter = new GamesAdapter(this, R.layout.game_list_item, images);
+				GamesAdapter adapter = new GamesAdapter(this, R.layout.game_list_item, images, gameInfo);
 				/*
 				-1 = autofit
 				 */
@@ -424,115 +424,16 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 		}
 	}
 
-	public class GamesAdapter extends ArrayAdapter<GameInfoStruct> {
-
-		private final int layoutid;
-		private List<GameInfoStruct> games;
-		
-		public GamesAdapter(Context context, int ResourceId, List<GameInfoStruct> images) {
-			super(context, ResourceId, images);
-			this.games = images;
-			this.layoutid = ResourceId;
-		}
-
-		public int getCount() {
-			//return mThumbIds.length;
-			return games.size();
-		}
-
-		public GameInfoStruct getItem(int position) {
-			return games.get(position);
-		}
-
-		public long getItemId(int position) {
-			return position;
-		}
-		
-		@Override
-		public View getView(int position, View convertView, ViewGroup parent) {
-			View v = convertView;
-			if (v == null) {
-				LayoutInflater vi = (LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-				v = vi.inflate(layoutid, null);
-			}
-			else
-			{
-				((TextView) v.findViewById(R.id.game_text)).setText("");
-				((TextView) v.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
-				ImageView preview = (ImageView) v.findViewById(R.id.game_icon);
-				preview.setImageResource(R.drawable.boxart);
-
-			}
-
-			((TextView) v.findViewById(R.id.currentPosition)).setText(String.valueOf(position));
-
-			final GameInfoStruct game = games.get(position);
-			if (game != null) {
-				createListItem(game, v, position);
-			}
-			return v;
-		}
-
-		private View createListItem(final GameInfoStruct game, final View childview, int pos) {
-			((TextView) childview.findViewById(R.id.game_text)).setText(game.getTitleName());
-			//If user has set values, then read them, if not read from database
-			if (!game.isDescriptionEmptyNull() && game.getFrontLink() != null && !game.getFrontLink().equals("")) {
-				childview.findViewById(R.id.childview).setOnLongClickListener(
-						gameInfo.configureLongClick(game));
-
-				if (!game.getFrontLink().equals("404")) {
-					gameInfo.setCoverImage(game.getGameID(), childview, game.getFrontLink(), pos);
-				} else {
-					ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-					preview.setImageResource(R.drawable.boxart);
-				}
-			} else if (VirtualMachineManager.IsLoadableExecutableFileName(game.getFile().getName())) {
-				ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-				preview.setImageResource(R.drawable.boxart);
-				childview.findViewById(R.id.childview).setOnLongClickListener(null);
-			} else {
-				childview.findViewById(R.id.childview).setOnLongClickListener(null);
-				// passing game, as to pass and use (if) any user defined values
-				final GameInfoStruct gameStats = gameInfo.getGameInfo(game.getFile(), childview, game, pos);
-
-				if (gameStats != null) {
-					games.set(pos, gameStats);
-					childview.findViewById(R.id.childview).setOnLongClickListener(
-							gameInfo.configureLongClick(gameStats));
-
-					if (gameStats.getFrontLink() != null && !gameStats.getFrontLink().equals("404")) {
-						gameInfo.setCoverImage(gameStats.getGameID(), childview, gameStats.getFrontLink(), pos);
-					}
-				} else {
-					ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-					preview.setImageResource(R.drawable.boxart);
-				}
-			}
-
-
-
-			childview.findViewById(R.id.childview).setOnClickListener(new OnClickListener() {
-				public void onClick(View view) {
-					launchGame(game);
-					return;
-				}
-			});
-			return childview;
-
-		}
-
-	}
-	
-	public void launchGame(GameInfoStruct game) {
+	public static void launchGame(GameInfoStruct game, Context context) {
 		if (game.getFile().exists()){
-			game.setlastplayed(mActivity);
+			game.setlastplayed(context);
 			try {
-				VirtualMachineManager.launchDisk(this, game.getFile());
+				VirtualMachineManager.launchDisk(context, game.getFile());
 			} catch (Exception e) {
-				displaySimpleMessage("Error", e.getMessage());
+				displaySimpleMessage("Error", e.getMessage(), context);
 			}
 		} else {
-			((MainActivity) mActivity).displayGameNotFound(game);
+			displayGameNotFound(game, context);
 		}
 	}
 

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -231,7 +231,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 
 		if (requestCode == 1 && resultCode == RESULT_OK){
 			if (data != null){
-				gameInfo.removeBitmapFromMemCache(data.getStringExtra("gameid"));
+				gameInfo.removeBitmapFromMemCache(data.getStringExtra("indexid"));
 			}
 			prepareFileListView(false);
 		}

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -18,11 +18,9 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
 import android.view.*;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.widget.*;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.GridView;
-import android.widget.TextView;
 import android.support.v4.widget.DrawerLayout;
 import java.io.File;
 import java.text.*;
@@ -38,7 +36,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 {
 	static Activity mActivity;
 	private int currentOrientation;
-	private static GameInfo gameInfo;
+	private GameInfo gameInfo;
 	protected NavigationDrawerFragment mNavigationDrawerFragment;
 
 	private List<GameInfoStruct> currentGames = new ArrayList<>();
@@ -374,7 +372,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 		@Override
 		protected List<GameInfoStruct> doInBackground(String... paths) {
 			
-			GameIndexer GI = new GameIndexer(mActivity);
+			GameIndexer GI = new GameIndexer(MainActivity.this);
 			if (fullscan){
 				GI.fullScan();
 			} else {

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -456,6 +456,14 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 				LayoutInflater vi = (LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 				v = vi.inflate(layoutid, null);
 			}
+			else
+			{
+				((TextView) v.findViewById(R.id.game_text)).setText("");
+				((TextView) v.findViewById(R.id.game_text)).setVisibility(View.VISIBLE);
+				ImageView preview = (ImageView) v.findViewById(R.id.game_icon);
+				preview.setImageResource(R.drawable.boxart);
+
+			}
 			final GameInfoStruct game = games.get(position);
 			if (game != null) {
 				createListItem(game, v, position);

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -464,6 +464,9 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 				preview.setImageResource(R.drawable.boxart);
 
 			}
+
+			((TextView) v.findViewById(R.id.currentPosition)).setText(String.valueOf(position));
+
 			final GameInfoStruct game = games.get(position);
 			if (game != null) {
 				createListItem(game, v, position);
@@ -479,7 +482,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 						gameInfo.configureLongClick(game.getTitleName(), game.getDescription(), game));
 
 				if (!game.getFrontLink().equals("404")) {
-					gameInfo.getImage(game.getGameID(), childview, game.getFrontLink());
+					gameInfo.getImage(game.getGameID(), childview, game.getFrontLink(), pos);
 					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 				} else {
 					ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
@@ -494,7 +497,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 			} else {
 				childview.findViewById(R.id.childview).setOnLongClickListener(null);
 				// passing game, as to pass and use (if) any user defined values
-				final GameInfoStruct gameStats = gameInfo.getGameInfo(game.getFile(), childview, game);
+				final GameInfoStruct gameStats = gameInfo.getGameInfo(game.getFile(), childview, game, pos);
 
 				if (gameStats != null) {
 					games.set(pos, gameStats);
@@ -502,7 +505,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 							gameInfo.configureLongClick(gameStats.getTitleName(), gameStats.getDescription(), game));
 
 					if (gameStats.getFrontLink() != null && !gameStats.getFrontLink().equals("404")) {
-						gameInfo.getImage(gameStats.getGameID(), childview, gameStats.getFrontLink());
+						gameInfo.getImage(gameStats.getGameID(), childview, gameStats.getFrontLink(), pos);
 						((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 					}
 				} else {

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -27,7 +27,6 @@ import android.support.v4.widget.DrawerLayout;
 import java.io.File;
 import java.text.*;
 import java.util.*;
-import java.util.zip.*;
 
 import com.virtualapplications.play.database.GameIndexer;
 import com.virtualapplications.play.database.GameInfo;
@@ -482,7 +481,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 						gameInfo.configureLongClick(game.getTitleName(), game.getDescription(), game));
 
 				if (!game.getFrontLink().equals("404")) {
-					gameInfo.getImage(game.getGameID(), childview, game.getFrontLink(), pos);
+					gameInfo.setCoverImage(game.getGameID(), childview, game.getFrontLink(), pos);
 					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 				} else {
 					ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
@@ -505,7 +504,7 @@ public class MainActivity extends AppCompatActivity implements NavigationDrawerF
 							gameInfo.configureLongClick(gameStats.getTitleName(), gameStats.getDescription(), game));
 
 					if (gameStats.getFrontLink() != null && !gameStats.getFrontLink().equals("404")) {
-						gameInfo.getImage(gameStats.getGameID(), childview, gameStats.getFrontLink(), pos);
+						gameInfo.setCoverImage(gameStats.getGameID(), childview, gameStats.getFrontLink(), pos);
 						((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 					}
 				} else {

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
@@ -1,6 +1,5 @@
 package com.virtualapplications.play;
 
-import android.app.Activity;
 import android.content.SharedPreferences;
 import android.os.*;
 import android.preference.*;
@@ -11,9 +10,6 @@ import android.widget.*;
 import java.io.File;
 import java.util.*;
 import android.support.v7.widget.Toolbar;
-import android.graphics.Point;
-
-import com.virtualapplications.play.database.IndexingDB;
 
 public class SettingsActivity extends PreferenceActivity implements SharedPreferences.OnSharedPreferenceChangeListener
 {
@@ -137,12 +133,12 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 		public void onCreate(Bundle savedInstanceState)
 		{
 			super.onCreate(savedInstanceState);
-            
-            addPreferencesFromResource(R.xml.settings_ui_fragment);
+
+			addPreferencesFromResource(R.xml.settings_ui_fragment);
 
 			getPreferenceManager().findPreference(RESCAN).setOnPreferenceClickListener(this);
 			getPreferenceManager().findPreference(CLEAR_UNAVAILABLE).setOnPreferenceClickListener(this);
-            getPreferenceManager().findPreference(CLEAR_CACHE).setOnPreferenceClickListener(this);
+			getPreferenceManager().findPreference(CLEAR_CACHE).setOnPreferenceClickListener(this);
 		}
 
 		@Override

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
@@ -172,14 +172,17 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 				case RESCAN:
 					preference.getEditor().putBoolean(RESCAN, true).apply();
 					preferenceCategory.removePreference(preference);
+					Toast.makeText(getActivity(), "Rescanning storage.", Toast.LENGTH_SHORT).show();
 					return true;
 				case CLEAR_UNAVAILABLE:
 					preference.getEditor().putBoolean(CLEAR_UNAVAILABLE, true).apply();
 					preferenceCategory.removePreference(preference);
+					Toast.makeText(getActivity(), "Removing unavailable games.", Toast.LENGTH_SHORT).show();
 					return true;
 				case CLEAR_CACHE:
 					clearCoverCache();
 					preferenceCategory.removePreference(preference);
+					Toast.makeText(getActivity(), "Clearing cover cache.", Toast.LENGTH_SHORT).show();
 					return true;
 				default:
 					return false;

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
@@ -7,6 +7,8 @@ import android.preference.*;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.*;
+
+import java.io.File;
 import java.util.*;
 import android.support.v7.widget.Toolbar;
 import android.graphics.Point;
@@ -15,6 +17,8 @@ import com.virtualapplications.play.database.IndexingDB;
 
 public class SettingsActivity extends PreferenceActivity implements SharedPreferences.OnSharedPreferenceChangeListener
 {
+	public static String RESCAN = "ui.rescan";
+	public static String CLEAR_UNAVAILABLE = "clear_unavailable";
 	@Override
 	public void onCreate(Bundle savedInstanceState)
 	{
@@ -135,31 +139,23 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
             addPreferencesFromResource(R.xml.settings_ui_fragment);
 
 			final PreferenceCategory preferenceCategory = (PreferenceCategory) findPreference("ui.storage");
-			final Preference button_f = (Preference)getPreferenceManager().findPreference("ui.rescan");
+			final Preference button_f = (Preference)getPreferenceManager().findPreference(RESCAN);
 			if (button_f != null) {
 				button_f.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
 					@Override
 					public boolean onPreferenceClick(Preference arg0) {
-						MainActivity.fullStorageScan();
+						button_f.getEditor().putBoolean(RESCAN, true).apply();
 						preferenceCategory.removePreference(button_f);
 						return true;
 					}
 				});
 			}
-			final Preference button_u = (Preference)getPreferenceManager().findPreference("ui.clear_unavailable");
+			final Preference button_u = (Preference)getPreferenceManager().findPreference(CLEAR_UNAVAILABLE);
 			if (button_u != null) {
 				button_u.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
 					@Override
 					public boolean onPreferenceClick(Preference arg0) {
-						IndexingDB iDB = new IndexingDB(getActivity());
-						List<GameInfoStruct> games = iDB.getIndexGISList(MainActivity.SORT_NONE);
-						iDB.close();
-						for (GameInfoStruct game : games){
-							if (!game.getFile().exists()) {
-								game.removeIndex(getActivity());
-							}
-						}
-						MainActivity.prepareFileListView(false);
+						button_u.getEditor().putBoolean(CLEAR_UNAVAILABLE, true).apply();
 						preferenceCategory.removePreference(button_u);
 						return true;
 					}
@@ -170,7 +166,7 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
                 button_c.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                     @Override
                     public boolean onPreferenceClick(Preference arg0) {
-                        MainActivity.clearCache();
+						clearCoverCache();
 						preferenceCategory.removePreference(button_c);
                         return true;
                     }
@@ -182,6 +178,18 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 		public void onDestroy()
 		{
 			super.onDestroy();
+		}
+
+		private void clearCoverCache()
+		{
+			File dir = new File(getActivity().getExternalFilesDir(null), "covers");
+			for (File file : dir.listFiles())
+			{
+				if (!file.isDirectory())
+				{
+					file.delete();
+				}
+			}
 		}
 	}
 }

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
@@ -17,8 +17,11 @@ import com.virtualapplications.play.database.IndexingDB;
 
 public class SettingsActivity extends PreferenceActivity implements SharedPreferences.OnSharedPreferenceChangeListener
 {
-	public static String RESCAN = "ui.rescan";
-	public static String CLEAR_UNAVAILABLE = "clear_unavailable";
+	public static final String RESCAN = "ui.rescan";
+	public static final String CLEAR_UNAVAILABLE = "ui.clear_unavailable";
+	private static final String UI_STORAGE = "ui.storage";
+	private static final String CLEAR_CACHE = "ui.clearcache";
+
 	@Override
 	public void onCreate(Bundle savedInstanceState)
 	{
@@ -138,7 +141,7 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
             
             addPreferencesFromResource(R.xml.settings_ui_fragment);
 
-			final PreferenceCategory preferenceCategory = (PreferenceCategory) findPreference("ui.storage");
+			final PreferenceCategory preferenceCategory = (PreferenceCategory) findPreference(UI_STORAGE);
 			final Preference button_f = (Preference)getPreferenceManager().findPreference(RESCAN);
 			if (button_f != null) {
 				button_f.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
@@ -161,7 +164,7 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 					}
 				});
 			}
-            final Preference button_c = (Preference)getPreferenceManager().findPreference("ui.clearcache");
+            final Preference button_c = (Preference)getPreferenceManager().findPreference(CLEAR_CACHE);
             if (button_c != null) {
                 button_c.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                     @Override

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
@@ -132,8 +132,7 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 		}
 	}
 
-	public static class UISettingsFragment extends PreferenceFragment
-	{
+	public static class UISettingsFragment extends PreferenceFragment implements Preference.OnPreferenceClickListener {
 		@Override
 		public void onCreate(Bundle savedInstanceState)
 		{
@@ -141,40 +140,9 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
             
             addPreferencesFromResource(R.xml.settings_ui_fragment);
 
-			final PreferenceCategory preferenceCategory = (PreferenceCategory) findPreference(UI_STORAGE);
-			final Preference button_f = (Preference)getPreferenceManager().findPreference(RESCAN);
-			if (button_f != null) {
-				button_f.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
-					@Override
-					public boolean onPreferenceClick(Preference arg0) {
-						button_f.getEditor().putBoolean(RESCAN, true).apply();
-						preferenceCategory.removePreference(button_f);
-						return true;
-					}
-				});
-			}
-			final Preference button_u = (Preference)getPreferenceManager().findPreference(CLEAR_UNAVAILABLE);
-			if (button_u != null) {
-				button_u.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
-					@Override
-					public boolean onPreferenceClick(Preference arg0) {
-						button_u.getEditor().putBoolean(CLEAR_UNAVAILABLE, true).apply();
-						preferenceCategory.removePreference(button_u);
-						return true;
-					}
-				});
-			}
-            final Preference button_c = (Preference)getPreferenceManager().findPreference(CLEAR_CACHE);
-            if (button_c != null) {
-                button_c.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
-                    @Override
-                    public boolean onPreferenceClick(Preference arg0) {
-						clearCoverCache();
-						preferenceCategory.removePreference(button_c);
-                        return true;
-                    }
-                });
-            }
+			getPreferenceManager().findPreference(RESCAN).setOnPreferenceClickListener(this);
+			getPreferenceManager().findPreference(CLEAR_UNAVAILABLE).setOnPreferenceClickListener(this);
+            getPreferenceManager().findPreference(CLEAR_CACHE).setOnPreferenceClickListener(this);
 		}
 
 		@Override
@@ -192,6 +160,29 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 				{
 					file.delete();
 				}
+			}
+		}
+
+		@Override
+		public boolean onPreferenceClick(Preference preference)
+		{
+			final PreferenceCategory preferenceCategory = (PreferenceCategory) findPreference(UI_STORAGE);
+			switch (preference.getKey())
+			{
+				case RESCAN:
+					preference.getEditor().putBoolean(RESCAN, true).apply();
+					preferenceCategory.removePreference(preference);
+					return true;
+				case CLEAR_UNAVAILABLE:
+					preference.getEditor().putBoolean(CLEAR_UNAVAILABLE, true).apply();
+					preferenceCategory.removePreference(preference);
+					return true;
+				case CLEAR_CACHE:
+					clearCoverCache();
+					preferenceCategory.removePreference(preference);
+					return true;
+				default:
+					return false;
 			}
 		}
 	}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
@@ -1,7 +1,9 @@
 package com.virtualapplications.play.database;
 
+import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;
+import android.database.Cursor;
 import android.os.Environment;
 import android.util.Log;
 
@@ -128,7 +130,19 @@ public class GameIndexer {
                             values.put(IndexingDB.KEY_SERIAL, serial);
                             values.put(IndexingDB.KEY_SIZE, f.length());
                             values.put(IndexingDB.KEY_LAST_PLAYED, 0);
+                            if (serial != null)
+                            {
+                                ContentResolver cr = mContext.getContentResolver();
+                                Cursor c = cr.query(SqliteHelper.Games.GAMES_URI, new String[]{SqliteHelper.Games.KEY_GAMEID}, SqliteHelper.Games.KEY_SERIAL + "=?", new String[]{serial}, null);
+                                if (c != null) {
+                                    if (c.moveToFirst()) {
+                                        values.put(IndexingDB.KEY_GAMEID, c.getString(c.getColumnIndex(SqliteHelper.Games.KEY_GAMEID)));
+                                    }
+                                    c.close();
+                                }
+                            }
                             toIndex.add(values);
+
                             //Log.i("INDEX", "Name: " + name + " PATH: " + folderPath + " Serial: " + serial + " Size " + f.length());
                         }
                     }

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -208,50 +208,54 @@ public class GameInfo {
 		
 		@Override
 		protected Bitmap doInBackground(String... params) {
+			String path = mContext.getExternalFilesDir(null) + "/covers/";
 			key = params[0];
-			if (GamesDbAPI.isNetworkAvailable(mContext) && boxart != null) {
-				String api = null;
-				if (!boxart.startsWith("boxart/original/front/")) {
-					api = boxart;
-				} else if (boxart.equals("200")) {
-					//200 boxart has no link associated with it and was set by the user
-					return null;
-				} else {
-					api = "http://thegamesdb.net/banners/" + boxart;
-				}
-				InputStream im = null;
-				BufferedInputStream bis = null;
-				try {
-					URL imageURL = new URL(api);
-					URLConnection conn1 = imageURL.openConnection();
-					
-					im = conn1.getInputStream();
-					bis = new BufferedInputStream(im, 512);
-					
-					BitmapFactory.Options options = new BitmapFactory.Options();
-					options.inJustDecodeBounds = true;
-					Bitmap bitmap = BitmapFactory.decodeStream(bis, null, options);
-
-					options.inSampleSize = calculateInSampleSize(options);
-					options.inJustDecodeBounds = false;
-					bis.close();
-					im.close();
-					conn1 = imageURL.openConnection();
-					im = conn1.getInputStream();
-					bis = new BufferedInputStream(im, 512);
-					bitmap = BitmapFactory.decodeStream(bis, null, options);
-
-					saveImage(key, bitmap);
-					return bitmap;
-				} catch (IOException e) {
-					
-				} finally {
+			File file = new File(path, key + ".jpg");
+			if(!file.exists()) {
+				if (GamesDbAPI.isNetworkAvailable(mContext) && boxart != null) {
+					String api = null;
+					if (!boxart.startsWith("boxart/original/front/")) {
+						api = boxart;
+					} else if (boxart.equals("200")) {
+						//200 boxart has no link associated with it and was set by the user
+						return null;
+					} else {
+						api = "http://thegamesdb.net/banners/" + boxart;
+					}
+					InputStream im = null;
+					BufferedInputStream bis = null;
 					try {
-						im.close();
+						URL imageURL = new URL(api);
+						URLConnection conn1 = imageURL.openConnection();
+
+						im = conn1.getInputStream();
+						bis = new BufferedInputStream(im, 512);
+
+						BitmapFactory.Options options = new BitmapFactory.Options();
+						options.inJustDecodeBounds = true;
+						Bitmap bitmap = BitmapFactory.decodeStream(bis, null, options);
+
+						options.inSampleSize = calculateInSampleSize(options);
+						options.inJustDecodeBounds = false;
 						bis.close();
-						im = null;
-						bis = null;
-					} catch (IOException ex) {}
+						im.close();
+						conn1 = imageURL.openConnection();
+						im = conn1.getInputStream();
+						bis = new BufferedInputStream(im, 512);
+						bitmap = BitmapFactory.decodeStream(bis, null, options);
+
+						saveImage(key, bitmap);
+						return bitmap;
+					} catch (IOException e) {
+
+					} finally {
+						try {
+							im.close();
+							bis.close();
+							im = null;
+							bis = null;
+						} catch (IOException ex) {}
+					}
 				}
 			}
 			return null;

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -244,8 +244,12 @@ public class GameInfo {
 
 					} finally {
 						try {
-							im.close();
-							byteArrayInputStream.close();
+							if (im != null) {
+								im.close();
+							}
+							if (byteArrayInputStream != null) {
+								byteArrayInputStream.close();
+							}
 							byteArrayInputStream = null;
 							im = null;
 						} catch (IOException ex) {}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -310,12 +310,10 @@ public class GameInfo {
 			setCoverImage(game.getName(), viewHolder, null, pos);
 			return null;
 		}
-		String suffix = serial.substring(5, serial.length());
 		String gameID = null,  title = null, overview = null, boxart = null;
 		ContentResolver cr = mContext.getContentResolver();
-		String selection = Games.KEY_SERIAL + "=? OR " + Games.KEY_SERIAL + "=? OR " + Games.KEY_SERIAL + "=? OR "
-							+ Games.KEY_SERIAL + "=? OR " + Games.KEY_SERIAL + "=? OR " + Games.KEY_SERIAL + "=?";
-		String[] selectionArgs = { serial, "SLUS" + suffix, "SLES" + suffix, "SLPS" + suffix, "SLPM" + suffix, "SCES" + suffix };
+		String selection = Games.KEY_SERIAL + "=?";
+		String[] selectionArgs = { serial};
 		Cursor c = cr.query(Games.GAMES_URI, null, selection, selectionArgs, null);
 		if (c != null && c.getCount() > 0) {
 			if (c.moveToFirst()) {

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -305,11 +305,11 @@ public class GameInfo {
 		};
 	}
 	
-	public GameInfoStruct getGameInfo(File game, GamesAdapter.CoverViewHolder viewHolder, GameInfoStruct gameInfoStruct, int pos) {
+	public void loadGameInfo(File game, GamesAdapter.CoverViewHolder viewHolder, GameInfoStruct gameInfoStruct, int pos)
+	{
 		GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameInfoStruct.getGameID(), gameInfoStruct.getSerial(), gameInfoStruct, pos);
 		gameDatabase.setView(viewHolder);
 		gameDatabase.execute(game);
-		return null;
 	}
 	
 	public String getSerial(File game) {

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -27,6 +27,7 @@ import com.virtualapplications.play.GameInfoEditActivity;
 import com.virtualapplications.play.GameInfoStruct;
 import com.virtualapplications.play.GamesAdapter;
 import com.virtualapplications.play.MainActivity;
+import com.virtualapplications.play.R;
 
 import org.apache.commons.io.IOUtils;
 
@@ -72,6 +73,14 @@ public class GameInfo {
 		if (viewHolder != null && Integer.parseInt (viewHolder.currentPositionView.getText().toString()) == pos) {
 			viewHolder.gameImageView.setImageBitmap(bitmap);
 			viewHolder.gameTextView.setVisibility(View.GONE);
+		}
+	}
+
+	private void setDefaultImageViewCover(GamesAdapter.CoverViewHolder viewHolder, int pos)
+	{
+		if (viewHolder != null && Integer.parseInt (viewHolder.currentPositionView.getText().toString()) == pos) {
+			viewHolder.gameImageView.setImageResource(R.drawable.boxart);
+			viewHolder.gameTextView.setVisibility(View.VISIBLE);
 		}
 	}
 
@@ -200,11 +209,11 @@ public class GameInfo {
 			if(!file.exists()) {
 				if (GamesDbAPI.isNetworkAvailable(mContext) && boxart != null) {
 					String api = null;
-					if (!boxart.startsWith("boxart/original/front/")) {
-						api = boxart;
-					} else if (boxart.equals("200")) {
+					if (boxart.equals("200") || boxart.equals("404") ) {
 						//200 boxart has no link associated with it and was set by the user
 						return null;
+					} else if (!boxart.startsWith("boxart/original/front/")) {
+						api = boxart;
 					} else {
 						api = "http://thegamesdb.net/banners/" + boxart;
 					}
@@ -250,6 +259,10 @@ public class GameInfo {
 		protected void onPostExecute(Bitmap image) {
 			if (image != null) {
 				setImageViewCover(viewHolder, image, pos);
+			}
+			else
+			{
+				setDefaultImageViewCover(viewHolder, pos);
 			}
 		}
 	}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -34,6 +34,8 @@ import com.virtualapplications.play.MainActivity;
 import com.virtualapplications.play.NativeInterop;
 import com.virtualapplications.play.database.SqliteHelper.Games;
 
+import static com.virtualapplications.play.MainActivity.launchGame;
+
 public class GameInfo {
 	
 	private Context mContext;
@@ -278,7 +280,7 @@ public class GameInfo {
 						new DialogInterface.OnClickListener() {
 							public void onClick(DialogInterface dialog, int which) {
 								dialog.dismiss();
-								((MainActivity)mContext).launchGame(gameFile);
+								launchGame(gameFile, mContext);
 								return;
 							}
 						});

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -115,14 +115,14 @@ public class GameInfo {
 		}
 	}
 
-	public Bitmap getImage(String key, View childview, String boxart, int pos) {
-		return getImage(key,childview,boxart, true, pos);
+	public void setCoverImage(String key, View childview, String boxart, int pos) {
+		setCoverImage(key,childview,boxart, true, pos);
 	}
-	public Bitmap getImage(final String key, final View childview, String boxart, boolean custom, final int pos) {
+	public void setCoverImage(final String key, final View childview, String boxart, boolean custom, final int pos) {
 		Bitmap cachedImage = getBitmapFromMemCache(key);
 		if (cachedImage != null) {
 			setImageViewCover(childview, cachedImage, pos);
-			return cachedImage;
+			return;
 		}
 		String path = mContext.getExternalFilesDir(null) + "/covers/";
 
@@ -146,12 +146,8 @@ public class GameInfo {
 
 				}
 			}).execute();
-
-
-			return null;
 		} else {
 			new GameImage(childview, boxart, pos).execute(key);
-			return null;
 		}
 	}
 	
@@ -309,7 +305,7 @@ public class GameInfo {
 	public GameInfoStruct getGameInfo(File game, View childview, GameInfoStruct gameInfoStruct, int pos) {
 		String serial = getSerial(game);
 		if (serial == null) {
-			getImage(game.getName(), childview, null, pos);
+			setCoverImage(game.getName(), childview, null, pos);
 			return null;
 		}
 		String suffix = serial.substring(5, serial.length());

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -12,28 +12,21 @@ import java.net.URLConnection;
 
 import android.app.AlertDialog;
 import android.content.Context;
-import android.content.ContentResolver;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
 import android.os.Build;
-import android.util.Log;
 import android.util.LruCache;
 import android.view.View;
 import android.view.View.OnLongClickListener;
 import android.widget.ImageView;
-import android.widget.TextView;
 
 import com.virtualapplications.play.GameInfoEditActivity;
 import com.virtualapplications.play.GameInfoStruct;
 import com.virtualapplications.play.GamesAdapter;
-import com.virtualapplications.play.R;
 import com.virtualapplications.play.MainActivity;
-import com.virtualapplications.play.NativeInterop;
-import com.virtualapplications.play.database.SqliteHelper.Games;
 
 import org.apache.commons.io.IOUtils;
 
@@ -305,16 +298,10 @@ public class GameInfo {
 		};
 	}
 	
-	public void loadGameInfo(File game, GamesAdapter.CoverViewHolder viewHolder, GameInfoStruct gameInfoStruct, int pos)
+	public void loadGameInfo(GamesAdapter.CoverViewHolder viewHolder, GameInfoStruct gameInfoStruct, int pos)
 	{
-		GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameInfoStruct.getGameID(), gameInfoStruct.getSerial(), gameInfoStruct, pos);
+		GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameInfoStruct, pos);
 		gameDatabase.setView(viewHolder);
-		gameDatabase.execute(game);
-	}
-	
-	public String getSerial(File game) {
-		String serial = NativeInterop.getDiskId(game.getPath());
-		Log.d("Play!", game.getName() + " [" + serial + "]");
-		return serial;
+		gameDatabase.execute();
 	}
 }

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -305,52 +305,10 @@ public class GameInfo {
 	}
 	
 	public GameInfoStruct getGameInfo(File game, GamesAdapter.CoverViewHolder viewHolder, GameInfoStruct gameInfoStruct, int pos) {
-		String serial = getSerial(game);
-		if (serial == null) {
-			setCoverImage(game.getName(), viewHolder, null, pos);
-			return null;
-		}
-		String gameID = null,  title = null, overview = null, boxart = null;
-		ContentResolver cr = mContext.getContentResolver();
-		String selection = Games.KEY_SERIAL + "=?";
-		String[] selectionArgs = { serial};
-		Cursor c = cr.query(Games.GAMES_URI, null, selection, selectionArgs, null);
-		if (c != null && c.getCount() > 0) {
-			if (c.moveToFirst()) {
-				do {
-					gameID = c.getString(c.getColumnIndex(Games.KEY_GAMEID));
-					title = c.getString(c.getColumnIndex(Games.KEY_TITLE));
-					overview = c.getString(c.getColumnIndex(Games.KEY_OVERVIEW));
-					boxart = c.getString(c.getColumnIndex(Games.KEY_BOXART));
-					if (gameID != null && !gameID.equals("")) {
-						break;
-					}
-				} while (c.moveToNext());
-			}
-			c.close();
-		}
-		if (overview != null && boxart != null &&
-			!overview.equals("") && !boxart.equals("")) {
-			if (gameInfoStruct.isTitleNameEmptyNull()){
-				gameInfoStruct.setTitleName(title, mContext);
-			}
-
-			if (gameInfoStruct.isDescriptionEmptyNull()){
-				gameInfoStruct.setDescription(overview, mContext);
-			}
-			if (gameInfoStruct.getFrontLink() == null || gameInfoStruct.getFrontLink().isEmpty()){
-				gameInfoStruct.setFrontLink(boxart, mContext);
-			}
-			if (gameInfoStruct.getGameID() == null){
-				gameInfoStruct.setGameID(gameID, mContext);
-			}
-			return gameInfoStruct;
-		} else {
-			GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameID, serial, gameInfoStruct, pos);
-			gameDatabase.setView(viewHolder);
-			gameDatabase.execute(game);
-			return null;
-		}
+		GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameInfoStruct.getGameID(), gameInfoStruct.getSerial(), gameInfoStruct, pos);
+		gameDatabase.setView(viewHolder);
+		gameDatabase.execute(game);
+		return null;
 	}
 	
 	public String getSerial(File game) {

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -30,8 +30,6 @@ import com.virtualapplications.play.MainActivity;
 
 import org.apache.commons.io.IOUtils;
 
-import static com.virtualapplications.play.MainActivity.launchGame;
-
 public class GameInfo {
 	
 	private Context mContext;
@@ -274,7 +272,10 @@ public class GameInfo {
 						new DialogInterface.OnClickListener() {
 							public void onClick(DialogInterface dialog, int which) {
 								dialog.dismiss();
-								launchGame(gameFile, mContext);
+								if(mContext instanceof MainActivity)
+								{
+									((MainActivity)mContext).launchGame(gameFile);
+								}
 								return;
 							}
 						});
@@ -288,7 +289,10 @@ public class GameInfo {
 								intent.putExtra("cover",gameFile.getFrontLink());
 								intent.putExtra("gameid",gameFile.getGameID());
 								intent.putExtra("indexid",gameFile.getIndexID());
-								((MainActivity)mContext).startActivityForResult(intent, 1);
+								if(mContext instanceof MainActivity)
+								{
+									((MainActivity) mContext).startActivityForResult(intent, 1);
+								}
 								return;
 							}
 						});

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -113,10 +113,10 @@ public class GameInfo {
 		}
 	}
 
-	public Bitmap getImage(String key, View childview, String boxart) {
-		return getImage(key,childview,boxart, true);
+	public Bitmap getImage(String key, View childview, String boxart, int pos) {
+		return getImage(key,childview,boxart, true, pos);
 	}
-	public Bitmap getImage(String key, View childview, String boxart, boolean custom) {
+	public Bitmap getImage(String key, View childview, String boxart, boolean custom, int pos) {
 		Bitmap cachedImage = getBitmapFromMemCache(key);
 		if (cachedImage != null) {
 			if (childview != null) {
@@ -136,14 +136,14 @@ public class GameInfo {
 			options.inPreferredConfig = Bitmap.Config.ARGB_8888;
 			Bitmap bitmap = BitmapFactory.decodeFile(file.getAbsolutePath(), options);
             addBitmapToMemoryCache(key, bitmap);
-			if (childview != null) {
+			if (childview != null && Integer.parseInt (((TextView) childview.findViewById(R.id.currentPosition)).getText().toString()) == pos) {
 				ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
 				preview.setImageBitmap(bitmap);
 				((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 			}
 			return bitmap;
 		} else {
-			new GameImage(childview, boxart).execute(key);
+			new GameImage(childview, boxart, pos).execute(key);
 			return null;
 		}
 	}
@@ -154,10 +154,12 @@ public class GameInfo {
 		private String key;
 		private ImageView preview;
 		private String boxart;
+        private int pos;
 		
-		public GameImage(View childview, String boxart) {
+		public GameImage(View childview, String boxart, int pos) {
 			this.childview = childview;
 			this.boxart = boxart;
+            this.pos = pos;
 		}
 		
 		protected void onPreExecute() {
@@ -245,7 +247,7 @@ public class GameInfo {
 		protected void onPostExecute(Bitmap image) {
 			if (image != null) {
 				saveImage(key, image);
-				if (preview != null) {
+                if (childview != null && Integer.parseInt (((TextView) childview.findViewById(R.id.currentPosition)).getText().toString()) == pos) {
 					preview.setImageBitmap(image);
 					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 				}
@@ -295,10 +297,10 @@ public class GameInfo {
 		};
 	}
 	
-	public GameInfoStruct getGameInfo(File game, View childview, GameInfoStruct gameInfoStruct) {
+	public GameInfoStruct getGameInfo(File game, View childview, GameInfoStruct gameInfoStruct, int pos) {
 		String serial = getSerial(game);
 		if (serial == null) {
-			getImage(game.getName(), childview, null);
+			getImage(game.getName(), childview, null, pos);
 			return null;
 		}
 		String suffix = serial.substring(5, serial.length());
@@ -339,7 +341,7 @@ public class GameInfo {
 			}
 			return gameInfoStruct;
 		} else {
-			GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameID, serial, gameInfoStruct);
+			GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameID, serial, gameInfoStruct, pos);
 			gameDatabase.setView(childview);
 			gameDatabase.execute(game);
 			return null;

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -29,6 +29,7 @@ import android.widget.TextView;
 
 import com.virtualapplications.play.GameInfoEditActivity;
 import com.virtualapplications.play.GameInfoStruct;
+import com.virtualapplications.play.GamesAdapter;
 import com.virtualapplications.play.R;
 import com.virtualapplications.play.MainActivity;
 import com.virtualapplications.play.NativeInterop;
@@ -73,12 +74,11 @@ public class GameInfo {
 		return mMemoryCache.remove(key);
 	}
 
-	private void setImageViewCover(View childview, Bitmap bitmap, int pos)
+	private void setImageViewCover(GamesAdapter.CoverViewHolder viewHolder, Bitmap bitmap, int pos)
 	{
-		if (childview != null && Integer.parseInt (((TextView) childview.findViewById(R.id.currentPosition)).getText().toString()) == pos) {
-			ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-			preview.setImageBitmap(bitmap);
-			childview.findViewById(R.id.game_text).setVisibility(View.GONE);
+		if (viewHolder != null && Integer.parseInt (viewHolder.currentPositionView.getText().toString()) == pos) {
+			viewHolder.gameImageView.setImageBitmap(bitmap);
+			viewHolder.gameTextView.setVisibility(View.GONE);
 		}
 	}
 
@@ -117,13 +117,13 @@ public class GameInfo {
 		}
 	}
 
-	public void setCoverImage(String key, View childview, String boxart, int pos) {
-		setCoverImage(key,childview,boxart, true, pos);
+	public void setCoverImage(String key, GamesAdapter.CoverViewHolder viewHolder, String boxart, int pos) {
+		setCoverImage(key,viewHolder,boxart, true, pos);
 	}
-	public void setCoverImage(final String key, final View childview, String boxart, boolean custom, final int pos) {
+	public void setCoverImage(final String key, final GamesAdapter.CoverViewHolder viewHolder, String boxart, boolean custom, final int pos) {
 		Bitmap cachedImage = getBitmapFromMemCache(key);
 		if (cachedImage != null) {
-			setImageViewCover(childview, cachedImage, pos);
+			setImageViewCover(viewHolder, cachedImage, pos);
 			return;
 		}
 		String path = mContext.getExternalFilesDir(null) + "/covers/";
@@ -144,32 +144,32 @@ public class GameInfo {
 				}
 				@Override
 				protected void onPostExecute(Bitmap bitmap) {
-					setImageViewCover(childview, bitmap, pos);
+					setImageViewCover(viewHolder, bitmap, pos);
 
 				}
 			}).execute();
 		} else {
-			new GameImage(childview, boxart, pos).execute(key);
+			new GameImage(viewHolder, boxart, pos).execute(key);
 		}
 	}
 	
 	public class GameImage extends AsyncTask<String, Integer, Bitmap> {
 		
-		private View childview;
+		private GamesAdapter.CoverViewHolder viewHolder;
 		private String key;
 		private ImageView preview;
 		private String boxart;
         private int pos;
 		
-		public GameImage(View childview, String boxart, int pos) {
-			this.childview = childview;
+		public GameImage(GamesAdapter.CoverViewHolder viewHolder, String boxart, int pos) {
+			this.viewHolder = viewHolder;
 			this.boxart = boxart;
             this.pos = pos;
 		}
 		
 		protected void onPreExecute() {
-			if (childview != null) {
-				preview = (ImageView) childview.findViewById(R.id.game_icon);
+			if (viewHolder != null) {
+				preview = viewHolder.gameImageView;
 			}
 		}
 		
@@ -257,7 +257,7 @@ public class GameInfo {
 		@Override
 		protected void onPostExecute(Bitmap image) {
 			if (image != null) {
-				setImageViewCover(childview, image, pos);
+				setImageViewCover(viewHolder, image, pos);
 			}
 		}
 	}
@@ -304,10 +304,10 @@ public class GameInfo {
 		};
 	}
 	
-	public GameInfoStruct getGameInfo(File game, View childview, GameInfoStruct gameInfoStruct, int pos) {
+	public GameInfoStruct getGameInfo(File game, GamesAdapter.CoverViewHolder viewHolder, GameInfoStruct gameInfoStruct, int pos) {
 		String serial = getSerial(game);
 		if (serial == null) {
-			setCoverImage(game.getName(), childview, null, pos);
+			setCoverImage(game.getName(), viewHolder, null, pos);
 			return null;
 		}
 		String suffix = serial.substring(5, serial.length());
@@ -349,7 +349,7 @@ public class GameInfo {
 			return gameInfoStruct;
 		} else {
 			GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameID, serial, gameInfoStruct, pos);
-			gameDatabase.setView(childview);
+			gameDatabase.setView(viewHolder);
 			gameDatabase.execute(game);
 			return null;
 		}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -260,13 +260,13 @@ public class GameInfo {
 		}
 	}
 	
-	public OnLongClickListener configureLongClick(final String title, final String overview, final GameInfoStruct gameFile) {
+	public OnLongClickListener configureLongClick(final GameInfoStruct gameFile) {
 		return new OnLongClickListener() {
 			public boolean onLongClick(View view) {
 				final AlertDialog.Builder builder = new AlertDialog.Builder(mContext);
 				builder.setCancelable(true);
-				builder.setTitle(title);
-				builder.setMessage(overview);
+				builder.setTitle(gameFile.getTitleName());
+				builder.setMessage(gameFile.getDescription());
 				builder.setNegativeButton("Close",
 						new DialogInterface.OnClickListener() {
 							public void onClick(DialogInterface dialog, int which) {

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -147,7 +147,7 @@ public class GameInfo {
 					setImageViewCover(viewHolder, bitmap, pos);
 
 				}
-			}).execute();
+			}).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
 		} else {
 			new GameImage(viewHolder, boxart, pos).execute(key);
 		}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -20,18 +20,12 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
 import android.os.Build;
-import android.os.StrictMode;
 import android.util.Log;
 import android.util.LruCache;
-import android.util.SparseArray;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
 import android.widget.ImageView;
-import android.widget.ImageView.ScaleType;
 import android.widget.TextView;
-
-import java.util.concurrent.ExecutionException;
 
 import com.virtualapplications.play.GameInfoEditActivity;
 import com.virtualapplications.play.GameInfoStruct;
@@ -77,6 +71,14 @@ public class GameInfo {
 		return mMemoryCache.remove(key);
 	}
 
+	private void setImageViewCover(View childview, Bitmap bitmap, int pos)
+	{
+		if (childview != null && Integer.parseInt (((TextView) childview.findViewById(R.id.currentPosition)).getText().toString()) == pos) {
+			ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
+			preview.setImageBitmap(bitmap);
+			childview.findViewById(R.id.game_text).setVisibility(View.GONE);
+		}
+	}
 
 	public void saveImage(String key, Bitmap image) {
 		saveImage(key, "", image);
@@ -119,11 +121,7 @@ public class GameInfo {
 	public Bitmap getImage(final String key, final View childview, String boxart, boolean custom, final int pos) {
 		Bitmap cachedImage = getBitmapFromMemCache(key);
 		if (cachedImage != null) {
-			if (childview != null) {
-				ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-				preview.setImageBitmap(cachedImage);
-				((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
-			}
+			setImageViewCover(childview, cachedImage, pos);
 			return cachedImage;
 		}
 		String path = mContext.getExternalFilesDir(null) + "/covers/";
@@ -144,11 +142,8 @@ public class GameInfo {
 				}
 				@Override
 				protected void onPostExecute(Bitmap bitmap) {
-					if (childview != null && Integer.parseInt (((TextView) childview.findViewById(R.id.currentPosition)).getText().toString()) == pos) {
-						ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-						preview.setImageBitmap(bitmap);
-						((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
-					}
+					setImageViewCover(childview, bitmap, pos);
+
 				}
 			}).execute();
 
@@ -264,10 +259,7 @@ public class GameInfo {
 		@Override
 		protected void onPostExecute(Bitmap image) {
 			if (image != null) {
-                if (childview != null && Integer.parseInt (((TextView) childview.findViewById(R.id.currentPosition)).getText().toString()) == pos) {
-					preview.setImageBitmap(image);
-					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
-				}
+				setImageViewCover(childview, image, pos);
 			}
 		}
 	}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -130,18 +130,18 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 
 	@Override
 	protected void onPostExecute(Document doc) {
-		
+
 		if (doc != null && doc.getElementsByTagName("Game") != null) {
 			try {
 				final Element root = (Element) doc.getElementsByTagName("Game").item(0);
 				final String remoteID = getValue(root, "id");
-				
+
 				ContentResolver cr = mContext.getContentResolver();
 				String selection = Games.KEY_GAMEID + "=?";
 				String[] selectionArgs = { remoteID };
 				Cursor c = cr.query(Games.GAMES_URI, null, selection, selectionArgs, null);
 				String dataID = null;
-				
+
 				if (elastic) {
 					if (c != null && c.getCount() > 0) {
 						if (c.moveToFirst()) {
@@ -155,6 +155,9 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 									if (gameInfoStruct.getGameID() == null){
 										gameInfoStruct.setGameID(dataID, null);
 									}
+									if (gameInfoStruct.isTitleNameEmptyNull()){
+										gameInfoStruct.setTitleName(title, null);
+									}
 									if (gameInfoStruct.isDescriptionEmptyNull()){
 										gameInfoStruct.setDescription(overview, null);
 									}
@@ -163,9 +166,9 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 									}
 									if (childview != null) {
 										childview.findViewById(R.id.childview).setOnLongClickListener(
-											gameInfo.configureLongClick(title, overview, gameInfoStruct));
+											gameInfo.configureLongClick(gameInfoStruct));
 										if (boxart != null) {
-											gameInfo.setCoverImage(remoteID, childview, boxart, pos);
+											gameInfo.setCoverImage(gameInfoStruct.getGameID(), childview, gameInfoStruct.getFrontLink(), pos);
 										}
 									}
 									break;
@@ -234,9 +237,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 					if (gameInfoStruct.getGameID() == null){
 						gameInfoStruct.setGameID(remoteID, null);
 					}
-					if (!gameInfoStruct.isTitleNameEmptyNull()){
-						m_title = gameInfoStruct.getTitleName();
-					} else {
+					if (gameInfoStruct.isTitleNameEmptyNull()){
 						gameInfoStruct.setTitleName(m_title, null);
 					}
 					if (gameInfoStruct.isDescriptionEmptyNull()){
@@ -248,14 +249,14 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 
 					if (childview != null) {
 						childview.findViewById(R.id.childview).setOnLongClickListener(
-								gameInfo.configureLongClick(m_title, overview, gameInfoStruct));
-						if (coverImage != null) {
-							gameInfo.setCoverImage(remoteID, childview, coverImage, pos);
+								gameInfo.configureLongClick(gameInfoStruct));
+						if (gameInfoStruct.getFrontLink() != null) {
+							gameInfo.setCoverImage(gameInfoStruct.getGameID(), childview, gameInfoStruct.getFrontLink(), pos);
 						}
 					}
 				}
 			} catch (Exception e) {
-				
+
 			}
 		}
 	}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -55,7 +55,6 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 	private static final String games_url = "http://thegamesdb.net/api/GetGamesList.php?platform=sony+playstation+2&name=";
     private static final String games_url_id = "http://thegamesdb.net/api/GetGame.php?platform=sony+playstation+2&id=";
 	private static final String games_list = "http://thegamesdb.net/api/GetPlatformGames.php?platform=11";
-	private boolean _terminate = true;
 
 	public GamesDbAPI(Context mContext, String gameID, String serial, GameInfoStruct gameInfoStruct, int pos) {
 		this.elastic = false;
@@ -117,8 +116,8 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 
 							if (elastic) {
 								this.gameID = remoteID;
-								_terminate = false;
-								return false;
+								this.elastic = false;
+								return doInBackground(gameFile);
 							} else {
 								final String title = getValue(root, "GameTitle");
 								final String overview = getValue(root, "Overview");
@@ -186,12 +185,6 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 					gameInfo.setCoverImage(gameInfoStruct.getGameID(), viewHolder, gameInfoStruct.getFrontLink(), pos);
 				}
 			}
-		}
-		else if(!_terminate)
-		{
-			GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameID, serial, this.gameInfoStruct, pos);
-			gameDatabase.setView(viewHolder);
-			gameDatabase.execute(gameFile);
 		}
 	}
 

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -186,6 +186,18 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 				}
 			}
 		}
+		else
+		{
+			if (gameInfoStruct.isTitleNameEmptyNull()){
+				gameInfoStruct.setTitleName(gameInfoStruct.getFile().getName(), mContext);
+			}
+			if (gameInfoStruct.isDescriptionEmptyNull()){
+				gameInfoStruct.setDescription("No Game Description Found", mContext);
+			}
+			if (gameInfoStruct.getFrontLink() == null || gameInfoStruct.getFrontLink().isEmpty()){
+					gameInfoStruct.setFrontLink("404", mContext);
+			}
+		}
 	}
 
 	public static boolean isNetworkAvailable(Context mContext) {

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -42,6 +42,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 
 	private final String serial;
 	private final GameInfoStruct gameInfoStruct;
+	private final int pos;
 	private int index;
 	private View childview;
 	private Context mContext;
@@ -54,11 +55,12 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
     private static final String games_url_id = "http://thegamesdb.net/api/GetGame.php?platform=sony+playstation+2&id=";
 	private static final String games_list = "http://thegamesdb.net/api/GetPlatformGames.php?platform=11";
 
-	public GamesDbAPI(Context mContext, String gameID, String serial, GameInfoStruct gameInfoStruct) {
+	public GamesDbAPI(Context mContext, String gameID, String serial, GameInfoStruct gameInfoStruct, int pos) {
 		this.elastic = false;
 		this.mContext = mContext;
 		this.gameID = gameID;
 		this.serial = serial;
+		this.pos = pos;
 		this.gameInfoStruct = gameInfoStruct;
 	}
 	
@@ -163,7 +165,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 										childview.findViewById(R.id.childview).setOnLongClickListener(
 											gameInfo.configureLongClick(title, overview, gameInfoStruct));
 										if (boxart != null) {
-											gameInfo.getImage(remoteID, childview, boxart);
+											gameInfo.getImage(remoteID, childview, boxart, pos);
 										}
 									}
 									break;
@@ -173,7 +175,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 					}
 					c.close();
 					if (dataID == null) {
-						GamesDbAPI gameDatabase = new GamesDbAPI(mContext, remoteID, serial, gameInfoStruct);
+						GamesDbAPI gameDatabase = new GamesDbAPI(mContext, remoteID, serial, gameInfoStruct, pos);
 						gameDatabase.setView(childview);
 						gameDatabase.execute(gameFile);
 					}
@@ -248,7 +250,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 						childview.findViewById(R.id.childview).setOnLongClickListener(
 								gameInfo.configureLongClick(m_title, overview, gameInfoStruct));
 						if (coverImage != null) {
-							gameInfo.getImage(remoteID, childview, coverImage);
+							gameInfo.getImage(remoteID, childview, coverImage, pos);
 						}
 					}
 				}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -22,33 +22,24 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import android.content.Context;
-import android.content.ContentValues;
-import android.content.ContentResolver;
-import android.database.Cursor;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.StrictMode;
 import android.util.Log;
-import android.view.View;
 
 import com.virtualapplications.play.Constants;
 import com.virtualapplications.play.GameInfoStruct;
 import com.virtualapplications.play.GamesAdapter;
-import com.virtualapplications.play.R;
-import com.virtualapplications.play.database.SqliteHelper.Games;
 
 public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 
-	private final String serial;
 	private final GameInfoStruct gameInfoStruct;
 	private final int pos;
-	private int index;
 	private GamesAdapter.CoverViewHolder viewHolder;
 	private Context mContext;
 	private String gameID;
-	private File gameFile;
 	private GameInfo gameInfo;
 	private boolean elastic;
 
@@ -56,11 +47,10 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
     private static final String games_url_id = "http://thegamesdb.net/api/GetGame.php?platform=sony+playstation+2&id=";
 	private static final String games_list = "http://thegamesdb.net/api/GetPlatformGames.php?platform=11";
 
-	public GamesDbAPI(Context mContext, String gameID, String serial, GameInfoStruct gameInfoStruct, int pos) {
+	public GamesDbAPI(Context mContext, GameInfoStruct gameInfoStruct, int pos) {
 		this.elastic = false;
 		this.mContext = mContext;
-		this.gameID = gameID;
-		this.serial = serial;
+		this.gameID = gameInfoStruct.getGameID();
 		this.pos = pos;
 		this.gameInfoStruct = gameInfoStruct;
 	}
@@ -84,9 +74,8 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 		if (GamesDbAPI.isNetworkAvailable(mContext)) {
 			try {
 				URL requestUrl;
-				if (params[0] != null) {
-					gameFile = params[0];
-					String filename = gameFile.getName();
+				if (gameInfoStruct.getFile() != null) {
+					String filename = gameInfoStruct.getFile().getName();
 					if (gameID != null) {
 						requestUrl = new URL(games_url_id + gameID);
 					} else {
@@ -117,7 +106,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 							if (elastic) {
 								this.gameID = remoteID;
 								this.elastic = false;
-								return doInBackground(gameFile);
+								return doInBackground();
 							} else {
 								final String title = getValue(root, "GameTitle");
 								final String overview = getValue(root, "Overview");
@@ -133,7 +122,6 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 								if (boxart != null) {
 									coverImage = getElementValue(boxart);
 								}
-
 
 								if (gameInfoStruct.getGameID() == null){
 									gameInfoStruct.setGameID(remoteID, mContext);
@@ -177,7 +165,8 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 
 	@Override
 	protected void onPostExecute(Boolean status) {
-		if (status) {
+		if (status)
+		{
 			if (viewHolder != null) {
 				viewHolder.childview.setOnLongClickListener(
 						gameInfo.configureLongClick(gameInfoStruct));

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -35,6 +35,7 @@ import android.view.View;
 
 import com.virtualapplications.play.Constants;
 import com.virtualapplications.play.GameInfoStruct;
+import com.virtualapplications.play.GamesAdapter;
 import com.virtualapplications.play.R;
 import com.virtualapplications.play.database.SqliteHelper.Games;
 
@@ -44,7 +45,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 	private final GameInfoStruct gameInfoStruct;
 	private final int pos;
 	private int index;
-	private View childview;
+	private GamesAdapter.CoverViewHolder viewHolder;
 	private Context mContext;
 	private String gameID;
 	private File gameFile;
@@ -65,8 +66,8 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 		this.gameInfoStruct = gameInfoStruct;
 	}
 	
-	public void setView(View childview) {
-		this.childview = childview;
+	public void setView(GamesAdapter.CoverViewHolder viewHolder) {
+		this.viewHolder = viewHolder;
 	}
 
 	protected void onPreExecute() {
@@ -247,18 +248,18 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 	@Override
 	protected void onPostExecute(Boolean status) {
 		if (status) {
-			if (childview != null) {
-				childview.findViewById(R.id.childview).setOnLongClickListener(
+			if (viewHolder != null) {
+				viewHolder.childview.setOnLongClickListener(
 						gameInfo.configureLongClick(gameInfoStruct));
 				if (gameInfoStruct.getFrontLink() != null) {
-					gameInfo.setCoverImage(gameInfoStruct.getGameID(), childview, gameInfoStruct.getFrontLink(), pos);
+					gameInfo.setCoverImage(gameInfoStruct.getGameID(), viewHolder, gameInfoStruct.getFrontLink(), pos);
 				}
 			}
 		}
 		else if(!_terminate)
 		{
 			GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameID, serial, this.gameInfoStruct, pos);
-			gameDatabase.setView(childview);
+			gameDatabase.setView(viewHolder);
 			gameDatabase.execute(gameFile);
 		}
 	}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -171,7 +171,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 				viewHolder.childview.setOnLongClickListener(
 						gameInfo.configureLongClick(gameInfoStruct));
 				if (gameInfoStruct.getFrontLink() != null) {
-					gameInfo.setCoverImage(gameInfoStruct.getGameID(), viewHolder, gameInfoStruct.getFrontLink(), pos);
+					gameInfo.setCoverImage(gameInfoStruct.getIndexID(), viewHolder, gameInfoStruct.getFrontLink(), pos);
 				}
 			}
 		}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -132,16 +132,16 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 													!overview.equals("") && !boxart.equals("")) {
 												dataID = c.getString(c.getColumnIndex(Games.KEY_GAMEID));
 												if (gameInfoStruct.getGameID() == null){
-													gameInfoStruct.setGameID(dataID, null);
+													gameInfoStruct.setGameID(dataID, mContext);
 												}
 												if (gameInfoStruct.isTitleNameEmptyNull()){
-													gameInfoStruct.setTitleName(title, null);
+													gameInfoStruct.setTitleName(title, mContext);
 												}
 												if (gameInfoStruct.isDescriptionEmptyNull()){
-													gameInfoStruct.setDescription(overview, null);
+													gameInfoStruct.setDescription(overview, mContext);
 												}
 												if (gameInfoStruct.getFrontLink() == null || gameInfoStruct.getFrontLink().isEmpty()){
-													gameInfoStruct.setFrontLink(boxart, null);
+													gameInfoStruct.setFrontLink(boxart, mContext);
 												}
 												c.close();
 												return true;
@@ -208,16 +208,16 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean> {
 								String m_title = getValue(root, "GameTitle");
 
 								if (gameInfoStruct.getGameID() == null){
-									gameInfoStruct.setGameID(remoteID, null);
+									gameInfoStruct.setGameID(remoteID, mContext);
 								}
 								if (gameInfoStruct.isTitleNameEmptyNull()){
-									gameInfoStruct.setTitleName(m_title, null);
+									gameInfoStruct.setTitleName(m_title, mContext);
 								}
 								if (gameInfoStruct.isDescriptionEmptyNull()){
-									gameInfoStruct.setDescription(overview, null);
+									gameInfoStruct.setDescription(overview, mContext);
 								}
 								if (gameInfoStruct.getFrontLink() == null || gameInfoStruct.getFrontLink().isEmpty()){
-									gameInfoStruct.setFrontLink(coverImage, null);
+									gameInfoStruct.setFrontLink(coverImage, mContext);
 								}
 
 								return true;

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -165,7 +165,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 										childview.findViewById(R.id.childview).setOnLongClickListener(
 											gameInfo.configureLongClick(title, overview, gameInfoStruct));
 										if (boxart != null) {
-											gameInfo.getImage(remoteID, childview, boxart, pos);
+											gameInfo.setCoverImage(remoteID, childview, boxart, pos);
 										}
 									}
 									break;
@@ -250,7 +250,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 						childview.findViewById(R.id.childview).setOnLongClickListener(
 								gameInfo.configureLongClick(m_title, overview, gameInfoStruct));
 						if (coverImage != null) {
-							gameInfo.getImage(remoteID, childview, coverImage, pos);
+							gameInfo.setCoverImage(remoteID, childview, coverImage, pos);
 						}
 					}
 				}

--- a/Source/ui_android/java/com/virtualapplications/play/database/IndexingDB.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/IndexingDB.java
@@ -202,6 +202,18 @@ public class IndexingDB extends SQLiteOpenHelper {
     }
 
 
+    public void RemoveUnavailable()
+    {
+        List<GameInfoStruct> games = getIndexGISList(MainActivity.SORT_NONE);
+        for (GameInfoStruct game : games)
+        {
+            if (!game.getFile().exists())
+            {
+                deleteIndex(IndexingDB.KEY_ID + "=?", new String[]{game.getIndexID()});
+            }
+        }
+    }
+
     public int getIndexCount() {
         SQLiteDatabase db = this.getReadableDatabase();
 

--- a/Source/ui_android/java/com/virtualapplications/play/database/IndexingDB.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/IndexingDB.java
@@ -176,8 +176,9 @@ public class IndexingDB extends SQLiteOpenHelper {
                     String OverView = cursor.getString(cursor.getColumnIndex(KEY_OVERVIEW));
                     String Path = cursor.getString(cursor.getColumnIndex(KEY_PATH));
                     String DiskName = cursor.getString(cursor.getColumnIndex(KEY_DISKNAME));
+                    String Serial = cursor.getString(cursor.getColumnIndex(KEY_SERIAL));
                     long last_played = cursor.getLong(cursor.getColumnIndex(KEY_LAST_PLAYED));
-                    GameInfoStruct values = new GameInfoStruct(IndexID, GameID, GameTitle, OverView, FrontCoverLink, last_played, new File(Path, DiskName));
+                    GameInfoStruct values = new GameInfoStruct(IndexID, GameID, GameTitle, OverView, FrontCoverLink, last_played, new File(Path, DiskName), Serial);
                     IndexList.add(values);
                 } while (cursor.moveToNext());
             }

--- a/Source/ui_android/java/com/virtualapplications/play/database/SqliteHelper.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/SqliteHelper.java
@@ -24,9 +24,7 @@ public class SqliteHelper {
 		public static final String TABLE_ID = "_id";
 		public static final String KEY_GAMEID = "GameID";
 		public static final String KEY_TITLE = "GameTitle";
-		public static final String KEY_OVERVIEW = "Overview";
 		public static final String KEY_SERIAL = "Serial";
-		public static final String KEY_BOXART = "Boxart";
 	}
 	
 	public static final class Covers implements BaseColumns {

--- a/Source/ui_android/java/com/virtualapplications/play/database/TheGamesDB.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/TheGamesDB.java
@@ -18,7 +18,6 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.IOException;

--- a/Source/ui_android/java/com/virtualapplications/play/database/TheGamesDB.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/TheGamesDB.java
@@ -66,9 +66,7 @@ public class TheGamesDB extends ContentProvider {
 					   + Games.TABLE_ID + " INTEGER PRIMARY KEY AUTOINCREMENT,"
 					   + Games.KEY_GAMEID + " VARCHAR(255),"
 					   + Games.KEY_TITLE + " VARCHAR(255),"
-					   + Games.KEY_OVERVIEW + " VARCHAR(255),"
-					   + Games.KEY_SERIAL + " VARCHAR(255),"
-					   + Games.KEY_BOXART + " VARCHAR(255)"+ ");");
+					   + Games.KEY_SERIAL + " VARCHAR(255)"+ ");");
 
 			db.execSQL("CREATE TABLE " + Covers.TABLE_NAME + " ("
 					   + Covers.TABLE_ID + " INTEGER PRIMARY KEY AUTOINCREMENT,"
@@ -127,7 +125,7 @@ public class TheGamesDB extends ContentProvider {
 		}
 
 		db.beginTransaction();
-		SQLiteStatement stmt = db.compileStatement("INSERT INTO "+ TABLE_NAME + "(" +Games.KEY_GAMEID + " ," + Games.KEY_TITLE + "," + Games.KEY_OVERVIEW + "," + Games.KEY_SERIAL + "," + Games.KEY_BOXART + ") VALUES(?,?,?,?,?)");
+		SQLiteStatement stmt = db.compileStatement("INSERT INTO "+ TABLE_NAME + "(" + Games.KEY_GAMEID +  "," + Games.KEY_TITLE +  "," +  Games.KEY_SERIAL + ") VALUES(?,?,?)");
 
 		int numInserted = 0;
 		try {
@@ -138,26 +136,15 @@ public class TheGamesDB extends ContentProvider {
 				if (KEY_GAMEID != null) {
 					stmt.bindString(1, KEY_GAMEID);
 				}
-
 				String KEY_TITLE = (String)(value.get(Games.KEY_TITLE));
 				if (KEY_TITLE != null) {
 					stmt.bindString(2, KEY_TITLE);
 				}
-
-				String KEY_OVERVIEW = (String)(value.get(Games.KEY_OVERVIEW));
-				if (KEY_OVERVIEW != null) {
-					stmt.bindString(3, KEY_OVERVIEW);
-				}
-
 				String KEY_SERIAL = (String)(value.get(Games.KEY_SERIAL));
 				if (KEY_SERIAL != null) {
-					stmt.bindString(4, KEY_SERIAL);
+					stmt.bindString(3, KEY_SERIAL);
 				}
 
-				String KEY_BOXART = (String)(value.get(Games.KEY_BOXART));
-				if (KEY_BOXART != null) {
-					stmt.bindString(5, KEY_BOXART);
-				}
 
 				stmt.execute();
 				stmt.clearBindings();
@@ -213,9 +200,7 @@ public class TheGamesDB extends ContentProvider {
 						ContentValues game = new ContentValues();
 						game.put(Games.KEY_GAMEID, c.getString(c.getColumnIndex(Games.KEY_GAMEID)));
 						game.put(Games.KEY_TITLE, c.getString(c.getColumnIndex(Games.KEY_TITLE)));
-						game.put(Games.KEY_OVERVIEW, c.getString(c.getColumnIndex(Games.KEY_OVERVIEW)));
 						game.put(Games.KEY_SERIAL, c.getString(c.getColumnIndex(Games.KEY_SERIAL)));
-						game.put(Games.KEY_BOXART, c.getString(c.getColumnIndex(Games.KEY_BOXART)));
 						games.add(game);
 					} while (c.moveToNext());
 				}
@@ -393,9 +378,7 @@ public class TheGamesDB extends ContentProvider {
 		gamesMap.put(Games.TABLE_ID, Games.TABLE_ID);
 		gamesMap.put(Games.KEY_GAMEID, Games.KEY_GAMEID);
 		gamesMap.put(Games.KEY_TITLE, Games.KEY_TITLE);
-		gamesMap.put(Games.KEY_OVERVIEW, Games.KEY_OVERVIEW);
 		gamesMap.put(Games.KEY_SERIAL, Games.KEY_SERIAL);
-		gamesMap.put(Games.KEY_BOXART, Games.KEY_BOXART);
 
 		sUriMatcher.addURI(Games.AUTHORITY, Games.TABLE_NAME + "/#", GAMESID);
 

--- a/build_android/src/main/res/layout/activity_gameinfo_edit.xml
+++ b/build_android/src/main/res/layout/activity_gameinfo_edit.xml
@@ -114,6 +114,12 @@
                     android:text=""
                     android:id="@+id/game_text" />
 
+                <TextView
+                    android:id="@+id/currentPosition"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="0"
+                    android:visibility="gone" />
             </LinearLayout>
 
         </LinearLayout>

--- a/build_android/src/main/res/layout/game_list_item.xml
+++ b/build_android/src/main/res/layout/game_list_item.xml
@@ -33,4 +33,12 @@
 			android:layout_alignParentBottom="true" />
 	</RelativeLayout>
 
+	<TextView
+		android:id="@+id/currentPosition"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_alignParentStart="true"
+		android:layout_alignParentTop="true"
+		android:visibility="gone" />
+
 </RelativeLayout>

--- a/build_android/src/main/res/xml/settings_ui_fragment.xml
+++ b/build_android/src/main/res/xml/settings_ui_fragment.xml
@@ -8,6 +8,7 @@
             android:key="ui.rescan"
             android:title="@string/pref_ui_rescan_all_title"
             android:summary="@string/pref_ui_rescan_all_summary"
+            android:defaultValue="0"
             android:persistent="false" />
         <Preference
             android:key="ui.clear_unavailable"


### PR DESCRIPTION
continuation of the other cleanup [PR](https://github.com/jpd002/Play-/pull/575).

While, I can't separate the commits, I'm opening a separate PR, to allow you to review the changes separately if you so wish.

```
TODO:Adding the serial to the database this way is not ideal, as a mismatch will persist
but as it stands that's the only way to get the pcitures and prevent them from being downloaded every run
```
this is probably the most important change, I believe `games.db` should be considered a read only reference, so we're no longer storing info to it.