### PR TITLE
Gamepad profile

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -198,6 +198,8 @@ set(COMMON_SRC_FILES
 	FpUtils.h
 	FrameDump.cpp
 	FrameDump.h
+	InputConfig.cpp
+	InputConfig.h
 	GenericMipsExecutor.h
 	gs/GsCachedArea.cpp
 	gs/GsCachedArea.h

--- a/Source/InputConfig.cpp
+++ b/Source/InputConfig.cpp
@@ -1,0 +1,46 @@
+#include "AppConfig.h"
+#include "InputConfig.h"
+#include "PathUtils.h"
+
+#define PROFILE_PATH ("inputprofiles")
+
+CInputConfig::CInputConfig(const Framework::CConfig::PathType& path)
+    : CConfig(path)
+{
+}
+
+bool CInputConfig::IsValidProfileName(std::string name)
+{
+	static const std::string valid_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-";
+	for(auto c : name)
+	{
+		if(valid_chars.find(c) == std::string::npos)
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+std::unique_ptr<CInputConfig> CInputConfig::LoadProfile(std::string name)
+{
+	auto path = GetProfilePath() / name;
+	path.replace_extension(".xml");
+	return std::make_unique<CInputConfig>(path);
+}
+
+Framework::CConfig::PathType CInputConfig::GetProfilePath()
+{
+	auto profile_path = CAppConfig::GetBasePath() / PROFILE_PATH;
+	Framework::PathUtils::EnsurePathExists(profile_path);
+	return profile_path;
+}
+
+Framework::CConfig::PathType CInputConfig::GetProfile(std::string name)
+{
+	auto profile_path = CAppConfig::GetBasePath() / PROFILE_PATH;
+	Framework::PathUtils::EnsurePathExists(profile_path);
+	profile_path /= name;
+	profile_path.replace_extension(".xml");
+	return profile_path;
+}

--- a/Source/InputConfig.h
+++ b/Source/InputConfig.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Config.h"
+
+#define DEFAULT_PROFILE ("default")
+
+class CInputConfig : public Framework::CConfig
+{
+public:
+	CInputConfig(const Framework::CConfig::PathType& path);
+	virtual ~CInputConfig() = default;
+
+	static bool IsValidProfileName(std::string);
+	static CConfig::PathType GetProfilePath();
+	static CConfig::PathType GetProfile(std::string = DEFAULT_PROFILE);
+	static std::unique_ptr<CInputConfig> LoadProfile(std::string = DEFAULT_PROFILE);
+};

--- a/Source/input/InputBindingManager.h
+++ b/Source/input/InputBindingManager.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "Config.h"
+#include "InputConfig.h"
 #include "ControllerInfo.h"
 #include "InputProvider.h"
 #include <array>
 #include <memory>
 #include <functional>
+#include <string>
 
 class CInputBindingManager
 {
@@ -60,7 +62,8 @@ public:
 	void SetPovHatBinding(uint32, PS2::CControllerInfo::BUTTON, const BINDINGTARGET&, uint32);
 	void SetSimulatedAxisBinding(uint32, PS2::CControllerInfo::BUTTON, const BINDINGTARGET&, const BINDINGTARGET&);
 
-	void Load();
+	void Reload();
+	void Load(std::string);
 	void Save();
 
 private:
@@ -149,6 +152,6 @@ private:
 	static uint32 m_buttonDefaultValue[PS2::CControllerInfo::MAX_BUTTONS];
 	static const char* m_padPreferenceName[MAX_PADS];
 
-	Framework::CConfig& m_config;
+	std::unique_ptr<CInputConfig> m_config;
 	ProviderMap m_providers;
 };

--- a/Source/ui_qt/ControllerConfig/controllerconfigdialog.cpp
+++ b/Source/ui_qt/ControllerConfig/controllerconfigdialog.cpp
@@ -199,9 +199,9 @@ void ControllerConfigDialog::on_delProfileButton_clicked()
 		auto profile_path = CInputConfig::GetProfile(profile_name);
 		if(fs::exists(profile_path))
 		{
-			fs::remove(profile_path);
 			int index = ui->comboBox->currentIndex();
 			ui->comboBox->removeItem(index);
+			fs::remove(profile_path);
 		}
 	}
 }

--- a/Source/ui_qt/ControllerConfig/controllerconfigdialog.cpp
+++ b/Source/ui_qt/ControllerConfig/controllerconfigdialog.cpp
@@ -153,7 +153,7 @@ int ControllerConfigDialog::OpenBindConfigDialog(int index)
 
 void ControllerConfigDialog::on_comboBox_currentIndexChanged(int index)
 {
-	ui->delProfileButton->setEnabled(index > 0);
+	ui->delProfileButton->setEnabled(ui->comboBox->count() > 1);
 
 	auto profile = ui->comboBox->itemText(index).toStdString();
 	m_inputManager->Load(profile.c_str());

--- a/Source/ui_qt/ControllerConfig/controllerconfigdialog.cpp
+++ b/Source/ui_qt/ControllerConfig/controllerconfigdialog.cpp
@@ -156,6 +156,7 @@ void ControllerConfigDialog::on_comboBox_currentIndexChanged(int index)
 	ui->delProfileButton->setEnabled(ui->comboBox->count() > 1);
 
 	auto profile = ui->comboBox->itemText(index).toStdString();
+	m_inputManager->Save();
 	m_inputManager->Load(profile.c_str());
 	CAppConfig::GetInstance().SetPreferenceString(PREF_INPUT_PAD1_PROFILE, profile.c_str());
 

--- a/Source/ui_qt/ControllerConfig/controllerconfigdialog.h
+++ b/Source/ui_qt/ControllerConfig/controllerconfigdialog.h
@@ -27,6 +27,10 @@ private slots:
 	void on_tableView_doubleClicked(const QModelIndex& index);
 	void on_ConfigAllButton_clicked();
 
+	void on_comboBox_currentIndexChanged(int index);
+	void on_addProfileButton_clicked();
+	void on_delProfileButton_clicked();
+
 private:
 	void PrepareBindingsView();
 	int OpenBindConfigDialog(int index);

--- a/Source/ui_qt/PreferenceDefs.h
+++ b/Source/ui_qt/PreferenceDefs.h
@@ -3,3 +3,4 @@
 #define PREFERENCE_AUDIO_ENABLEOUTPUT "audio.enableoutput"
 #define PREF_UI_PAUSEWHENFOCUSLOST "ui.pausewhenfocuslost"
 #define PREF_VIDEO_GS_HANDLER "video.gshandler"
+#define PREF_INPUT_PAD1_PROFILE "input.pad1.profile"

--- a/Source/ui_qt/Qt_ui/controllerconfigdialog.ui
+++ b/Source/ui_qt/Qt_ui/controllerconfigdialog.ui
@@ -26,26 +26,6 @@
    <string>Controller Manager</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="1" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QPushButton" name="ConfigAllButton">
-     <property name="text">
-      <string>Config All</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0" colspan="2">
     <widget class="QTabWidget" name="tabWidget">
      <property name="enabled">
@@ -81,6 +61,53 @@ QGroupBox::title {
        </item>
       </layout>
      </widget>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QPushButton" name="ConfigAllButton">
+     <property name="text">
+      <string>Config All</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Profile(s)</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item>
+       <widget class="QComboBox" name="comboBox">
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="addProfileButton">
+        <property name="text">
+         <string>Add</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="delProfileButton">
+        <property name="text">
+         <string>Remove</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/Source/ui_qt/mainwindow.cpp
+++ b/Source/ui_qt/mainwindow.cpp
@@ -150,7 +150,10 @@ void MainWindow::InitVirtualMachine()
 	{
 		m_virtualMachine->CreatePadHandler(CPH_GenericInput::GetFactoryFunction());
 		auto padHandler = static_cast<CPH_GenericInput*>(m_virtualMachine->GetPadHandler());
+		auto profile = CAppConfig::GetInstance().GetPreferenceString(PREF_INPUT_PAD1_PROFILE);
+
 		auto& bindingManager = padHandler->GetBindingManager();
+		bindingManager.Load(profile);
 
 		//Create QtKeyInputProvider
 		m_qtKeyInputProvider = std::make_shared<CInputProviderQtKey>();
@@ -642,6 +645,7 @@ void MainWindow::RegisterPreferences()
 	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREFERENCE_AUDIO_ENABLEOUTPUT, true);
 	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREF_UI_PAUSEWHENFOCUSLOST, true);
 	CAppConfig::GetInstance().RegisterPreferenceInteger(PREF_VIDEO_GS_HANDLER, SettingsDialog::GS_HANDLERS::OPENGL);
+	CAppConfig::GetInstance().RegisterPreferenceString(PREF_INPUT_PAD1_PROFILE, "default");
 }
 
 void MainWindow::focusOutEvent(QFocusEvent* event)


### PR DESCRIPTION
~~this PR would require these changes https://github.com/jpd002/Play--Framework/commit/3ab44ec526647666ebdd73f95dcce8ed6da9f8e9 in Framework repo.~~

~~however, I'm not sure how you feel about those particular changes? more specifically the `Framework` ones? making path editable and Load accessible like that.~~

I also moved gamepad config to their own xml, i know a while back, you didnt really want that, under slightly different context (aka gamepad1 vs gamepad2), however in this case, i think the config file will be overflooded and harder to manage if we keep all the profiles in the same `config.xml` file

TODO:

~~- [ ] add few error msg dialogs~~
~~- [ ] clean up commits, use descriptive names~~
- [x] Address the TODO comments