### PR TITLE
Linux deployment

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -77,8 +77,16 @@ travis_script()
             if [ "$CXX" = "g++" ]; then export CXX="g++-5" CC="gcc-5"; fi
             export PATH=/opt/cmake-3.8.1-Linux-x86_64/bin/:$PATH
             source /opt/qt56/bin/qt56-env.sh || true
-            cmake .. -G"$BUILD_TYPE" -DCMAKE_PREFIX_PATH=/opt/qt56/;
+            cmake .. -G"$BUILD_TYPE" -DCMAKE_PREFIX_PATH=/opt/qt56/ -DCMAKE_INSTALL_PREFIX=./appdir/usr;
             cmake --build .
+            cmake --build . --target install
+
+            # AppImage Creation
+            wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+            chmod a+x linuxdeployqt*.AppImage
+            unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+            ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -qmake=/opt/qt56/bin/qmake
+            ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -qmake=/opt/qt56/bin/qmake
         elif [ "$TARGET_OS" = "OSX" ]; then
             export CMAKE_PREFIX_PATH="$(brew --prefix qt5)"
             cmake .. -G"$BUILD_TYPE"
@@ -110,6 +118,9 @@ travis_before_deploy()
     pushd $SHORT_HASH
     if [ -z "$ANDROID_KEYSTORE_PASS" ]; then
         return
+    fi;
+    if [ "$TARGET_OS" = "Linux" ]; then
+        cp ../../build_cmake/build/Play*.AppImage .
     fi;
     if [ "$TARGET_OS" = "Android" ]; then
         cp ../../build_android/build/outputs/apk/release/Play-release-unsigned.apk .

--- a/Source/ui_qt/CMakeLists.txt
+++ b/Source/ui_qt/CMakeLists.txt
@@ -221,6 +221,13 @@ elseif(TARGET_PLATFORM_WIN32)
 		win32/InputProviderDirectInput.h
 	)
 	add_executable(Play WIN32 ${QT_SOURCES} ${QT_MOC_SRCS} ${QT_RES_SOURCES} ${QT_UI_HEADERS})
+elseif(TARGET_PLATFORM_UNIX)
+	add_executable(Play ${QT_SOURCES} ${QT_MOC_SRCS} ${QT_RES_SOURCES} ${QT_UI_HEADERS})
+
+	install(TARGETS Play DESTINATION bin RENAME Play PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ)
+
+	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../installer_unix/Play.desktop DESTINATION share/applications)
+	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../icons/icon_base.png DESTINATION share/icons RENAME Play.png)
 else()
 	add_executable(Play ${QT_SOURCES} ${QT_MOC_SRCS} ${QT_RES_SOURCES} ${QT_UI_HEADERS})
 endif()

--- a/installer_unix/Play.desktop
+++ b/installer_unix/Play.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Play!
+TryExec=/usr/bin/Play
+Exec=/usr/bin/Play
+Icon=Play
+Version=1.0
+Terminal=false
+Type=Application
+Categories=Game;Emulator;
+


### PR DESCRIPTION
an amalgamation of #628 (app image) #543 (install)

for testing initially built on Ubuntu 16.04 (using Qt 5.12):
resulting package tested on Ubuntu 16.04, arch linux (PS4) (dont know how versioning work on arch XD)

Note: I can't test travis deployment, but assuming its straight forward, that should work just fine as committed

resolves #635 closes #628 closes #543