### PR TITLE
remove libc from AppImage

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -17,7 +17,6 @@ travis_before_install()
             sudo add-apt-repository --yes ppa:beineri/opt-qt-5.12.3-xenial
             sudo apt update -qq
             sudo apt install -qq qt512base gcc-9 g++-9 libgl1-mesa-dev libglu1-mesa-dev libalut-dev libevdev-dev
-            apt download libc6
         fi
     elif [ "$TARGET_OS" = "Linux_Clang_Format" ]; then
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
@@ -75,19 +74,15 @@ travis_script()
             ctest
             cmake --build . --target install
             if [ "$TARGET_ARCH" = "x86_64" ]; then
-                mkdir tmp; cd tmp
-                ar x ../../libc6*
-                cd ../appdir/
-                tar xf ../tmp/data.tar.xz
-                cd ..
-                rm -rf tmp;
-
                 mkdir -p appdir/usr/optional/
                 mkdir -p appdir/usr/optional/libstdc++/
                 cp /usr/lib/*-linux-gnu/libstdc++.so.6 ./appdir/usr/optional/libstdc++/
                 cp ../AppRun ./appdir/AppRun
                 cp ../exec.so ./appdir/usr/optional/exec.so
                 printf "#include <memory>\nint main(){std::make_exception_ptr(0);}" | $CXX -x c++ -o ./appdir/usr/optional/checker -
+
+                mkdir -p appdir/usr/share/doc/libc6/
+                echo "" > appdir/usr/share/doc/libc6/copyright
                 # AppImage Creation
                 unset QTDIR; unset QT_PLUGIN_PATH; unset LD_LIBRARY_PATH;
                 export VERSION="${TRAVIS_COMMIT:0:8}"


### PR DESCRIPTION
closes #830 

`linuxdeployqt` doesnt like xenial glibc version, so we must use `-unsupported-allow-new-glibc`,
however, that param still doesnt allow us to package an image, as it expect us to package `glibc`,
but it only checks for `appdir/usr/share/doc/libc6/copyright`.

Note:
we could build on trusty to avoid the work around, but that would net us nothing.
as `-unsupported-allow-new-glibc` does nothing more than skip a check (nothing more or less is packaged)
https://github.com/jpd002/Play-/compare/e4be67948255e207a299a6b3881c77cd546c290c...84c6697b437fdd122d8769440b960a91d311ce51?expand=1