### PR TITLE
CPU instruction set warning (readme)

### DIFF
--- a/Readme.html
+++ b/Readme.html
@@ -125,10 +125,11 @@
 			<h2 id="requirements">System Requirements</h2>
 			
 		    <ul>
-		        <li>OS: Windows XP/Vista/7</li>
-		        <li>CPU: x86 CPU running @ 2.0GHz and + is recommended. Doesn't take advantage of multi-core CPUs yet.</li>
+		        <li>OS: Windows XP/Vista/7/8/8.1/10</li>
+		        <li>CPU: x86 SSSE3 CPU running @ 2.0GHz and + is recommended.</li>
 		        <li>RAM: 256MBs of RAM is recommended.</li>
 		        <li>Video Card: Any DirectX9 class GPU should be enough.</li>
+			<li>Note: Play! doesn't take advantage of multi-core CPUs yet.</li>
 		    </ul>
 			
 		</div>


### PR DESCRIPTION
Add a warning about the instruction set.
Play! don't support instruction set under SSSE3.