### PR TITLE
Arm64 travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,15 @@ matrix:
       env:
         - BUILD_TYPE="Unix Makefiles"
         - TARGET_OS=Linux
+        - TARGET_ARCH=x86_64
+      sudo: require
+    - os: linux
+      arch: arm64
+      dist: bionic
+      env:
+        - BUILD_TYPE="Unix Makefiles"
+        - TARGET_OS=Linux
+        - TARGET_ARCH=ARM64
       sudo: require
     - os: osx
       osx_image: xcode10.3

--- a/Source/ui_qt/GSH_OpenGLQt.cpp
+++ b/Source/ui_qt/GSH_OpenGLQt.cpp
@@ -1,6 +1,13 @@
+#if !defined(GLES_COMPATIBILITY)
 #include "GSH_OpenGLQt.h"
+#endif
+
 #include <QWindow>
 #include <QOpenGLContext>
+
+#if defined(GLES_COMPATIBILITY)
+#include "GSH_OpenGLQt.h"
+#endif
 
 CGSH_OpenGLQt::CGSH_OpenGLQt(QWindow* renderWindow)
     : m_renderWindow(renderWindow)

--- a/Source/ui_qt/openglwindow.cpp
+++ b/Source/ui_qt/openglwindow.cpp
@@ -5,7 +5,11 @@ OpenGLWindow::OpenGLWindow(QWindow* parent)
     : QWindow(parent)
 {
 	QSurfaceFormat format;
+#if defined(GLES_COMPATIBILITY)
+	format.setVersion(3, 0);
+#else
 	format.setVersion(3, 2);
+#endif
 	format.setProfile(QSurfaceFormat::CoreProfile);
 	format.setSwapBehavior(QSurfaceFormat::DoubleBuffer);
 


### PR DESCRIPTION
this will only build Qt GLES Arm64 version on travis, it will not deploy it.
to deploy it, we need to build `linuxdeployqt` from source, since no prebuilt version currently exist, however thats currently causing me issues, since it builds, but refused to package due to the current glibc version (since they want to "encourage" use of older version for compatibility reasons).

edit:
the header problem stems from clash of GLEW/Qt vs GLES/Qt so there was no configuration that would work for all of them