### PR TITLE
Remove boost dependency

### DIFF
--- a/Source/ui_ios/Purei_Prefix.pch
+++ b/Source/ui_ios/Purei_Prefix.pch
@@ -20,8 +20,6 @@
 	#include <unordered_map>
 	#include <memory>
 	#include <map>
-
-	#include <boost/signals2.hpp>
 #endif
 
 


### PR DESCRIPTION
Boost has already been removed from the project, but this include somehow lasted and was causing an error if boost was not available.
This file could probably be removed anyway since it hasn't been updated.