### PR TITLE
Qt gamepad cleanup master

### DIFF
--- a/Source/ui_unix/controllerconfigdialog.cpp
+++ b/Source/ui_unix/controllerconfigdialog.cpp
@@ -85,14 +85,10 @@ void ControllerConfigDialog::on_ConfigAllButton_clicked()
 		InputEventSelectionDialog IESD;
 		IESD.Setup(button.c_str(), m_inputManager,
 				   static_cast<PS2::CControllerInfo::BUTTON>(i), m_inputDeviceManager);
-		if(IESD.exec())
+		auto res = IESD.exec();
+		m_inputDeviceManager.get()->DisconnectInputEventCallback();
+		if(!res)
 		{
-			m_inputDeviceManager.get()->DisconnectInputEventCallback();
-			std::this_thread::sleep_for(std::chrono::seconds(2));
-		}
-		else
-		{
-			m_inputDeviceManager.get()->DisconnectInputEventCallback();
 			break;
 		}
 	}

--- a/Source/ui_unix/controllerconfigdialog.cpp
+++ b/Source/ui_unix/controllerconfigdialog.cpp
@@ -65,31 +65,29 @@ void ControllerConfigDialog::on_buttonBox_clicked(QAbstractButton *button)
 
 void ControllerConfigDialog::on_tableView_doubleClicked(const QModelIndex &index)
 {
-	std::string button(PS2::CControllerInfo::m_buttonName[index.row()]);
-	std::transform(button.begin(), button.end(),button.begin(), ::toupper);
-
-	InputEventSelectionDialog IESD;
-	IESD.Setup(button.c_str(), m_inputManager,
-			   static_cast<PS2::CControllerInfo::BUTTON>(index.row()), m_inputDeviceManager);
-	IESD.exec();
-	m_inputDeviceManager.get()->DisconnectInputEventCallback();
+	OpenBindConfigDialog(index.row());
 }
 
 void ControllerConfigDialog::on_ConfigAllButton_clicked()
 {
 	for(int i = 0; i < PS2::CControllerInfo::MAX_BUTTONS; ++i)
 	{
-		std::string button(PS2::CControllerInfo::m_buttonName[i]);
-		std::transform(button.begin(), button.end(),button.begin(), ::toupper);
-
-		InputEventSelectionDialog IESD;
-		IESD.Setup(button.c_str(), m_inputManager,
-				   static_cast<PS2::CControllerInfo::BUTTON>(i), m_inputDeviceManager);
-		auto res = IESD.exec();
-		m_inputDeviceManager.get()->DisconnectInputEventCallback();
-		if(!res)
+		if(!OpenBindConfigDialog(i))
 		{
 			break;
 		}
 	}
+}
+
+int ControllerConfigDialog::OpenBindConfigDialog(int index)
+{
+	std::string button(PS2::CControllerInfo::m_buttonName[index]);
+	std::transform(button.begin(), button.end(),button.begin(), ::toupper);
+
+	InputEventSelectionDialog IESD;
+	IESD.Setup(button.c_str(), m_inputManager,
+			   static_cast<PS2::CControllerInfo::BUTTON>(index), m_inputDeviceManager);
+	auto res = IESD.exec();
+	m_inputDeviceManager.get()->DisconnectInputEventCallback();
+	return res;
 }

--- a/Source/ui_unix/controllerconfigdialog.h
+++ b/Source/ui_unix/controllerconfigdialog.h
@@ -27,6 +27,7 @@ private slots:
 	void on_ConfigAllButton_clicked();
 
 private:
+	int OpenBindConfigDialog(int index);
 	CInputBindingManager* m_inputManager;
 	std::unique_ptr<CGamePadDeviceListener> m_inputDeviceManager;
 	Ui::ControllerConfigDialog *ui;

--- a/Source/ui_unix/inputeventselectiondialog.cpp
+++ b/Source/ui_unix/inputeventselectiondialog.cpp
@@ -45,9 +45,10 @@ void InputEventSelectionDialog::Setup(const char* text, CInputBindingManager *in
 		{
 			if(abs->flat)
 			{
-				int midVal = abs->maximum/2;
-				int triggerVal = abs->maximum/10;
-				if (value < midVal + triggerVal && value > midVal - triggerVal)
+				int triggerRange = abs->maximum/100*20;
+				int triggerVal1 = abs->maximum - triggerRange;
+				int triggerVal2 = abs->minimum + triggerRange;
+				if(value < triggerVal1 && triggerVal2 < value)
 				{
 					setCounter(0);
 					return;

--- a/Source/ui_unix/inputeventselectiondialog.cpp
+++ b/Source/ui_unix/inputeventselectiondialog.cpp
@@ -10,6 +10,10 @@ InputEventSelectionDialog::InputEventSelectionDialog(QWidget *parent) :
 	setWindowFlags(Qt::Window | Qt::WindowCloseButtonHint);
 	setFixedSize(size());
 
+	// workaround to avoid direct thread ui access
+	connect(this, SIGNAL(setSelectedButtonLabelText(QString)), ui->selectedbuttonlabel, SLOT(setText(QString)));
+	connect(this, SIGNAL(setCountDownLabelText(QString)), ui->countdownlabel, SLOT(setText(QString)));
+
 	m_isCounting = false;
 	m_running = true;
 	m_thread = std::thread([this]{ CountDownThreadLoop(); });
@@ -49,7 +53,7 @@ void InputEventSelectionDialog::Setup(const char* text, CInputBindingManager *in
 					return;
 				}
 				setCounter(1);
-				ui->selectedbuttonlabel->setText("Selected Key: " + key);
+				setSelectedButtonLabelText("Selected Key: " + key);
 				m_key1.id = code;
 				m_key1.device = device;
 				m_key1.type = type;
@@ -62,7 +66,7 @@ void InputEventSelectionDialog::Setup(const char* text, CInputBindingManager *in
 				m_key1.type = type;
 				m_key1.value = value;
 				m_key1.bindtype = CInputBindingManager::BINDINGTYPE::BINDING_POVHAT;
-				ui->selectedbuttonlabel->setText("Selected Key: " + key);
+				setSelectedButtonLabelText("Selected Key: " + key);
 			}
 		}
 		else
@@ -71,7 +75,7 @@ void InputEventSelectionDialog::Setup(const char* text, CInputBindingManager *in
 			{
 				if(click_count == 0)
 				{
-					ui->selectedbuttonlabel->setText("(-) Key Selected: " + key);
+					setSelectedButtonLabelText("(-) Key Selected: " + key);
 					m_key1.id = code;
 					m_key1.device = device;
 					m_key1.type = type;
@@ -82,12 +86,12 @@ void InputEventSelectionDialog::Setup(const char* text, CInputBindingManager *in
 					m_key2.id = code;
 					m_key2.device = device;
 					m_key2.type = type;
-					ui->selectedbuttonlabel->setText("(+) Key Selected: " + key);
+					setSelectedButtonLabelText("(+) Key Selected: " + key);
 				}
 			}
 			else
 			{
-				ui->selectedbuttonlabel->setText("Selected Key: " + key);
+				setSelectedButtonLabelText("Selected Key: " + key);
 				m_key1.id = code;
 				m_key1.device = device;
 				m_key1.type = type;
@@ -117,13 +121,13 @@ void InputEventSelectionDialog::keyPressEvent(QKeyEvent* ev)
 			m_key1.id = ev->key();
 			m_key1.device = {0};
 			m_key1.bindtype = CInputBindingManager::BINDINGTYPE::BINDING_SIMULATEDAXIS;
-			ui->selectedbuttonlabel->setText("(-) Key Selected: " + key);
+			setSelectedButtonLabelText("(-) Key Selected: " + key);
 		}
 		else
 		{
 			m_key2.id = ev->key();
 			m_key2.device = {0};
-			ui->selectedbuttonlabel->setText("(+) Key Selected: " + key);
+			setSelectedButtonLabelText("(+) Key Selected: " + key);
 		}
 	}
 	else
@@ -131,7 +135,7 @@ void InputEventSelectionDialog::keyPressEvent(QKeyEvent* ev)
 		m_key1.id = ev->key();
 		m_key1.device = {0};
 		m_key1.bindtype = CInputBindingManager::BINDINGTYPE::BINDING_SIMPLE;
-		ui->selectedbuttonlabel->setText("Key Selected: " + key);
+		setSelectedButtonLabelText("Key Selected: " + key);
 	}
 }
 
@@ -153,7 +157,7 @@ void InputEventSelectionDialog::CountDownThreadLoop()
 		{
 			if(diff.count() < 3)
 			{
-				ui->countdownlabel->setText(m_countingtext.arg(static_cast<int>(3 - diff.count())));
+				setCountDownLabelText(m_countingtext.arg(static_cast<int>(3 - diff.count())));
 			}
 			else
 			{
@@ -170,7 +174,7 @@ void InputEventSelectionDialog::CountDownThreadLoop()
 						{
 							click_count++;
 							m_isCounting = 0;
-							ui->countdownlabel->setText(m_countingtext.arg(3));
+							setCountDownLabelText(m_countingtext.arg(3));
 							continue;
 						}
 						else if(m_key2.id > 0)
@@ -186,7 +190,7 @@ void InputEventSelectionDialog::CountDownThreadLoop()
 		}
 		else if(diff.count() < 3)
 		{
-			ui->countdownlabel->setText(m_countingtext.arg(3));
+			setCountDownLabelText(m_countingtext.arg(3));
 		}
 	}
 }
@@ -198,12 +202,12 @@ bool InputEventSelectionDialog::setCounter(int value)
 		if(click_count == 0)
 		{
 			m_key1.id = -1;
-			ui->selectedbuttonlabel->setText("Selected Key: None");
+			setSelectedButtonLabelText("Selected Key: None");
 		}
 		else
 		{
 			m_key2.id = -1;
-			ui->selectedbuttonlabel->setText("(+) Selected Key: None");
+			setSelectedButtonLabelText("(+) Selected Key: None");
 		}
 		m_isCounting = false;
 		return false;

--- a/Source/ui_unix/inputeventselectiondialog.h
+++ b/Source/ui_unix/inputeventselectiondialog.h
@@ -2,14 +2,15 @@
 
 #include <QDialog>
 #include <QKeyEvent>
-
+#include <chrono>
+#include <thread>
 #include "ui_unix/PH_HidUnix.h"
 
 #include "GamePad/GamePadInputEventListener.h"
 #include "GamePad/GamePadDeviceListener.h"
 
 namespace Ui {
-class InputEventSelectionDialog;
+	class InputEventSelectionDialog;
 }
 
 class InputEventSelectionDialog : public QDialog
@@ -24,12 +25,27 @@ public:
 
 protected:
 	void					keyPressEvent(QKeyEvent*) Q_DECL_OVERRIDE;
+	void					keyReleaseEvent(QKeyEvent*) Q_DECL_OVERRIDE;
 
 private:
+	struct BINDINGINFOEXTENDED : CInputBindingManager::BINDINGINFO
+	{
+		int value;
+		CInputBindingManager::BINDINGTYPE bindtype;
+	};
+	void					CountDownThreadLoop();
+	bool					 setCounter(int);
 	int									click_count = 0;
-	QString								labeltext = QString("Select new binding for\n%1");
+	QString								m_bindingtext = QString("Select new binding for\n%1");
+	QString								m_countingtext = QString("Press & Hold Button for %1 Seconds to assign key");
 	PS2::CControllerInfo::BUTTON		m_button;
-	CInputBindingManager::BINDINGINFO	m_key1;
+	BINDINGINFOEXTENDED					m_key1;
+	CInputBindingManager::BINDINGINFO	m_key2;
 	CInputBindingManager				*m_inputManager;
 	Ui::InputEventSelectionDialog		*ui;
+	std::chrono::time_point<std::chrono::system_clock> m_countStart = std::chrono::system_clock::now();
+	std::thread							m_thread;
+	std::atomic<bool>					m_running;
+	std::atomic<bool>					m_isCounting;
+
 };

--- a/Source/ui_unix/inputeventselectiondialog.h
+++ b/Source/ui_unix/inputeventselectiondialog.h
@@ -48,4 +48,7 @@ private:
 	std::atomic<bool>					m_running;
 	std::atomic<bool>					m_isCounting;
 
+Q_SIGNALS:
+	void								setSelectedButtonLabelText(QString);
+	void								setCountDownLabelText(QString);
 };

--- a/build_unix/inputeventselectiondialog.ui
+++ b/build_unix/inputeventselectiondialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>320</width>
+    <width>342</width>
     <height>131</height>
    </rect>
   </property>
@@ -14,8 +14,28 @@
    <string>Button Configuration</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0">
+    <widget class="QLabel" name="selectedbuttonlabel">
+     <property name="text">
+      <string>Selected Key: None</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="countdownlabel">
+     <property name="text">
+      <string>Press &amp; Hold Button for 3 Seconds to assign key</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="bindinglabel">
      <property name="text">
       <string>Select new binding for
 


### PR DESCRIPTION
added 3 second button registration window when configuring gamepad, this allows us to remove the 2 second sleep i previously added to avoid the same button getting registered multiple time.

I've removed direct calls to UI when configuration controllers as that was on occasion causing crashes.

lastly, control filter that was setup to prevent certain buttons from spamming the configuration also prevented the range condition `if (value < midVal + triggerVal && value > midVal - triggerVal)` from triggering, so now we'll check the last 20% of the range, which allows us enough range to set an on/off region

edit, you also asked to maybe move the gamepad files our of `ui_unix`, would framework be a better place?