### PR TITLE
Fix for ONI , The Incredibles , The Incredibles rise of the Underminer and Spongebob the movie.

### DIFF
--- a/patches.xml
+++ b/patches.xml
@@ -1,4 +1,3 @@
-
 <Patches>
 	<Executable Name="SLES_506.72;1" Title="Baldur's Gate: Dark Alliance" Region="EU">
 		<Patch Address="0x00300478" Value="0x00000001" Description="Enable libcdvd tracing."/>

--- a/patches.xml
+++ b/patches.xml
@@ -26,9 +26,19 @@
 		<Patch Address="0x002751B4" Value="0x00000000" Description="Nullify spin wait" />
 	</Executable>
 	
-	
 	<Executable Name="SLUS_212.74;1" Title="Outrun" Region="US">
 		<Patch Address="0x00141C88" Value="0x1000000A" Description="Disable NET SIF bind." />
 	</Executable>
 	
+	<Executable Name="SLUS_209.05;1" Title="The Incredibles" Region="US">
+		<Patch Address="0x0010ec20" Value="0x00000000" Description="Fix hang." />
+	</Executable>
+
+	<Executable Name="SLES_501.76;1" Title="Oni" Region="EU">
+		<Patch Address="0x001cef7c" Value="0x00000000 // bc0f $001cef7c" Description="Fix hang by skip branch if copro 0 condition false." />
+	</Executable>
+
+	<Executable Name="SLUS_212.17;1" Title="The Incredibles Rise of the Underminer" Region="US">
+		<Patch Address="0x001110e0" Value="0x00000000" Description="Fix hang." />
+	</Executable>
 </Patches>

--- a/patches.xml
+++ b/patches.xml
@@ -1,3 +1,4 @@
+
 <Patches>
 	<Executable Name="SLES_506.72;1" Title="Baldur's Gate: Dark Alliance" Region="EU">
 		<Patch Address="0x00300478" Value="0x00000001" Description="Enable libcdvd tracing."/>
@@ -40,5 +41,9 @@
 
 	<Executable Name="SLUS_212.17;1" Title="The Incredibles Rise of the Underminer" Region="US">
 		<Patch Address="0x001110e0" Value="0x00000000" Description="Fix hang." />
+	</Executable>
+
+	<Executable Name="SLUS_209.04;1" Title="SpongeBob Squarepants The Movie" Region="US">
+		<Patch Address="0x0010f3e0" Value="0x00000000" Description="Fix hang." />
 	</Executable>
 </Patches>


### PR DESCRIPTION
Add 4 fix for 4 games.
Note : The ONI fix is only compatible with the pal FR version, and the fix for the Incredibles and Spongebob games are for NTSC-U versions.