### PR TITLE
Boost removal

### DIFF
--- a/Source/ui_qt/win32/DebugSupport/ELFSymbolView.cpp
+++ b/Source/ui_qt/win32/DebugSupport/ELFSymbolView.cpp
@@ -282,7 +282,7 @@ void CELFSymbolView::GetItemInfo(LVITEM* outItem) const
 {
 	if(outItem->iItem >= m_items.size()) return;
 	const ITEM& item(m_items[outItem->iItem]);
-	const PooledString* itemText(NULL);
+	const std::tstring* itemText(NULL);
 	switch(outItem->iSubItem)
 	{
 	case 0:
@@ -304,5 +304,5 @@ void CELFSymbolView::GetItemInfo(LVITEM* outItem) const
 		itemText = &item.section;
 		break;
 	}
-	outItem->pszText = const_cast<TCHAR*>(static_cast<const std::tstring&>(*itemText).c_str());
+	outItem->pszText = const_cast<TCHAR*>(itemText->c_str());
 }

--- a/Source/ui_qt/win32/DebugSupport/ELFSymbolView.h
+++ b/Source/ui_qt/win32/DebugSupport/ELFSymbolView.h
@@ -3,7 +3,9 @@
 #include "win32/Window.h"
 #include "win32/ListView.h"
 #include "ELF.h"
-#include <boost/flyweight.hpp>
+
+#include <vector>
+#include <string>
 
 class CELFSymbolView : public Framework::Win32::CWindow
 {
@@ -12,16 +14,14 @@ public:
 	virtual ~CELFSymbolView();
 
 private:
-	typedef boost::flyweight<std::tstring> PooledString;
-
 	struct ITEM
 	{
-		PooledString name;
-		PooledString address;
-		PooledString size;
-		PooledString type;
-		PooledString binding;
-		PooledString section;
+		std::tstring name;
+		std::tstring address;
+		std::tstring size;
+		std::tstring type;
+		std::tstring binding;
+		std::tstring section;
 	};
 
 	typedef std::vector<ITEM> ItemArray;


### PR DESCRIPTION
- [x] remove boost::scoped_ptr (merged)
- [x] remove boost::lexicasl_cast (merged)
- [x] boost::noncopyable (merged)
- [x] remove boost::bind (merged) 
- [x] remove boost::replace_all (merged)
- [x] remove boost::erase_all (merged)
- [x] remove boost::is_any_of (merged)
- [x] remove boost::split (merged)
~- [ ] remove boost::any~ 
~- [ ] remove boost::any_cast~ boost::any_* will be dealt with in a separate PR.
- [x] remove boost::filesystem
- [x] remove boost::signals2::* (merged) 
  - [x] boost::signals2::signal (merged) 
  - [x] boost::signals2::trackable (merged)
  - [x] boost::signals2::connection (merged)
- [x] boost::flyweight

~~though these commit touch `Win32_UI`, since its to be removed, I haven't build it to test their validity,
however, as of f29638a the changes are simple enough to presume they're valid.~~

You'd need this PR https://github.com/jpd002/Play--Framework/pull/18 and https://github.com/jpd002/Play-Dependencies/pull/17

Note to self: c1d1235 is probably an issue with my own setup, need to check it out.