### PR TITLE
allow selecting cdfs as disc type

### DIFF
--- a/Source/ui_qt/vfsdiscselectordialog.cpp
+++ b/Source/ui_qt/vfsdiscselectordialog.cpp
@@ -57,7 +57,7 @@ void VFSDiscSelectorDialog::Refresh_disc_drive()
 		if(storage.isValid() && storage.isReady())
 		{
 			QString FS(storage.fileSystemType());
-			if(QString::compare(FS, "UDF", Qt::CaseInsensitive) == 0 || QString::compare(FS, "ISO9660", Qt::CaseInsensitive) == 0)
+			if(QString::compare(FS, "UDF", Qt::CaseInsensitive) == 0 || QString::compare(FS, "ISO9660", Qt::CaseInsensitive) == 0 || QString::compare(FS, "CDFS", Qt::CaseInsensitive) == 0)
 			{
 				QString device(storage.device());
 				QString name;


### PR DESCRIPTION
related to #806 
note, this still doesnt allow games to start from disc on windows, since i think `COpticalMedia` can't create a valid stream from cdvd physical address? (atleast for the games i've tested)