### PR TITLE
Update TheGamesDB to legacy domain

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -229,7 +229,7 @@ public class GameInfo
 					}
 					else
 					{
-						api = "http://thegamesdb.net/banners/" + boxart;
+						api = "http://legacy.thegamesdb.net/banners/" + boxart;
 					}
 					InputStream im = null;
 					try

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -42,9 +42,9 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Boolean>
 	private String gameID;
 	private GameInfo gameInfo;
 	private boolean elastic;
-	private static final String games_url = "http://thegamesdb.net/api/GetGamesList.php?platform=sony+playstation+2&name=";
-	private static final String games_url_id = "http://thegamesdb.net/api/GetGame.php?platform=sony+playstation+2&id=";
-	private static final String games_list = "http://thegamesdb.net/api/GetPlatformGames.php?platform=11";
+	private static final String games_url = "http://legacy.thegamesdb.net/api/GetGamesList.php?platform=sony+playstation+2&name=";
+	private static final String games_url_id = "http://legacy.thegamesdb.net/api/GetGame.php?platform=sony+playstation+2&id=";
+	private static final String games_list = "http://legacy.thegamesdb.net/api/GetPlatformGames.php?platform=11";
 
 	public GamesDbAPI(Context mContext, GameInfoStruct gameInfoStruct, int pos)
 	{

--- a/Source/ui_ios/CoverViewController.m
+++ b/Source/ui_ios/CoverViewController.m
@@ -102,7 +102,7 @@ static NSString * const reuseIdentifier = @"coverCell";
 	UIImage *placeholder = [UIImage imageNamed:@"boxart.png"];
 	cell.backgroundView = [[UIImageView alloc] initWithImage:placeholder];
     if ([game objectForKey:@"boxart"] != nil && ![[game objectForKey:@"boxart"] isEqual:@"404"]) {
-        NSString *imageIcon = [[NSString alloc] initWithFormat:@"http://thegamesdb.net/banners/_gameviewcache/%@", [game objectForKey:@"boxart"]];
+        NSString *imageIcon = [[NSString alloc] initWithFormat:@"http://legacy.thegamesdb.net/banners/_gameviewcache/%@", [game objectForKey:@"boxart"]];
         [(UIImageView *)cell.backgroundView sd_setImageWithURL:[NSURL URLWithString:imageIcon] placeholderImage:placeholder];
 	} else {
 		cell.nameLabel.text = [[[disk objectForKey:@"file"] lastPathComponent] stringByDeletingPathExtension];


### PR DESCRIPTION
the current api will be completely removed in time for now we're slow preparing to replace the current(aka old) site with the beta(new) site as such the main domain name will eventually drop the old api, and the legacy domain name will be available during the transition stage to the new api.

P.S. Legacy subdomain will also be eventually be put offline, but by then I'd have PR for it as well.