### PR TITLE
[POC/discuss]Interlacing offset Fix

### DIFF
--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -202,10 +202,29 @@ void CGSH_OpenGL::FlipImpl()
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_RED);
 
+
+		static FramebufferPtr previousFramebuffer;
+		if(halfHeight)
+		{
+			if(!previousFramebuffer)
+			{
+				previousFramebuffer = FramebufferPtr(new CFramebuffer(fb.GetBufPtr(), fb.GetBufWidth(), FRAMEBUFFER_HEIGHT, fb.nPSM, m_fbScale, m_multisampleEnabled));
+			}
+			glActiveTexture(GL_TEXTURE2);
+			glBindTexture(GL_TEXTURE_2D, previousFramebuffer->m_texture);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_RED);
+		}
+
+
 		glUseProgram(*m_presentProgram);
 
 		assert(m_presentTextureUniform != -1);
 		glUniform1i(m_presentTextureUniform, 0);
+ 		glUniform1i(m_presentTextureUniform, 2);
 
 		assert(m_presentTexCoordScaleUniform != -1);
 		glUniform2f(m_presentTexCoordScaleUniform, u1, v1);
@@ -213,11 +232,31 @@ void CGSH_OpenGL::FlipImpl()
 		glBindBuffer(GL_ARRAY_BUFFER, m_presentVertexBuffer);
 		glBindVertexArray(m_presentVertexArray);
 
+		glUniform1f(m_presentFieldUniform, (m_nCSR & CSR_FIELD) == CSR_FIELD ? 1 : 0);
+
 #ifdef _DEBUG
 		m_presentProgram->Validate();
 #endif
 
 		glDrawArrays(GL_TRIANGLES, 0, 3);
+
+		if(halfHeight)
+		{
+			if(previousFramebuffer)
+			{
+				glBindFramebuffer(GL_FRAMEBUFFER, previousFramebuffer->m_framebuffer);
+				glBindFramebuffer(GL_READ_FRAMEBUFFER, framebuffer->m_framebuffer);
+
+				//Copy buffers
+				glBlitFramebuffer(
+					0, 0, framebuffer->m_width * m_fbScale, framebuffer->m_height * m_fbScale,
+					0, 0, previousFramebuffer->m_width * m_fbScale, previousFramebuffer->m_height * m_fbScale,
+					GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+				glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+				glBindFramebuffer(GL_FRAMEBUFFER, m_presentFramebuffer);
+			}
+		}
 	}
 
 	CHECKGLERROR();
@@ -281,7 +320,9 @@ void CGSH_OpenGL::InitializeRC()
 	m_presentVertexBuffer = GeneratePresentVertexBuffer();
 	m_presentVertexArray = GeneratePresentVertexArray();
 	m_presentTextureUniform = glGetUniformLocation(*m_presentProgram, "g_texture");
+	m_presentTexture2Uniform = glGetUniformLocation(*m_presentProgram, "g_texture2");
 	m_presentTexCoordScaleUniform = glGetUniformLocation(*m_presentProgram, "g_texCoordScale");
+	m_presentFieldUniform = glGetUniformLocation(*m_presentProgram, "g_field");
 
 	m_copyToFbProgram = GenerateCopyToFbProgram();
 	m_copyToFbTexture = Framework::OpenGl::CTexture::Create();
@@ -1718,10 +1759,10 @@ void CGSH_OpenGL::DoRenderPass()
 	{
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, m_renderState.texture0Handle);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, m_renderState.texture0MinFilter);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, m_renderState.texture0MagFilter);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, m_renderState.texture0WrapS);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, m_renderState.texture0WrapT);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, m_renderState.texture0AlphaAsIndex ? GL_ALPHA : GL_RED);
 
 		glActiveTexture(GL_TEXTURE1);

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.h
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.h
@@ -410,7 +410,9 @@ private:
 	Framework::OpenGl::CBuffer m_presentVertexBuffer;
 	Framework::OpenGl::CVertexArray m_presentVertexArray;
 	GLint m_presentTextureUniform = -1;
+	GLint m_presentTexture2Uniform = -1;
 	GLint m_presentTexCoordScaleUniform = -1;
+	GLint m_presentFieldUniform = -1;
 
 	Framework::OpenGl::ProgramPtr m_copyToFbProgram;
 	Framework::OpenGl::CTexture m_copyToFbTexture;

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL_Shader.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL_Shader.cpp
@@ -467,9 +467,15 @@ Framework::OpenGl::ProgramPtr CGSH_OpenGL::GeneratePresentProgram()
 		shaderBuilder << "in vec2 v_texCoord;" << std::endl;
 		shaderBuilder << "out vec4 fragColor;" << std::endl;
 		shaderBuilder << "uniform sampler2D g_texture;" << std::endl;
+		shaderBuilder << "uniform sampler2D g_texture2;" << std::endl;
+		shaderBuilder << "uniform float g_field;" << std::endl;
 		shaderBuilder << "void main()" << std::endl;
 		shaderBuilder << "{" << std::endl;
-		shaderBuilder << "	fragColor = texture(g_texture, v_texCoord);" << std::endl;
+		shaderBuilder << "	vec2 p = vec2(floor(gl_FragCoord.x), floor(gl_FragCoord.y));" << std::endl;
+		shaderBuilder << "	if (mod(p.y, 2.0) == g_field)" << std::endl;
+		shaderBuilder << "		fragColor = texture(g_texture, v_texCoord);" << std::endl;
+		shaderBuilder << "	else" << std::endl;
+		shaderBuilder << "		fragColor = texture(g_texture2, v_texCoord);" << std::endl;
 		shaderBuilder << "}" << std::endl;
 
 		pixelShader.SetSource(shaderBuilder.str().c_str());


### PR DESCRIPTION
I noticed this really annoying screen shake in few games, and after some investigating it turned out to be related to games that support interlacing, the short version of it is, one of the pair of frames needed to be offset'ed by 1 pixel (per display size) to fix.

this seem to work for all games I've tested with few exception:

- ever blue seem to require 3 pixel offset

- Champions of Norrath US version, seems to require offset of half a pixel offset (?) (but I also think texture play a part here, in that if you step per frame, you can see that the texture (for the menu) actually changes, in that it loses it border top or bottom with alternating frame, thus exaggerate the effect)

- future tactics, will this work well with it, during the initial loading screen, you can see the text shake, though I haven't noticed this during game play or even the start menu... idle loop skip? or need a better frame indicator than `m_nCSR`?

- Dark Cloud, in the 1st area, the character is stable, but the mountain in the background seems to be be offset'ed, so its now shaking XD

- as a side effect of offsetting the image by a pixel, the top and bottom border of the game appears to be shaking

so, I posted this mainly to ask if you suggest applying this patch somewhere else? perhaps to the frame buffer itself? maybe however the interlaced frame is processed can be changed? we can offset the buffer by adding an extra line(duplicate the previous/next row) (though this won't work when the window size is 2x the original game, as then we'd need to offset by 2 pixels)
