### PR TITLE
Fix path builder

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -260,6 +260,8 @@ set(COMMON_SRC_FILES
 	iop/Iop_MtapMan.h
 	iop/Iop_PadMan.cpp
 	iop/Iop_PadMan.h
+	iop/Iop_PathUtils.cpp
+	iop/Iop_PathUtils.h
 	iop/Iop_RootCounters.cpp
 	iop/Iop_RootCounters.h
 	iop/Iop_SifCmd.cpp

--- a/Source/iop/DirectoryDevice.cpp
+++ b/Source/iop/DirectoryDevice.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 #include "DirectoryDevice.h"
+#include "Iop_PathUtils.h"
 #include "StdStream.h"
 #include "string_cast.h"
 #include "../AppConfig.h"
@@ -30,7 +31,7 @@ Framework::CStdStream* CreateStdStream(const std::wstring& path, const char* mod
 Framework::CStream* CDirectoryDevice::GetFile(uint32 accessType, const char* devicePath)
 {
 	auto basePath = CAppConfig::GetInstance().GetPreferencePath(m_basePathPreferenceName.c_str());
-	auto path = basePath / devicePath;
+	auto path = Iop::PathUtils::MakeHostPath(basePath, devicePath);
 
 	const char* mode = nullptr;
 	switch(accessType)
@@ -67,7 +68,7 @@ Framework::CStream* CDirectoryDevice::GetFile(uint32 accessType, const char* dev
 Directory CDirectoryDevice::GetDirectory(const char* devicePath)
 {
 	auto basePath = CAppConfig::GetInstance().GetPreferencePath(m_basePathPreferenceName.c_str());
-	auto path = basePath / devicePath;
+	auto path = Iop::PathUtils::MakeHostPath(basePath, devicePath);
 	if(!fs::is_directory(path))
 	{
 		throw std::runtime_error("Not a directory.");

--- a/Source/iop/Iop_McServ.cpp
+++ b/Source/iop/Iop_McServ.cpp
@@ -639,7 +639,7 @@ void CMcServ::GetEntSpace(uint32* args, uint32 argsSize, uint32* ret, uint32 ret
 	                          cmd->port, cmd->slot, cmd->flags, cmd->name);
 
 	auto mcPath = CAppConfig::GetInstance().GetPreferencePath(m_mcPathPreference[cmd->port]);
-	auto savePath = mcPath / cmd->name;
+	auto savePath = MakeHostPath(mcPath, cmd->name);
 
 	if(fs::exists(savePath) && fs::is_directory(savePath))
 	{

--- a/Source/iop/Iop_McServ.cpp
+++ b/Source/iop/Iop_McServ.cpp
@@ -5,6 +5,7 @@
 #include "../PS2VM_Preferences.h"
 #include "../Log.h"
 #include "Iop_McServ.h"
+#include "Iop_PathUtils.h"
 #include "Iop_Sysmem.h"
 #include "Iop_SifCmd.h"
 #include "Iop_SifManPs2.h"
@@ -52,21 +53,6 @@ CMcServ::CMcServ(CIopBios& bios, CSifMan& sifMan, CSifCmd& sifCmd, CSysmem& sysM
 const char* CMcServ::GetMcPathPreference(unsigned int port)
 {
 	return m_mcPathPreference[port];
-}
-
-fs::path CMcServ::MakeHostPath(const fs::path& baseHostPath, const char* mcPath)
-{
-	if(strlen(mcPath) == 0)
-	{
-		//If we're not adding anything, just return whatever we had
-		//We don't want to introduce a trailing slash since it will
-		//break other stuff
-		return baseHostPath;
-	}
-	auto result = baseHostPath;
-	result.concat("/");
-	result.concat(mcPath);
-	return result;
 }
 
 std::string CMcServ::GetId() const
@@ -520,7 +506,7 @@ void CMcServ::ChDir(uint32* args, uint32 argsSize, uint32* ret, uint32 retSize, 
 		}
 
 		auto mcPath = CAppConfig::GetInstance().GetPreferencePath(m_mcPathPreference[cmd->port]);
-		auto hostPath = MakeHostPath(mcPath, newCurrentDirectory.c_str());
+		auto hostPath = Iop::PathUtils::MakeHostPath(mcPath, newCurrentDirectory.c_str());
 
 		if(fs::exists(hostPath) && fs::is_directory(hostPath))
 		{
@@ -568,7 +554,7 @@ void CMcServ::GetDir(uint32* args, uint32 argsSize, uint32* ret, uint32 retSize,
 			auto mcPath = CAppConfig::GetInstance().GetPreferencePath(m_mcPathPreference[cmd->port]);
 			if(cmd->name[0] != SEPARATOR_CHAR)
 			{
-				mcPath = MakeHostPath(mcPath, m_currentDirectory.c_str());
+				mcPath = Iop::PathUtils::MakeHostPath(mcPath, m_currentDirectory.c_str());
 			}
 			mcPath = fs::absolute(mcPath);
 
@@ -579,7 +565,7 @@ void CMcServ::GetDir(uint32* args, uint32 argsSize, uint32* ret, uint32 retSize,
 				return;
 			}
 
-			auto searchPath = MakeHostPath(mcPath, cmd->name);
+			auto searchPath = Iop::PathUtils::MakeHostPath(mcPath, cmd->name);
 			searchPath.remove_filename();
 			if(!fs::exists(searchPath))
 			{
@@ -639,7 +625,7 @@ void CMcServ::GetEntSpace(uint32* args, uint32 argsSize, uint32* ret, uint32 ret
 	                          cmd->port, cmd->slot, cmd->flags, cmd->name);
 
 	auto mcPath = CAppConfig::GetInstance().GetPreferencePath(m_mcPathPreference[cmd->port]);
-	auto savePath = MakeHostPath(mcPath, cmd->name);
+	auto savePath = Iop::PathUtils::MakeHostPath(mcPath, cmd->name);
 
 	if(fs::exists(savePath) && fs::is_directory(savePath))
 	{
@@ -784,11 +770,11 @@ fs::path CMcServ::GetAbsoluteFilePath(unsigned int port, unsigned int slot, cons
 
 	if(name[0] == SEPARATOR_CHAR)
 	{
-		return MakeHostPath(mcPath, name);
+		return Iop::PathUtils::MakeHostPath(mcPath, name);
 	}
 	else
 	{
-		return MakeHostPath(MakeHostPath(mcPath, m_currentDirectory.c_str()), name);
+		return Iop::PathUtils::MakeHostPath(Iop::PathUtils::MakeHostPath(mcPath, m_currentDirectory.c_str()), name);
 	}
 }
 

--- a/Source/iop/Iop_McServ.h
+++ b/Source/iop/Iop_McServ.h
@@ -56,7 +56,6 @@ namespace Iop
 		virtual ~CMcServ() = default;
 
 		static const char* GetMcPathPreference(unsigned int);
-		static fs::path MakeHostPath(const fs::path&, const char*);
 
 		std::string GetId() const override;
 		std::string GetFunctionName(unsigned int) const override;

--- a/Source/iop/Iop_PathUtils.cpp
+++ b/Source/iop/Iop_PathUtils.cpp
@@ -1,0 +1,17 @@
+#include <cstring>
+#include "Iop_PathUtils.h"
+
+fs::path Iop::PathUtils::MakeHostPath(const fs::path& baseHostPath, const char* guestPath)
+{
+	if(strlen(guestPath) == 0)
+	{
+		//If we're not adding anything, just return whatever we had
+		//We don't want to introduce a trailing slash since it will
+		//break other stuff
+		return baseHostPath;
+	}
+	auto result = baseHostPath;
+	result.concat("/");
+	result.concat(guestPath);
+	return result;
+}

--- a/Source/iop/Iop_PathUtils.h
+++ b/Source/iop/Iop_PathUtils.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "filesystem_def.h"
+
+namespace Iop
+{
+	namespace PathUtils
+	{
+		fs::path MakeHostPath(const fs::path&, const char*);
+	}
+}

--- a/tools/McServTest/Main.cpp
+++ b/tools/McServTest/Main.cpp
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include "iop/IopBios.h"
 #include "iop/Iop_McServ.h"
+#include "iop/Iop_PathUtils.h"
 #include "iop/Iop_SubSystem.h"
 #include "AppConfig.h"
 #include "PathUtils.h"
@@ -28,12 +29,12 @@ void PrepareTestEnvironment(const CGameTestSheet::EnvironmentActionArray& enviro
 	{
 		if(environmentAction.type == CGameTestSheet::ENVIRONMENT_ACTION_CREATE_DIRECTORY)
 		{
-			auto folderToCreate = Iop::CMcServ::MakeHostPath(memoryCardPath, environmentAction.name.c_str());
+			auto folderToCreate = Iop::PathUtils::MakeHostPath(memoryCardPath, environmentAction.name.c_str());
 			Framework::PathUtils::EnsurePathExists(folderToCreate);
 		}
 		else if(environmentAction.type == CGameTestSheet::ENVIRONMENT_ACTION_CREATE_FILE)
 		{
-			auto fileToCreate = Iop::CMcServ::MakeHostPath(memoryCardPath, environmentAction.name.c_str());
+			auto fileToCreate = Iop::PathUtils::MakeHostPath(memoryCardPath, environmentAction.name.c_str());
 			auto inputStream = Framework::CreateOutputStdStream(fileToCreate.native());
 			inputStream.Seek(environmentAction.size - 1, Framework::STREAM_SEEK_SET);
 			inputStream.Write8(0x00);


### PR DESCRIPTION
as far as i can tell, these seem to be the only problematic lines, ill do another sweep later.

if device path starts with "/" the combined path truncates all of basePath except for partition part...

on windows
```cpp
std::filesystem::path basePath = "C:\blah\blash\blah";
char* devicePath = "/evil_access";
basePath / devicePath == "C:\evil_access";
```

Linux:
https://coliru.stacked-crooked.com/a/76ffae7f68e39128

~~Note: need to test this fix on Linux/OSX~~

Note to self:
fixes in `IOP_McServ` can probably just use `MakeHostPath()` instead