### PR TITLE
Better ObjC property declarations.

### DIFF
--- a/Source/ui_macosx/OutputWindowController.h
+++ b/Source/ui_macosx/OutputWindowController.h
@@ -8,8 +8,8 @@
 
 @interface OutputWindowController : NSWindowController
 
-@property(assign, nonatomic) IBOutlet NSOpenGLView* openGlView;
-@property(assign, nonatomic) id<OutputWindowDelegate> delegate;
+@property(weak, nonatomic) IBOutlet NSOpenGLView* openGlView;
+@property(weak, nonatomic) id<OutputWindowDelegate> delegate;
 
 -(NSSize)contentSize;
 

--- a/Source/ui_macosx/PreferencesWindowController.h
+++ b/Source/ui_macosx/PreferencesWindowController.h
@@ -5,7 +5,7 @@
 	IBOutlet NSToolbar*		toolbar;
 }
 
-@property NSViewController* currentViewController;
+@property (strong) NSViewController* currentViewController;
 
 +(PreferencesWindowController*)defaultController;
 -(void)show;

--- a/Source/ui_macosx/VfsManagerBindings.h
+++ b/Source/ui_macosx/VfsManagerBindings.h
@@ -2,10 +2,9 @@
 
 @interface VfsManagerBinding : NSObject
 
-@property NSString* deviceName;
-
--(NSString*)bindingType;
--(NSString*)bindingValue;
+@property (copy) NSString* deviceName;
+@property (readonly, copy) NSString* bindingType;
+@property (readonly, copy) NSString* bindingValue;
 -(void)requestModification;
 -(void)save;
 
@@ -23,12 +22,12 @@
 
 @interface VfsManagerDirectoryBinding : VfsManagerBinding
 
-@property NSString* preferenceName;
-@property NSString* value;
+@property (copy) NSString* preferenceName;
+@property (copy) NSString* value;
 
 -(VfsManagerDirectoryBinding*)init: (NSString*)deviceName preferenceName: (NSString*)preferenceName;
--(NSString*)bindingType;
--(NSString*)bindingValue;
+@property (readonly, copy) NSString* bindingType;
+@property (readonly, copy) NSString* bindingValue;
 -(void)requestModification;
 -(void)save;
 
@@ -36,11 +35,11 @@
 
 @interface VfsManagerCdrom0Binding : VfsManagerBinding
 
-@property NSString* value;
+@property (copy) NSString* value;
 
 -(VfsManagerCdrom0Binding*)init;
--(NSString*)bindingType;
--(NSString*)bindingValue;
+@property (readonly, copy) NSString* bindingType;
+@property (readonly, copy) NSString* bindingValue;
 -(void)requestModification;
 -(void)save;
 


### PR DESCRIPTION
As a general rule, delegates and `IBOutlets` are `weak`, `NSString`s should be `copy`.