### PR TITLE
fix cover art url string formatting

### DIFF
--- a/Source/ui_shared/BootablesProcesses.cpp
+++ b/Source/ui_shared/BootablesProcesses.cpp
@@ -114,7 +114,7 @@ void FetchGameTitles()
 						}
 						if(!game.boxArtUrl.empty())
 						{
-							auto coverUrl = string_format("%s/%s", game.baseImgUrl.c_str(), game.boxArtUrl.c_str());
+							auto coverUrl = string_format("%s%s", game.baseImgUrl.c_str(), game.boxArtUrl.c_str());
 							BootablesDb::CClient::GetInstance().SetCoverUrl(bootable.path, coverUrl.c_str());
 						}
 


### PR DESCRIPTION
extra / causes cdn to create a unique cache to that url, which we over TGDB dont actually clear when new image is uploaded