### PR TITLE
Resolution Multipliers

### DIFF
--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -285,7 +285,7 @@ void CGSH_OpenGL::LoadState(Framework::CZipArchiveReader& archive)
 void CGSH_OpenGL::RegisterPreferences()
 {
 	CGSHandler::RegisterPreferences();
-	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREF_CGSH_OPENGL_ENABLEHIGHRESMODE, false);
+	CAppConfig::GetInstance().RegisterPreferenceInteger(PREF_CGSH_OPENGL_RESOLUTION_FACTOR, 1);
 	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES, false);
 }
 
@@ -301,7 +301,7 @@ void CGSH_OpenGL::NotifyPreferencesChangedImpl()
 
 void CGSH_OpenGL::LoadPreferences()
 {
-	m_fbScale = CAppConfig::GetInstance().GetPreferenceBoolean(PREF_CGSH_OPENGL_ENABLEHIGHRESMODE) ? 2 : 1;
+	m_fbScale = CAppConfig::GetInstance().GetPreferenceInteger(PREF_CGSH_OPENGL_RESOLUTION_FACTOR);
 	m_forceBilinearTextures = CAppConfig::GetInstance().GetPreferenceBoolean(PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES);
 }
 

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.h
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.h
@@ -11,6 +11,7 @@
 #include "opengl/Resource.h"
 
 #define PREF_CGSH_OPENGL_ENABLEHIGHRESMODE "renderer.opengl.enablehighresmode"
+#define PREF_CGSH_OPENGL_RESOLUTION_FACTOR "renderer.opengl.resfactor"
 #define PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES "renderer.opengl.forcebilineartextures"
 
 class CGSH_OpenGL : public CGSHandler

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.h
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.h
@@ -10,7 +10,6 @@
 #include "opengl/Shader.h"
 #include "opengl/Resource.h"
 
-#define PREF_CGSH_OPENGL_ENABLEHIGHRESMODE "renderer.opengl.enablehighresmode"
 #define PREF_CGSH_OPENGL_RESOLUTION_FACTOR "renderer.opengl.resfactor"
 #define PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES "renderer.opengl.forcebilineartextures"
 

--- a/Source/ui_android/SettingsManager.cpp
+++ b/Source/ui_android/SettingsManager.cpp
@@ -23,6 +23,16 @@ void CSettingsManager::SetPreferenceBoolean(const std::string& name, bool value)
 	CAppConfig::GetInstance().SetPreferenceBoolean(name.c_str(), value);
 }
 
+int CSettingsManager::GetPreferenceInteger(const std::string& name)
+{
+	return CAppConfig::GetInstance().GetPreferenceInteger(name.c_str());
+}
+
+void CSettingsManager::SetPreferenceInteger(const std::string& name, int value)
+{
+	CAppConfig::GetInstance().SetPreferenceInteger(name.c_str(), value);
+}
+
 extern "C" JNIEXPORT void JNICALL Java_com_virtualapplications_play_SettingsManager_save(JNIEnv* env, jobject obj)
 {
 	CSettingsManager::GetInstance().Save();
@@ -41,4 +51,14 @@ extern "C" JNIEXPORT jboolean JNICALL Java_com_virtualapplications_play_Settings
 extern "C" JNIEXPORT void JNICALL Java_com_virtualapplications_play_SettingsManager_setPreferenceBoolean(JNIEnv* env, jobject obj, jstring name, jboolean value)
 {
 	CSettingsManager::GetInstance().SetPreferenceBoolean(GetStringFromJstring(env, name), value == JNI_TRUE);
+}
+
+extern "C" JNIEXPORT jint JNICALL Java_com_virtualapplications_play_SettingsManager_getPreferenceInteger(JNIEnv* env, jobject obj, jstring name)
+{
+	return CSettingsManager::GetInstance().GetPreferenceInteger(GetStringFromJstring(env, name).c_str());
+}
+
+extern "C" JNIEXPORT void JNICALL Java_com_virtualapplications_play_SettingsManager_setPreferenceInteger(JNIEnv* env, jobject obj, jstring name, jint value)
+{
+	CSettingsManager::GetInstance().SetPreferenceInteger(GetStringFromJstring(env, name).c_str(), value);
 }

--- a/Source/ui_android/SettingsManager.h
+++ b/Source/ui_android/SettingsManager.h
@@ -10,6 +10,8 @@ public:
 	void RegisterPreferenceBoolean(const std::string&, bool);
 	bool GetPreferenceBoolean(const std::string&);
 	void SetPreferenceBoolean(const std::string&, bool);
+	int GetPreferenceInteger(const std::string&);
+	void SetPreferenceInteger(const std::string&, int);
 
 private:
 };

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
@@ -98,7 +98,7 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 					String stringValue = value.toString();
 					ListPreference listBoxPref = (ListPreference)preference;
 					listBoxPref.setSummary(stringValue + "x");
-					return false;
+					return true;
 				}
 			});
 			pref.setSummary(pref.getEntry());
@@ -147,8 +147,8 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 				else if(pref instanceof ListPreference)
 				{
 					ListPreference listBoxPref = (ListPreference)pref;
-					int val = SettingsManager.getPreferenceInteger(listBoxPref.getKey());
-					listBoxPref.setValueIndex(val - 1);
+					String val = String.valueOf(SettingsManager.getPreferenceInteger(listBoxPref.getKey()));
+					listBoxPref.setValue(val);
 				}
 				else if(pref instanceof PreferenceGroup)
 				{
@@ -176,10 +176,11 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 				@Override
 				public boolean onPreferenceChange(Preference preference, Object value)
 				{
-					String stringValue = value.toString();
+					int index = Integer.parseInt(value.toString());
 					ListPreference listBoxPref = (ListPreference)preference;
-					listBoxPref.setSummary(stringValue);
-					return false;
+
+					listBoxPref.setSummary(listBoxPref.getEntries()[index]);
+					return true;
 				}
 			});
 			pref.setSummary(pref.getEntry());

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
@@ -89,6 +89,19 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 			super.onCreate(savedInstanceState);
 			addPreferencesFromResource(R.xml.settings_emu_fragment);
 			writeToPreferences(getPreferenceScreen());
+			ListPreference pref = (ListPreference)findPreference("renderer.opengl.resfactor");
+			pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
+			{
+				@Override
+				public boolean onPreferenceChange(Preference preference, Object value)
+				{
+					String stringValue = value.toString();
+					ListPreference listBoxPref = (ListPreference)preference;
+					listBoxPref.setSummary(stringValue + "x");
+					return false;
+				}
+			});
+			pref.setSummary(pref.getEntry());
 		}
 
 		@Override
@@ -157,6 +170,19 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 			getPreferenceManager().findPreference(RESCAN).setOnPreferenceClickListener(this);
 			getPreferenceManager().findPreference(CLEAR_UNAVAILABLE).setOnPreferenceClickListener(this);
 			getPreferenceManager().findPreference(CLEAR_CACHE).setOnPreferenceClickListener(this);
+			ListPreference pref = (ListPreference)findPreference("ui.theme_selection");
+			pref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener()
+			{
+				@Override
+				public boolean onPreferenceChange(Preference preference, Object value)
+				{
+					String stringValue = value.toString();
+					ListPreference listBoxPref = (ListPreference)preference;
+					listBoxPref.setSummary(stringValue);
+					return false;
+				}
+			});
+			pref.setSummary(pref.getEntry());
 		}
 
 		@Override

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
@@ -108,6 +108,12 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 					CheckBoxPreference checkBoxPref = (CheckBoxPreference)pref;
 					SettingsManager.setPreferenceBoolean(checkBoxPref.getKey(), checkBoxPref.isChecked());
 				}
+				else if(pref instanceof ListPreference)
+				{
+					ListPreference listBoxPref = (ListPreference)pref;
+					int val = Integer.parseInt(listBoxPref.getValue());
+					SettingsManager.setPreferenceInteger(listBoxPref.getKey(), val);
+				}
 				else if(pref instanceof PreferenceGroup)
 				{
 					readFromPreferences((PreferenceGroup)pref);
@@ -124,6 +130,12 @@ public class SettingsActivity extends PreferenceActivity implements SharedPrefer
 				{
 					CheckBoxPreference checkBoxPref = (CheckBoxPreference)pref;
 					checkBoxPref.setChecked(SettingsManager.getPreferenceBoolean(checkBoxPref.getKey()));
+				}
+				else if(pref instanceof ListPreference)
+				{
+					ListPreference listBoxPref = (ListPreference)pref;
+					int val = SettingsManager.getPreferenceInteger(listBoxPref.getKey());
+					listBoxPref.setValueIndex(val - 1);
 				}
 				else if(pref instanceof PreferenceGroup)
 				{

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsManager.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsManager.java
@@ -14,4 +14,8 @@ public class SettingsManager
 	public static native boolean getPreferenceBoolean(String name);
 
 	public static native void setPreferenceBoolean(String name, boolean value);
+
+	public static native int getPreferenceInteger(String name);
+
+	public static native void setPreferenceInteger(String name, int value);
 }

--- a/Source/ui_ios/Base.lproj/Main.storyboard
+++ b/Source/ui_ios/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="VnE-Sh-vgR">
-    <device id="retina4_7" orientation="portrait">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="VnE-Sh-vgR">
+    <device id="retina6_1" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,7 +14,7 @@
             <objects>
                 <collectionViewController id="1v5-6a-quN" customClass="CoverViewController" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="NSw-mS-htR">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="KVN-ya-NZC">
@@ -74,18 +74,18 @@
         <scene sceneID="HiI-a8-Su8">
             <objects>
                 <tableViewController id="EKd-Wn-cXY" customClass="SettingsViewController" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" allowsSelection="NO" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="tEL-bT-e8B">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="tEL-bT-e8B">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <sections>
                             <tableViewSection headerTitle="General" id="i4m-ae-hB6">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="OgE-FZ-RPW">
-                                        <rect key="frame" x="0.0" y="55.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="OgE-FZ-RPW" id="qaC-qx-F8g">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Show Frame and Draw Call Counters" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="EdS-rD-YnE">
@@ -96,17 +96,17 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5Wo-ch-s5J">
-                                                    <rect key="frame" x="316" y="6" width="51" height="31"/>
+                                                    <rect key="frame" x="354" y="6" width="51" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                 </switch>
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="rOH-Uw-qJJ">
-                                        <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="99.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rOH-Uw-qJJ" id="qXs-M0-cy0">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Show Virtual Pad" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="iHL-ZH-BWp">
@@ -117,7 +117,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hMN-wf-jlB">
-                                                    <rect key="frame" x="316" y="6" width="51" height="31"/>
+                                                    <rect key="frame" x="354" y="6" width="51" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                 </switch>
                                             </subviews>
@@ -128,31 +128,38 @@
                             <tableViewSection headerTitle="Video" id="9eF-GH-FHV">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="aKd-pO-wvH">
-                                        <rect key="frame" x="0.0" y="199.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="199.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="aKd-pO-wvH" id="Fvc-Vb-9Op">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Enable High Resolution Mode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="xz7-VY-07q">
-                                                    <rect key="frame" x="8" y="11" width="247" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Resolution Factor" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="pAZ-KI-8ms">
+                                                    <rect key="frame" x="8" y="11.5" width="247" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r5o-M4-kDB">
-                                                    <rect key="frame" x="316" y="6" width="51" height="31"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="XXXX" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aiY-EV-WhA">
+                                                    <rect key="frame" x="349" y="11" width="45" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <gestureRecognizers/>
+                                        <connections>
+                                            <segue destination="IRm-nc-RK7" kind="show" id="mF5-RO-lok"/>
+                                        </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="43Z-1v-KCU">
-                                        <rect key="frame" x="0.0" y="243.5" width="375" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="43Z-1v-KCU">
+                                        <rect key="frame" x="0.0" y="243.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="43Z-1v-KCU" id="U6X-5o-YfP">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Force Bilinear Filtering" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="YhT-fM-2SJ">
@@ -163,7 +170,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RW9-T7-1NA">
-                                                    <rect key="frame" x="316" y="6" width="51" height="31"/>
+                                                    <rect key="frame" x="354" y="6" width="51" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                 </switch>
                                             </subviews>
@@ -173,11 +180,11 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Audio" id="K0b-oh-ls1" userLabel="Audio">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="2yl-0q-ezn">
-                                        <rect key="frame" x="0.0" y="343.5" width="375" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="2yl-0q-ezn">
+                                        <rect key="frame" x="0.0" y="343.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2yl-0q-ezn" id="y1A-mp-vkH">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Enable Audio Output" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="0LA-tq-NdV">
@@ -188,7 +195,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="h83-A2-2Ax">
-                                                    <rect key="frame" x="316" y="6" width="51" height="31"/>
+                                                    <rect key="frame" x="354" y="6" width="51" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                 </switch>
                                             </subviews>
@@ -198,15 +205,15 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Version Information" id="d6N-kI-BBa">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="bUB-Fr-n0c">
-                                        <rect key="frame" x="0.0" y="443.5" width="375" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="bUB-Fr-n0c">
+                                        <rect key="frame" x="0.0" y="443.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="bUB-Fr-n0c" id="VCQ-yX-pIE">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.30 - __DATE__" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="w2T-id-DC8">
-                                                    <rect key="frame" x="16" y="14" width="343" height="15.5"/>
+                                                    <rect key="frame" x="20" y="14" width="374" height="15.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -231,8 +238,8 @@
                     <navigationItem key="navigationItem" title="Settings" id="uG2-4L-hAD"/>
                     <connections>
                         <outlet property="enableAudioOutput" destination="h83-A2-2Ax" id="B29-zr-Rdh"/>
-                        <outlet property="enableHighResMode" destination="r5o-M4-kDB" id="5lh-Jf-qiC"/>
                         <outlet property="forceBilinearFiltering" destination="RW9-T7-1NA" id="IOT-Cx-rrp"/>
+                        <outlet property="resolutionFactor" destination="aiY-EV-WhA" id="BNd-7Q-xpD"/>
                         <outlet property="showFpsSwitch" destination="5Wo-ch-s5J" id="Ius-gD-fIr"/>
                         <outlet property="showVirtualPadSwitch" destination="hMN-wf-jlB" id="1Sb-Wi-cwa"/>
                         <outlet property="versionInfoLabel" destination="w2T-id-DC8" id="Sk7-qJ-alx"/>
@@ -240,7 +247,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DlU-rA-yok" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1846" y="-329"/>
+            <point key="canvasLocation" x="1845.5999999999999" y="-329.68515742128938"/>
         </scene>
         <!--Emulator View Controller-->
         <scene sceneID="tne-QT-ifu">
@@ -251,11 +258,11 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="GlEsView">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HC8-HH-sed">
-                                <rect key="frame" x="320" y="322" width="55" height="23"/>
+                                <rect key="frame" x="359" y="437" width="55" height="23"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" title="Menu"/>
@@ -277,7 +284,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="VnE-Sh-vgR" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="VLy-tx-N4x">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     </navigationBar>
@@ -289,6 +296,103 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0kd-C1-sbT" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="26" y="279"/>
+        </scene>
+        <!--Resolution Factor-->
+        <scene sceneID="ikd-Ep-pvM">
+            <objects>
+                <tableViewController id="IRm-nc-RK7" customClass="ResolutionFactorSelectorViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="dQD-0J-dyg">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <sections>
+                            <tableViewSection id="IMV-ck-klO">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="QnU-4u-N2y">
+                                        <rect key="frame" x="0.0" y="35" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="QnU-4u-N2y" id="410-zJ-9ui">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="1x" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EtM-UK-rdV">
+                                                    <rect key="frame" x="20" y="11" width="17" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="QhO-wa-wzz">
+                                        <rect key="frame" x="0.0" y="79" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="QhO-wa-wzz" id="ucj-ps-CDf">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="2x" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wBZ-KJ-geB">
+                                                    <rect key="frame" x="20" y="11" width="19" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="ckK-ck-C5Y">
+                                        <rect key="frame" x="0.0" y="123" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ckK-ck-C5Y" id="ew3-I2-poE">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="4x" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fsp-ub-4kA">
+                                                    <rect key="frame" x="20" y="11" width="19" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="RZH-Ya-zxm">
+                                        <rect key="frame" x="0.0" y="167" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RZH-Ya-zxm" id="Isa-d1-mUT">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="8x" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NeF-zb-D6p">
+                                                    <rect key="frame" x="20" y="11" width="19" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="IRm-nc-RK7" id="wZS-D0-XeN"/>
+                            <outlet property="delegate" destination="IRm-nc-RK7" id="y6a-fa-xlq"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Resolution Factor" id="Qk1-d9-Vy0"/>
+                    <connections>
+                        <segue destination="AH3-X4-gIY" kind="unwind" identifier="returnToSettings" unwindAction="returnToSettings:" id="YFA-OE-kdT"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Cdb-FD-cE2" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="AH3-X4-gIY" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="2735" y="-330"/>
         </scene>
     </scenes>
 </document>

--- a/Source/ui_ios/CMakeLists.txt
+++ b/Source/ui_ios/CMakeLists.txt
@@ -63,6 +63,7 @@ set(OSX_SOURCES
 	GlEsView.mm
 	GSH_OpenGLiOS.cpp
 	main.mm
+	ResolutionFactorSelectorViewController.mm
 	SettingsViewController.mm
 	VirtualPadButton.mm
 	VirtualPadItem.mm
@@ -78,6 +79,7 @@ set(OSX_HEADERS
 	EmulatorViewController.h
 	GlEsView.h
 	GSH_OpenGLiOS.h
+	ResolutionFactorSelectorViewController.h
 	SettingsViewController.h
 	VirtualPadButton.h
 	VirtualPadItem.h

--- a/Source/ui_ios/ResolutionFactorSelectorViewController.h
+++ b/Source/ui_ios/ResolutionFactorSelectorViewController.h
@@ -3,7 +3,6 @@
 
 @interface ResolutionFactorSelectorViewController : UITableViewController
 {
-	
 }
 
 @property int factor;

--- a/Source/ui_ios/ResolutionFactorSelectorViewController.h
+++ b/Source/ui_ios/ResolutionFactorSelectorViewController.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+#include "Types.h"
+
+@interface ResolutionFactorSelectorViewController : UITableViewController
+{
+	
+}
+
+@property int factor;
+
+@end

--- a/Source/ui_ios/ResolutionFactorSelectorViewController.mm
+++ b/Source/ui_ios/ResolutionFactorSelectorViewController.mm
@@ -1,0 +1,22 @@
+#import "ResolutionFactorSelectorViewController.h"
+
+@implementation ResolutionFactorSelectorViewController
+
+-(void)viewDidAppear: (BOOL)animated
+{
+	int index = log2(self.factor);
+	UITableViewCell* cell = [self.tableView cellForRowAtIndexPath: [NSIndexPath indexPathForRow: index inSection: 0]];
+	if(cell != nil)
+	{
+		cell.accessoryType = UITableViewCellAccessoryCheckmark;
+	}
+}
+
+-(void)tableView: (UITableView*)tableView didSelectRowAtIndexPath: (NSIndexPath*)indexPath
+{
+	self.factor = 1 << [indexPath row];
+	[tableView deselectRowAtIndexPath: indexPath animated: YES];
+	[self performSegueWithIdentifier: @"returnToSettings" sender: self];
+}
+
+@end

--- a/Source/ui_ios/SettingsViewController.h
+++ b/Source/ui_ios/SettingsViewController.h
@@ -5,12 +5,14 @@
 	IBOutlet UISwitch* showFpsSwitch;
 	IBOutlet UISwitch* showVirtualPadSwitch;
 
-	IBOutlet UISwitch* enableHighResMode;
+	IBOutlet UILabel* resolutionFactor;
 	IBOutlet UISwitch* forceBilinearFiltering;
 
 	IBOutlet UISwitch* enableAudioOutput;
 
 	IBOutlet UILabel* versionInfoLabel;
 }
+
+-(IBAction)returnToSettings: (UIStoryboardSegue*)segue;
 
 @end

--- a/Source/ui_ios/SettingsViewController.h
+++ b/Source/ui_ios/SettingsViewController.h
@@ -13,6 +13,6 @@
 	IBOutlet UILabel* versionInfoLabel;
 }
 
--(IBAction)returnToSettings: (UIStoryboardSegue*)segue;
+- (IBAction)returnToSettings:(UIStoryboardSegue*)segue;
 
 @end

--- a/Source/ui_ios/SettingsViewController.mm
+++ b/Source/ui_ios/SettingsViewController.mm
@@ -16,7 +16,7 @@
 	
 	[enableAudioOutput setOn: CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_AUDIO_ENABLEOUTPUT)];
 
-	NSString* versionString = [NSString stringWithFormat: @"0.%02d - %s", APP_VERSION, __DATE__];
+	NSString* versionString = [NSString stringWithFormat: @"%s - %s", PLAY_VERSION, __DATE__];
 	versionInfoLabel.text = versionString;
 }
 

--- a/Source/ui_ios/SettingsViewController.mm
+++ b/Source/ui_ios/SettingsViewController.mm
@@ -1,4 +1,5 @@
 #import "SettingsViewController.h"
+#import "ResolutionFactorSelectorViewController.h"
 #include "../AppConfig.h"
 #include "PreferenceDefs.h"
 #include "AppDef.h"
@@ -6,12 +7,18 @@
 
 @implementation SettingsViewController
 
+-(void)updateResolutionFactorLabel
+{
+	int factor = CAppConfig::GetInstance().GetPreferenceInteger(PREF_CGSH_OPENGL_RESOLUTION_FACTOR);
+	[resolutionFactor setText: [NSString stringWithFormat: @"%dx", factor]];
+}
+
 -(void)viewDidLoad
 {
 	[showFpsSwitch setOn: CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_SHOWFPS)];
 	[showVirtualPadSwitch setOn: CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_SHOWVIRTUALPAD)];
 
-	[enableHighResMode setOn: CAppConfig::GetInstance().GetPreferenceBoolean(PREF_CGSH_OPENGL_ENABLEHIGHRESMODE)];
+	[self updateResolutionFactorLabel];
 	[forceBilinearFiltering setOn: CAppConfig::GetInstance().GetPreferenceBoolean(PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES)];
 	
 	[enableAudioOutput setOn: CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_AUDIO_ENABLEOUTPUT)];
@@ -25,12 +32,35 @@
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_SHOWFPS, showFpsSwitch.isOn);
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_SHOWVIRTUALPAD, showVirtualPadSwitch.isOn);
 	
-	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_CGSH_OPENGL_ENABLEHIGHRESMODE, enableHighResMode.isOn);
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES, forceBilinearFiltering.isOn);
 	
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_AUDIO_ENABLEOUTPUT, enableAudioOutput.isOn);
 	
 	CAppConfig::GetInstance().Save();
+}
+
+-(void)tableView: (UITableView*)tableView didSelectRowAtIndexPath: (NSIndexPath*)indexPath
+{
+	[tableView deselectRowAtIndexPath: indexPath animated: YES];
+}
+
+-(void)prepareForSegue: (UIStoryboardSegue*)segue sender: (id)sender
+{
+	if([segue.destinationViewController isKindOfClass: [ResolutionFactorSelectorViewController class]])
+	{
+		ResolutionFactorSelectorViewController* selector = (ResolutionFactorSelectorViewController*)segue.destinationViewController;
+		selector.factor = CAppConfig::GetInstance().GetPreferenceInteger(PREF_CGSH_OPENGL_RESOLUTION_FACTOR);
+	}
+}
+
+-(IBAction)returnToSettings: (UIStoryboardSegue*)segue
+{
+	if([segue.sourceViewController isKindOfClass: [ResolutionFactorSelectorViewController class]])
+	{
+		ResolutionFactorSelectorViewController* selector = (ResolutionFactorSelectorViewController*)segue.sourceViewController;
+		CAppConfig::GetInstance().SetPreferenceInteger(PREF_CGSH_OPENGL_RESOLUTION_FACTOR, selector.factor);
+		[self updateResolutionFactorLabel];
+	}
 }
 
 @end

--- a/Source/ui_qt/Qt_ui/settingsdialog.ui
+++ b/Source/ui_qt/Qt_ui/settingsdialog.ui
@@ -109,6 +109,16 @@
      </item>
     </widget>
    </item>
+   <item row="1" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="1">
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="frameShape">
@@ -133,24 +143,11 @@
       </widget>
      </widget>
      <widget class="QWidget" name="Video">
-      <widget class="QCheckBox" name="checkBox_enable_highres">
-       <property name="geometry">
-        <rect>
-         <x>20</x>
-         <y>20</y>
-         <width>341</width>
-         <height>22</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Enable High Resolution</string>
-       </property>
-      </widget>
       <widget class="QCheckBox" name="checkBox_force_bilinear_filtering">
        <property name="geometry">
         <rect>
          <x>20</x>
-         <y>50</y>
+         <y>80</y>
          <width>341</width>
          <height>22</height>
         </rect>
@@ -163,7 +160,7 @@
        <property name="geometry">
         <rect>
          <x>20</x>
-         <y>100</y>
+         <y>130</y>
          <width>161</width>
          <height>27</height>
         </rect>
@@ -191,13 +188,42 @@
        <property name="geometry">
         <rect>
          <x>20</x>
-         <y>80</y>
+         <y>110</y>
          <width>151</width>
          <height>17</height>
         </rect>
        </property>
        <property name="text">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Presentation Mode:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_3">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>30</y>
+         <width>151</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Resolution:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+      <widget class="QSpinBox" name="spinBox_resolution">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>50</y>
+         <width>150</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>10</number>
        </property>
       </widget>
      </widget>
@@ -216,16 +242,6 @@
        </property>
       </widget>
      </widget>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
-     </property>
     </widget>
    </item>
   </layout>

--- a/Source/ui_qt/Qt_ui/settingsdialog.ui
+++ b/Source/ui_qt/Qt_ui/settingsdialog.ui
@@ -210,21 +210,40 @@
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Resolution:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
       </widget>
-      <widget class="QSpinBox" name="spinBox_resolution">
+      <widget class="QComboBox" name="comboBox_res_multiplyer">
        <property name="geometry">
         <rect>
          <x>20</x>
          <y>50</y>
          <width>150</width>
-         <height>22</height>
+         <height>27</height>
         </rect>
        </property>
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>10</number>
-       </property>
+       <item>
+        <property name="text">
+         <string>1x (~480)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>2x (~960p)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>4x (~1920p)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>8x (~4320p / 8k)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>16x (~7680p / 16k)</string>
+        </property>
+       </item>
       </widget>
      </widget>
      <widget class="QWidget" name="Audio">

--- a/Source/ui_qt/mainwindow.cpp
+++ b/Source/ui_qt/mainwindow.cpp
@@ -411,6 +411,14 @@ void MainWindow::on_actionSettings_triggered()
 	SettingsDialog sd;
 	sd.exec();
 	SetupSoundHandler();
+	if(m_virtualMachine != nullptr)
+	{
+		auto gsHandler = m_virtualMachine->GetGSHandler();
+		if(gsHandler)
+		{
+			gsHandler->NotifyPreferencesChanged();
+		}
+	}
 }
 
 void MainWindow::SetupSaveLoadStateSlots()

--- a/Source/ui_qt/settingsdialog.cpp
+++ b/Source/ui_qt/settingsdialog.cpp
@@ -2,6 +2,7 @@
 #include "ui_settingsdialog.h"
 #include "PreferenceDefs.h"
 #include "../gs/GSH_OpenGL/GSH_OpenGL.h"
+#include <cmath>
 
 SettingsDialog::SettingsDialog(QWidget* parent)
     : QDialog(parent)
@@ -32,7 +33,9 @@ void SettingsDialog::changePage(QListWidgetItem* current, QListWidgetItem* previ
 
 void SettingsDialog::LoadPreferences()
 {
-	ui->spinBox_resolution->setValue(CAppConfig::GetInstance().GetPreferenceInteger(PREF_CGSH_OPENGL_RESOLUTION_FACTOR));
+	int factor = CAppConfig::GetInstance().GetPreferenceInteger(PREF_CGSH_OPENGL_RESOLUTION_FACTOR);
+	int factor_index = std::log2(factor);
+	ui->comboBox_res_multiplyer->setCurrentIndex(factor_index);
 	ui->checkBox_force_bilinear_filtering->setChecked(CAppConfig::GetInstance().GetPreferenceBoolean(PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES));
 
 	ui->checkBox_enable_audio->setChecked(CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_AUDIO_ENABLEOUTPUT));
@@ -55,7 +58,8 @@ void SettingsDialog::on_comboBox_presentation_mode_currentIndexChanged(int index
 	CAppConfig::GetInstance().SetPreferenceInteger(PREF_CGSHANDLER_PRESENTATION_MODE, index);
 }
 
-void SettingsDialog::on_spinBox_resolution_valueChanged(int val)
+void SettingsDialog::on_comboBox_res_multiplyer_currentIndexChanged(int index)
 {
-	CAppConfig::GetInstance().SetPreferenceInteger(PREF_CGSH_OPENGL_RESOLUTION_FACTOR, val);
+	int factor = pow(2, index);
+	CAppConfig::GetInstance().SetPreferenceInteger(PREF_CGSH_OPENGL_RESOLUTION_FACTOR, factor);
 }

--- a/Source/ui_qt/settingsdialog.cpp
+++ b/Source/ui_qt/settingsdialog.cpp
@@ -32,17 +32,11 @@ void SettingsDialog::changePage(QListWidgetItem* current, QListWidgetItem* previ
 
 void SettingsDialog::LoadPreferences()
 {
-	ui->checkBox_enable_highres->setChecked(CAppConfig::GetInstance().GetPreferenceBoolean(PREF_CGSH_OPENGL_ENABLEHIGHRESMODE));
+	ui->spinBox_resolution->setValue(CAppConfig::GetInstance().GetPreferenceInteger(PREF_CGSH_OPENGL_RESOLUTION_FACTOR));
 	ui->checkBox_force_bilinear_filtering->setChecked(CAppConfig::GetInstance().GetPreferenceBoolean(PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES));
 
 	ui->checkBox_enable_audio->setChecked(CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_AUDIO_ENABLEOUTPUT));
 	ui->comboBox_presentation_mode->setCurrentIndex(CAppConfig::GetInstance().GetPreferenceInteger(PREF_CGSHANDLER_PRESENTATION_MODE));
-}
-
-void SettingsDialog::on_checkBox_enable_highres_clicked(bool checked)
-{
-
-	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_CGSH_OPENGL_ENABLEHIGHRESMODE, checked);
 }
 
 void SettingsDialog::on_checkBox_force_bilinear_filtering_clicked(bool checked)
@@ -59,4 +53,9 @@ void SettingsDialog::on_checkBox_enable_audio_clicked(bool checked)
 void SettingsDialog::on_comboBox_presentation_mode_currentIndexChanged(int index)
 {
 	CAppConfig::GetInstance().SetPreferenceInteger(PREF_CGSHANDLER_PRESENTATION_MODE, index);
+}
+
+void SettingsDialog::on_spinBox_resolution_valueChanged(int val)
+{
+	CAppConfig::GetInstance().SetPreferenceInteger(PREF_CGSH_OPENGL_RESOLUTION_FACTOR, val);
 }

--- a/Source/ui_qt/settingsdialog.h
+++ b/Source/ui_qt/settingsdialog.h
@@ -21,11 +21,12 @@ public:
 	void LoadPreferences();
 
 private slots:
-	void on_checkBox_enable_highres_clicked(bool checked);
 	void on_checkBox_force_bilinear_filtering_clicked(bool checked);
 	void on_checkBox_enable_audio_clicked(bool checked);
 	void on_comboBox_presentation_mode_currentIndexChanged(int index);
 	void changePage(QListWidgetItem* current, QListWidgetItem* previous);
+
+	void on_spinBox_resolution_valueChanged(int val);
 
 private:
 	Ui::SettingsDialog* ui;

--- a/Source/ui_qt/settingsdialog.h
+++ b/Source/ui_qt/settingsdialog.h
@@ -25,8 +25,7 @@ private slots:
 	void on_checkBox_enable_audio_clicked(bool checked);
 	void on_comboBox_presentation_mode_currentIndexChanged(int index);
 	void changePage(QListWidgetItem* current, QListWidgetItem* previous);
-
-	void on_spinBox_resolution_valueChanged(int val);
+	void on_comboBox_res_multiplyer_currentIndexChanged(int index);
 
 private:
 	Ui::SettingsDialog* ui;

--- a/build_android/src/main/res/values-zh/strings.xml
+++ b/build_android/src/main/res/values-zh/strings.xml
@@ -44,8 +44,7 @@
 
 	<string name="pref_emu_video">视频设置</string>
 
-	<string name="pref_emu_video_enable_highres_title">启用高分辨率模式</string>
-	<string name="pref_emu_video_enable_highres_summary">启用 2x 大小的帧缓冲区进行渲染。</string>
+	<string name="pref_emu_video_res_factor_title">Set Resolution Factor</string>
 
 	<string name="pref_emu_video_force_bilinear_title">强制双线性过滤</string>
 	<string name="pref_emu_video_force_bilinear_summary">强制在所有纹理上使用双线性过滤。</string>

--- a/build_android/src/main/res/values/donottranslate.xml
+++ b/build_android/src/main/res/values/donottranslate.xml
@@ -34,8 +34,6 @@
 		<item>2</item>
 		<item>4</item>
 		<item>8</item>
-		<item>16</item>
-		<item>32</item>
     </string-array>
 
 </resources>

--- a/build_android/src/main/res/values/donottranslate.xml
+++ b/build_android/src/main/res/values/donottranslate.xml
@@ -29,4 +29,13 @@
 		<item>elf</item>
 	</string-array>
 
+	<string-array name="pref_emu_video_res_factor_values">
+		<item>1</item>
+		<item>2</item>
+		<item>4</item>
+		<item>8</item>
+		<item>16</item>
+		<item>32</item>
+    </string-array>
+
 </resources>

--- a/build_android/src/main/res/values/strings.xml
+++ b/build_android/src/main/res/values/strings.xml
@@ -86,8 +86,6 @@
 		<item>2x</item>
 		<item>4x</item>
 		<item>8x</item>
-		<item>16x</item>
-		<item>32x</item>
 	</string-array>
 
 	<!-- Emulator Drawer -->

--- a/build_android/src/main/res/values/strings.xml
+++ b/build_android/src/main/res/values/strings.xml
@@ -44,8 +44,7 @@
 
 	<string name="pref_emu_video">Video Settings</string>
 
-	<string name="pref_emu_video_enable_highres_title">Enable High Resolution Mode</string>
-	<string name="pref_emu_video_enable_highres_summary">Enables usage of 2x sized framebuffers for rendering.</string>
+	<string name="pref_emu_video_res_factor_title">Set Resolution Factor</string>
 
 	<string name="pref_emu_video_force_bilinear_title">Force Bilinear Filtering</string>
 	<string name="pref_emu_video_force_bilinear_summary">Forces usage of bilinear filtering on all textures.</string>
@@ -80,6 +79,15 @@
 		<item>Teal</item>
 		<item>Dark Purple</item>
 		<item>Green</item>
+	</string-array>
+
+	<string-array name="pref_emu_video_res_factor_entries">
+		<item>1x</item>
+		<item>2x</item>
+		<item>4x</item>
+		<item>8x</item>
+		<item>16x</item>
+		<item>32x</item>
 	</string-array>
 
 	<!-- Emulator Drawer -->

--- a/build_android/src/main/res/xml/settings_emu_fragment.xml
+++ b/build_android/src/main/res/xml/settings_emu_fragment.xml
@@ -18,12 +18,14 @@
 	<PreferenceCategory
 		android:title="@string/pref_emu_video"
 		>
-		<CheckBoxPreference
-			android:key="renderer.opengl.enablehighresmode"
-			android:title="@string/pref_emu_video_enable_highres_title"
-			android:summary="@string/pref_emu_video_enable_highres_summary"
-			android:persistent="false"
-		/>
+		<ListPreference
+			android:key="renderer.opengl.resfactor"
+			android:title="@string/pref_emu_video_res_factor_title"
+			android:entries="@array/pref_emu_video_res_factor_entries"
+			android:entryValues="@array/pref_emu_video_res_factor_values"
+			android:defaultValue="1"
+			android:negativeButtonText="@null"
+			android:positiveButtonText="@null"/>
 		<CheckBoxPreference
 			android:key="renderer.opengl.forcebilineartextures"
 			android:title="@string/pref_emu_video_force_bilinear_title"


### PR DESCRIPTION
Notes:
~~Windows: UI needs updating, Im aware that passing some DROPDOWN flag to CListBox allows me to create a drop down menu to add resolution multipliers, but how would I create a label for it?~~
Since current Win32 UI we'll be replaced with Qt, no need to worry about this

iOS: no experience in iOS (/UI), so I can't do much about it (if it even has the option now for higher resolution?)

Qt: tested on OSX/Win32 works fine
~~Android: 👍, though I noticed some indentation inconsistency in the xml, so will fix that.
edit:
for android I noticed you're using `CSettingsManager` which then calls `CAppConfig`, is that necessary?~~