### PR TITLE
[DO NOT MERGE] Add pre-compiled binaries for Linux, via AppImage, update Qt on linux to 5.9.1

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -57,7 +57,7 @@ travis_script()
         if [ "$TARGET_OS" = "Linux" ]; then
             if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
             export PATH=/opt/cmake-3.8.1-Linux-x86_64/bin/:$PATH
-            source /opt/qt591/bin/qt591-env.sh || true
+            source /opt/qt59/bin/qt59-env.sh || true
             cmake .. -G"$BUILD_TYPE" -DCMAKE_PREFIX_PATH=/opt/qt591/ -DCMAKE_INSTALL_PREFIX=./appdir/usr;
             cmake --build .
             cmake --build . --target install

--- a/.travis.sh
+++ b/.travis.sh
@@ -58,7 +58,7 @@ travis_script()
             if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
             export PATH=/opt/cmake-3.8.1-Linux-x86_64/bin/:$PATH
             source /opt/qt59/bin/qt59-env.sh || true
-            cmake .. -G"$BUILD_TYPE" -DCMAKE_PREFIX_PATH=/opt/qt591/ -DCMAKE_INSTALL_PREFIX=./appdir/usr;
+            cmake .. -G"$BUILD_TYPE" -DCMAKE_PREFIX_PATH=/opt/qt59/ -DCMAKE_INSTALL_PREFIX=./appdir/usr;
             cmake --build .
             cmake --build . --target install
             # AppImage Creation

--- a/.travis.sh
+++ b/.travis.sh
@@ -7,7 +7,7 @@ travis_before_install()
         sudo add-apt-repository --yes ppa:beineri/opt-qt591-trusty
         sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
         sudo apt-get update -qq
-        sudo apt-get install -qq qt591base gcc-5 g++-5 libalut-dev
+        sudo apt-get install -qq qt59base gcc-5 g++-5 libalut-dev
         curl -sSL https://cmake.org/files/v3.8/cmake-3.8.1-Linux-x86_64.tar.gz | sudo tar -xzC /opt
     elif [ "$TARGET_OS" = "OSX" ]; then
         sudo npm install -g appdmg


### PR DESCRIPTION
This adds pre-compiled linux binaries.

---

This won't work right now, because it requires adding `make install` [step to cmake](https://cmake.org/cmake/help/v3.0/command/install.html).

Namely, the `install` step needs to install:
- A Play.desktop
- An icon
- The executable

You can look at the [Arch Linux package](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=play-emu-git) for [inspiration](https://aur.archlinux.org/cgit/aur.git/tree/?h=play-emu-git).