### PR TITLE
Updated boost include

### DIFF
--- a/Source/saves/Icon.h
+++ b/Source/saves/Icon.h
@@ -2,12 +2,7 @@
 
 #include "Types.h"
 #include "Stream.h"
-
-#ifdef _WIN32
 #include <memory>
-#else
-#include <boost/config/no_tr1/memory.hpp>
-#endif
 
 class CIcon
 {

--- a/Source/saves/Icon.h
+++ b/Source/saves/Icon.h
@@ -6,7 +6,7 @@
 #ifdef _WIN32
 #include <memory>
 #else
-#include <boost/tr1/memory.hpp>
+#include <boost/config/no_tr1/memory.hpp>
 #endif
 
 class CIcon


### PR DESCRIPTION
Replaced deprecated include. Should compile not only on the newest boost version, but on old ones as well.