### PR TITLE
[WIP] Move the Framedebugger to OpenGL

### DIFF
--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -2246,16 +2246,28 @@ Framework::CBitmap CGSH_OpenGL::GetTextureImpl(uint64 tex0Reg, uint32 maxMip, ui
 	}
 
 	auto texFormat = GetTextureFormatInfo(tex0.nPsm);
-	auto bitsPerPixel = 8;
-	auto format = GL_RED;
-	if(texFormat.format != GL_RED)
-	{
-		bitsPerPixel = 32;
-		format = GL_BGRA;
-	}
+	auto bitsPerPixel =
+	    [format = tex0.nPsm]() {
+		    switch(format)
+		    {
+		    case PSMCT16:
+			    return 16;
+		    case PSMT4:
+		    case PSMT8:
+		    case PSMT8H:
+		    case PSMT4HL:
+		    case PSMT4HH:
+			    return 8;
+		    default:
+			    assert(false);
+		    case PSMCT32:
+		    case PSMCT24:
+			    return 32;
+		    }
+	    }();
 
 	auto imgbuffer = Framework::CBitmap(width, height, bitsPerPixel);
-	glGetTexImage(GL_TEXTURE_2D, 0, format, GL_UNSIGNED_BYTE, imgbuffer.GetPixels());
+	glGetTexImage(GL_TEXTURE_2D, 0, texFormat.format, texFormat.type, imgbuffer.GetPixels());
 	glBindTexture(GL_TEXTURE_2D, 0);
 	return imgbuffer;
 #else

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -2182,7 +2182,7 @@ Framework::CBitmap CGSH_OpenGL::GetScreenshot()
 Framework::CBitmap CGSH_OpenGL::GetFramebuffer(uint64 frameReg)
 {
 	Framework::CBitmap result;
-	m_mailBox.SendCall([&]() { result = GetFramebufferImpl(frameReg); }, true);
+	SendGSCall([&]() { result = GetFramebufferImpl(frameReg); }, true);
 	return result;
 }
 
@@ -2211,7 +2211,7 @@ Framework::CBitmap CGSH_OpenGL::GetFramebufferImpl(uint64 frameReg)
 Framework::CBitmap CGSH_OpenGL::GetTexture(uint64 tex0Reg, uint32 maxMip, uint64 miptbp1Reg, uint64 miptbp2Reg, uint32 mipLevel)
 {
 	Framework::CBitmap result;
-	m_mailBox.SendCall([&]() { result = GetTextureImpl(tex0Reg, maxMip, miptbp1Reg, miptbp2Reg, mipLevel); }, true);
+	SendGSCall([&]() { result = GetTextureImpl(tex0Reg, maxMip, miptbp1Reg, miptbp2Reg, mipLevel); }, true);
 	return result;
 }
 

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -623,8 +623,15 @@ void CGSH_OpenGL::SetRenderingContext(uint64 primReg)
 		//			glDisable(GL_BLEND);
 		//		}
 
-		m_renderState.blendEnabled = prim.nAlpha ? GL_TRUE : GL_FALSE;
-		m_validGlState &= ~GLSTATE_BLEND;
+		if(((prim.nAlpha != 0) && m_alphaBlendingEnabled))
+		{
+			m_renderState.blendEnabled = GL_TRUE;
+			m_validGlState &= ~GLSTATE_BLEND;
+		}
+		else
+		{
+			m_renderState.blendEnabled = GL_FALSE;
+		}
 	}
 
 	if(!m_renderState.isValid ||
@@ -1132,7 +1139,7 @@ void CGSH_OpenGL::FillShaderCapsFromTest(SHADERCAPS& shaderCaps, const uint64& t
 		}
 		else
 		{
-			shaderCaps.hasAlphaTest = 1;
+			shaderCaps.hasAlphaTest = m_alphaTestingEnabled ? 1 : 0;
 			shaderCaps.alphaTestMethod = test.nAlphaMethod;
 		}
 	}
@@ -1700,7 +1707,7 @@ void CGSH_OpenGL::DoRenderPass()
 		m_validGlState |= GLSTATE_BLEND;
 	}
 
-	if((m_validGlState & GLSTATE_DEPTHTEST) == 0)
+	if((m_validGlState & GLSTATE_DEPTHTEST) == 0 && m_depthTestingEnabled)
 	{
 		m_renderState.depthTest ? glEnable(GL_DEPTH_TEST) : glDisable(GL_DEPTH_TEST);
 		m_validGlState |= GLSTATE_DEPTHTEST;
@@ -2170,6 +2177,121 @@ Framework::CBitmap CGSH_OpenGL::GetScreenshot()
 		return imgbuffer.Resize(dispWidth * m_fbScale, dispHeight * 2 * m_fbScale);
 	}
 	return imgbuffer;
+}
+
+Framework::CBitmap CGSH_OpenGL::GetFramebuffer(uint64 frameReg)
+{
+	Framework::CBitmap result;
+	m_mailBox.SendCall([&]() { result = GetFramebufferImpl(frameReg); }, true);
+	return result;
+}
+
+Framework::CBitmap CGSH_OpenGL::GetFramebufferImpl(uint64 frameReg)
+{
+
+	auto frame = make_convertible<FRAME>(frameReg);
+	auto framebuffer = FindFramebuffer(frame);
+	if(!framebuffer)
+	{
+		return Framework::CBitmap();
+	}
+	else
+	{
+		glBindFramebuffer(GL_FRAMEBUFFER, framebuffer->m_framebuffer);
+		auto imgbuffer = Framework::CBitmap(framebuffer->m_width, framebuffer->m_height, 32);
+		glReadPixels(0, 0, framebuffer->m_width, framebuffer->m_height, GL_BGRA, GL_UNSIGNED_BYTE, imgbuffer.GetPixels());
+		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		return imgbuffer;
+	}
+}
+
+Framework::CBitmap CGSH_OpenGL::GetTexture(uint64 tex0Reg, uint32 maxMip, uint64 miptbp1Reg, uint64 miptbp2Reg, uint32 mipLevel)
+{
+	Framework::CBitmap result;
+	m_mailBox.SendCall([&]() { result = GetTextureImpl(tex0Reg, maxMip, miptbp1Reg, miptbp2Reg, mipLevel); }, true);
+	return result;
+}
+
+Framework::CBitmap CGSH_OpenGL::GetTextureImpl(uint64 tex0Reg, uint32 maxMip, uint64 miptbp1Reg, uint64 miptbp2Reg, uint32 mipLevel)
+{
+	// auto miptbp1 = make_convertible<MIPTBP1>(miptbp1Reg);
+	// auto miptbp2 = make_convertible<MIPTBP2>(miptbp2Reg);
+	// auto texInfo = LoadTexture(tex0, maxMip, miptbp1, miptbp2);
+	auto tex0 = make_convertible<TEX0>(tex0Reg);
+	auto width = std::max<uint32>(tex0.GetWidth() >> mipLevel, 1);
+	auto height = std::max<uint32>(tex0.GetHeight() >> mipLevel, 1);
+
+	FRAME frame = {};
+	frame.nPtr = tex0.GetBufPtr() / 8192;
+	frame.nWidth = tex0.GetWidth() / 64;
+	frame.nPsm = tex0.nPsm;
+	auto framebuffer = FindFramebuffer(frame);
+	if(framebuffer)
+	{
+		glBindFramebuffer(GL_FRAMEBUFFER, framebuffer->m_framebuffer);
+		auto imgbuffer = Framework::CBitmap(width, height, 32);
+		glReadPixels(0, 0, width, height, GL_BGRA, GL_UNSIGNED_BYTE, imgbuffer.GetPixels());
+		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		return imgbuffer;
+	}
+
+	auto texInfo = PrepareTexture(tex0);
+	if(texInfo.textureHandle == 0)
+	{
+		return Framework::CBitmap();
+	}
+
+	auto texFormat = GetTextureFormatInfo(tex0.nPsm);
+	auto bitsPerPixel = 8;
+	auto format = GL_RED;
+	if(texFormat.format != GL_RED)
+	{
+		bitsPerPixel = 32;
+		format = GL_BGRA;
+	}
+
+	auto imgbuffer = Framework::CBitmap(width, height, bitsPerPixel);
+	glGetTexImage(GL_TEXTURE_2D, 0, format, GL_UNSIGNED_BYTE, imgbuffer.GetPixels());
+	glBindTexture(GL_TEXTURE_2D, 0);
+	return imgbuffer;
+}
+
+const CGSH_OpenGL::VERTEX* CGSH_OpenGL::GetInputVertices() const
+{
+	return m_VtxBuffer;
+}
+
+bool CGSH_OpenGL::GetDepthTestingEnabled() const
+{
+	return m_depthTestingEnabled;
+}
+
+void CGSH_OpenGL::SetDepthTestingEnabled(bool depthTestingEnabled)
+{
+	m_depthTestingEnabled = depthTestingEnabled;
+	m_renderState.isValid = false;
+}
+
+bool CGSH_OpenGL::GetAlphaBlendingEnabled() const
+{
+	return m_alphaBlendingEnabled;
+}
+
+void CGSH_OpenGL::SetAlphaBlendingEnabled(bool alphaBlendingEnabled)
+{
+	m_alphaBlendingEnabled = alphaBlendingEnabled;
+	m_renderState.isValid = false;
+}
+
+bool CGSH_OpenGL::GetAlphaTestingEnabled() const
+{
+	return m_alphaTestingEnabled;
+}
+
+void CGSH_OpenGL::SetAlphaTestingEnabled(bool alphaTestingEnabled)
+{
+	m_alphaTestingEnabled = alphaTestingEnabled;
+	m_renderState.isValid = false;
 }
 
 /////////////////////////////////////////////////////////////

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -2188,7 +2188,7 @@ Framework::CBitmap CGSH_OpenGL::GetFramebuffer(uint64 frameReg)
 
 Framework::CBitmap CGSH_OpenGL::GetFramebufferImpl(uint64 frameReg)
 {
-
+#ifndef GLES_COMPATIBILITY
 	auto frame = make_convertible<FRAME>(frameReg);
 	auto framebuffer = FindFramebuffer(frame);
 	if(!framebuffer)
@@ -2203,6 +2203,9 @@ Framework::CBitmap CGSH_OpenGL::GetFramebufferImpl(uint64 frameReg)
 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
 		return imgbuffer;
 	}
+#else
+	throw std::runtime_error("Feature is not implemented in current backend.");
+#endif
 }
 
 Framework::CBitmap CGSH_OpenGL::GetTexture(uint64 tex0Reg, uint32 maxMip, uint64 miptbp1Reg, uint64 miptbp2Reg, uint32 mipLevel)
@@ -2214,6 +2217,7 @@ Framework::CBitmap CGSH_OpenGL::GetTexture(uint64 tex0Reg, uint32 maxMip, uint64
 
 Framework::CBitmap CGSH_OpenGL::GetTextureImpl(uint64 tex0Reg, uint32 maxMip, uint64 miptbp1Reg, uint64 miptbp2Reg, uint32 mipLevel)
 {
+#ifndef GLES_COMPATIBILITY
 	// auto miptbp1 = make_convertible<MIPTBP1>(miptbp1Reg);
 	// auto miptbp2 = make_convertible<MIPTBP2>(miptbp2Reg);
 	// auto texInfo = LoadTexture(tex0, maxMip, miptbp1, miptbp2);
@@ -2254,6 +2258,10 @@ Framework::CBitmap CGSH_OpenGL::GetTextureImpl(uint64 tex0Reg, uint32 maxMip, ui
 	glGetTexImage(GL_TEXTURE_2D, 0, format, GL_UNSIGNED_BYTE, imgbuffer.GetPixels());
 	glBindTexture(GL_TEXTURE_2D, 0);
 	return imgbuffer;
+#else
+	throw std::runtime_error("Feature is not implemented in current backend.");
+#endif
+
 }
 
 const CGSH_OpenGL::VERTEX* CGSH_OpenGL::GetInputVertices() const

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.h
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.h
@@ -22,6 +22,14 @@
 class CGSH_OpenGL : public CGSHandler
 {
 public:
+	struct VERTEX
+	{
+		uint64 nPosition;
+		uint64 nRGBAQ;
+		uint64 nUV;
+		uint64 nST;
+		uint8 nFog;
+	};
 	CGSH_OpenGL(bool = true);
 	virtual ~CGSH_OpenGL();
 
@@ -34,6 +42,19 @@ public:
 	void ProcessLocalToLocalTransfer() override;
 	void ProcessClutTransfer(uint32, uint32) override;
 	void ReadFramebuffer(uint32, uint32, void*) override;
+
+	bool GetDepthTestingEnabled() const;
+	void SetDepthTestingEnabled(bool);
+
+	bool GetAlphaBlendingEnabled() const;
+	void SetAlphaBlendingEnabled(bool);
+
+	bool GetAlphaTestingEnabled() const;
+	void SetAlphaTestingEnabled(bool);
+
+	Framework::CBitmap GetFramebuffer(uint64);
+	Framework::CBitmap GetTexture(uint64, uint32, uint64, uint64, uint32);
+	const VERTEX* GetInputVertices() const;
 
 	Framework::CBitmap GetScreenshot() override;
 
@@ -162,15 +183,6 @@ private:
 	};
 
 	typedef void (CGSH_OpenGL::*TEXTUREUPDATER)(uint32, uint32, unsigned int, unsigned int, unsigned int, unsigned int);
-
-	struct VERTEX
-	{
-		uint64 nPosition;
-		uint64 nRGBAQ;
-		uint64 nUV;
-		uint64 nST;
-		uint8 nFog;
-	};
 
 	enum
 	{
@@ -351,6 +363,9 @@ private:
 
 	void DumpTexture(unsigned int, unsigned int, uint32);
 
+	Framework::CBitmap GetFramebufferImpl(uint64);
+	Framework::CBitmap GetTextureImpl(uint64, uint32, uint64, uint64, uint32);
+
 	//Texture updaters
 	void TexUpdater_Invalid(uint32, uint32, unsigned int, unsigned int, unsigned int, unsigned int);
 
@@ -373,6 +388,9 @@ private:
 	unsigned int m_fbScale = 1;
 	bool m_multisampleEnabled = false;
 	bool m_accurateAlphaTestEnabled = false;
+	bool m_depthTestingEnabled = true;
+	bool m_alphaBlendingEnabled = true;
+	bool m_alphaTestingEnabled = true;
 
 	uint8* m_pCvtBuffer;
 

--- a/Source/ui_qt/mainwindow.cpp
+++ b/Source/ui_qt/mainwindow.cpp
@@ -112,6 +112,7 @@ MainWindow::MainWindow(QWidget* parent)
 #ifdef DEBUGGER_INCLUDED
 	m_debugger = std::make_unique<CDebugger>(*m_virtualMachine);
 	m_frameDebugger = std::make_unique<CFrameDebugger>();
+	m_frameDebugger->Show(SW_SHOWMAXIMIZED);
 
 	auto debugMenu = new QMenu(this);
 	debugMenuUi = new Ui::DebugMenu();

--- a/Source/ui_qt/win32/DebugSupport/CMakeLists.txt
+++ b/Source/ui_qt/win32/DebugSupport/CMakeLists.txt
@@ -27,6 +27,13 @@ if(NOT TARGET gsh_d3d9)
 	)
 endif()
 
+if(NOT TARGET gsh_opengl_win32)
+	add_subdirectory(
+		${CMAKE_CURRENT_SOURCE_DIR}/../../../gs/GSH_OpenGLWin32
+		${CMAKE_CURRENT_BINARY_DIR}/gsh_opengl_win32
+	)
+endif()
+
 set(SRC_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 set(SRC_FILES
 	${SRC_ROOT}/CallStackWnd.cpp
@@ -72,6 +79,8 @@ set(SRC_FILES
 	${SRC_ROOT}/FrameDebugger/GsContextStateView.h
 	${SRC_ROOT}/FrameDebugger/GsInputStateView.cpp
 	${SRC_ROOT}/FrameDebugger/GsInputStateView.h
+	${SRC_ROOT}/FrameDebugger/GSH_OpenGL_Framedebugger.cpp
+	${SRC_ROOT}/FrameDebugger/GSH_OpenGL_Framedebugger.h
 	${SRC_ROOT}/FrameDebugger/GsPacketListView.cpp
 	${SRC_ROOT}/FrameDebugger/GsPacketListView.h
 	${SRC_ROOT}/FrameDebugger/GsStateUtils.cpp
@@ -120,6 +129,6 @@ set(SRC_FILES
 )
 
 add_library(PlayDebugSupport STATIC ${SRC_FILES})
-target_link_libraries(PlayDebugSupport uxtheme Framework_Win32 PlayCore gsh_d3d9)
+target_link_libraries(PlayDebugSupport uxtheme Framework_Win32 PlayCore gsh_d3d9 gsh_opengl_win32)
 target_compile_definitions(PlayDebugSupport PRIVATE NOMINMAX)
 target_include_directories(PlayDebugSupport PRIVATE ../../${CMAKE_CURRENT_SOURCE_DIR})

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/CheckerboardShader.ps
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/CheckerboardShader.ps
@@ -15,3 +15,16 @@ float4 main(VertexOutput input) : COLOR
 		return float4(0.75f, 0.75f, 0.75f, 1);
 	}
 }
+
+in vec2 a_texCoord;
+void main()
+{
+	if(fmod(floor(a_texCoord.x) + floor(a_texCoord.y), 2) < 1)
+	{
+		gl_FragColor =  vec4(1, 1, 1, 1);
+	}
+	else
+	{
+		gl_FragColor =  vec4(0.75f, 0.75f, 0.75f, 1);
+	}
+}

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/CheckerboardShader.vs
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/CheckerboardShader.vs
@@ -18,3 +18,13 @@ VertexOutput main(VertexInput input)
 	output.texCoord = ((input.position.xy + 1.0f) / 2.0f) * g_screenSize / 10.f;
 	return output;
 }
+
+float2 g_screenSize;
+layout (location = 0) in vec4 a_position;
+out vec2 a_texCoord;
+
+void main()
+{
+	gl_Position =  a_position;
+	a_texCoord = ((a_position.xy + 1.0f) / 2.0f) * g_screenSize / 10.f;
+}

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/FrameDebugger.cpp
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/FrameDebugger.cpp
@@ -28,10 +28,11 @@ CFrameDebugger::CFrameDebugger()
 	m_handlerOutputWindow = std::make_unique<COutputWnd>(m_hWnd);
 	m_handlerOutputWindow->Show(SW_SHOW);
 
-	m_gs = std::make_unique<CGSH_Direct3D9>(m_handlerOutputWindow.get());
+	m_gs = std::make_unique<CGSH_OpenGLWin32>(m_handlerOutputWindow.get());
 	m_gs->SetLoggingEnabled(false);
 	m_gs->Initialize();
 	m_gs->Reset();
+	CHECKGLERROR();
 
 	memset(&m_currentMetadata, 0, sizeof(m_currentMetadata));
 

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/FrameDebugger.h
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/FrameDebugger.h
@@ -6,7 +6,7 @@
 #include "win32/Static.h"
 #include "win32/Splitter.h"
 #include "../OutputWnd.h"
-#include "gs/GSH_Direct3D9/GSH_Direct3D9.h"
+#include "gs/GSH_OpenGLWin32/GSH_OpenGLWin32.h"
 #include "FrameDump.h"
 #include "Vu1Vm.h"
 #include "GsInputStateView.h"
@@ -46,7 +46,7 @@ private:
 	void SetFbDisplayMode(CGsContextView::FB_DISPLAY_MODE);
 	void StepVu1();
 
-	std::unique_ptr<CGSH_Direct3D9> m_gs;
+	std::unique_ptr<CGSH_OpenGLWin32> m_gs;
 	CGsPacketMetadata m_currentMetadata;
 	DRAWINGKICK_INFO m_currentDrawingKick;
 	CGsContextView::FB_DISPLAY_MODE m_fbDisplayMode = CGsContextView::FB_DISPLAY_MODE_RAW;

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/GSH_OpenGL_Framedebugger.cpp
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/GSH_OpenGL_Framedebugger.cpp
@@ -384,12 +384,18 @@ void CGSH_OpenGLFramedebugger::LoadTextureFromBitmap(const Framework::CBitmap& b
 			    case 8:
 				    return {GL_R8, GL_RED};
 			    case 16:
+				    return {GL_RGB5_A1, GL_BGRA};
 			    case 32:
 			    default:
 				    return {GL_RGBA8, GL_BGRA};
 			    }
 		    }();
 
+		auto type = GL_UNSIGNED_BYTE;
+		if(bitmap.GetBitsPerPixel() == 16)
+		{
+			type = GL_UNSIGNED_SHORT_5_5_5_1;
+		}
 		glActiveTexture(GL_TEXTURE0+4);
 		glGenTextures(1, &m_activeTexture);
 		glBindTexture(GL_TEXTURE_2D, m_activeTexture);
@@ -398,6 +404,12 @@ void CGSH_OpenGLFramedebugger::LoadTextureFromBitmap(const Framework::CBitmap& b
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		if(bitmap.GetBitsPerPixel() == 8)
+		{
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_RED);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_G, GL_RED);
+		}
 		glBindTexture(GL_TEXTURE_2D, 0);
 		CHECKGLERROR();
 	}

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/GSH_OpenGL_Framedebugger.cpp
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/GSH_OpenGL_Framedebugger.cpp
@@ -142,13 +142,13 @@ Framework::OpenGl::CBuffer CGSH_OpenGLFramedebugger::GenerateVertexBuffer()
 	// clang-format off
 	static float vertices[] =
 	{
-		 1.0f,  1.0f, 0.0f,		1.0f, 1.0f,
-		 1.0f, -1.0f, 0.0f,		1.0f, 0.0f,
-		-1.0f, -1.0f, 0.0f,		0.0f, 0.0f,
+		 1.0f,  1.0f, 0.0f,		1.0f, 0.0f,
+		 1.0f, -1.0f, 0.0f,		1.0f, 1.0f,
+		-1.0f, -1.0f, 0.0f,		0.0f, 1.0f,
 
-		-1.0f, -1.0f, 0.0f,		0.0f, 0.0f,
-		-1.0f,  1.0f, 0.0f,		0.0f, 1.0f,
-		 1.0f,  1.0f, 0.0f,		1.0f, 1.0f,
+		-1.0f, -1.0f, 0.0f,		0.0f, 1.0f,
+		-1.0f,  1.0f, 0.0f,		0.0f, 0.0f,
+		 1.0f,  1.0f, 0.0f,		1.0f, 0.0f,
 
 	};
 	// clang-format on

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/GSH_OpenGL_Framedebugger.cpp
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/GSH_OpenGL_Framedebugger.cpp
@@ -1,0 +1,404 @@
+#include "GSH_OpenGL_Framedebugger.h"
+#include <assert.h>
+#include <sstream>
+
+#ifdef GLES_COMPATIBILITY
+#define GLSL_VERSION "#version 300 es"
+#else
+#define GLSL_VERSION "#version 150"
+#endif
+
+PIXELFORMATDESCRIPTOR CGSH_OpenGLFramedebugger::m_pfd =
+	{
+		sizeof(PIXELFORMATDESCRIPTOR),
+		1,
+		PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER,
+		PFD_TYPE_RGBA,
+		32,
+		0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0,
+		0,
+		32,
+		0,
+		0,
+		PFD_MAIN_PLANE,
+		0,
+		0, 0, 0};
+
+CGSH_OpenGLFramedebugger::CGSH_OpenGLFramedebugger(Framework::Win32::CWindow* outputWindow)
+	: m_outputWnd(outputWindow)
+{
+	InitializeImpl();
+	PrepareFramedebugger();
+}
+
+void CGSH_OpenGLFramedebugger::InitializeImpl()
+{
+	m_dc = GetDC(m_outputWnd->m_hWnd);
+	unsigned int pf = ChoosePixelFormat(m_dc, &m_pfd);
+	SetPixelFormat(m_dc, pf, &m_pfd);
+	m_context = wglCreateContext(m_dc);
+	wglMakeCurrent(m_dc, m_context);
+
+	auto createContextAttribsARB = reinterpret_cast<PFNWGLCREATECONTEXTATTRIBSARBPROC>(wglGetProcAddress("wglCreateContextAttribsARB"));
+	if(createContextAttribsARB != nullptr)
+	{
+		static const int attributes[] =
+			{
+				WGL_CONTEXT_MAJOR_VERSION_ARB, 3,
+				WGL_CONTEXT_MINOR_VERSION_ARB, 2,
+				WGL_CONTEXT_PROFILE_MASK_ARB, WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
+				0};
+
+		auto newContext = createContextAttribsARB(m_dc, nullptr, attributes);
+		assert(newContext != nullptr);
+
+		if(newContext != nullptr)
+		{
+			auto prevContext = m_context;
+			m_context = newContext;
+			wglMakeCurrent(m_dc, m_context);
+
+			auto deleteResult = wglDeleteContext(prevContext);
+			assert(deleteResult == TRUE);
+		}
+	}
+
+	//GLEW doesn't work well with core profiles, thus, we need to enable "experimental" to make
+	//sure it properly gets all function pointers.
+	glewExperimental = GL_TRUE;
+	auto result = glewInit();
+	assert(result == GLEW_OK);
+	//Clear any error that might rise from GLEW getting function pointers
+	glGetError();
+
+	if(wglSwapIntervalEXT)
+	{
+		wglSwapIntervalEXT(-1);
+	}
+}
+
+void CGSH_OpenGLFramedebugger::ReleaseImpl()
+{
+	wglMakeCurrent(NULL, NULL);
+
+	auto deleteResult = wglDeleteContext(m_context);
+	assert(deleteResult == TRUE);
+}
+
+void CGSH_OpenGLFramedebugger::Begin()
+{
+	wglMakeCurrent(m_dc, m_context);
+}
+
+void CGSH_OpenGLFramedebugger::PresentBackbuffer()
+{
+	SwapBuffers(m_dc);
+}
+
+void CGSH_OpenGLFramedebugger::PrepareFramedebugger()
+{
+
+	m_vertexArray = GenerateVertexArray();
+	m_vertexBufferFramedebugger = GenerateVertexBuffer();
+
+	m_checkerboardProgram = GenerateCheckerboardProgram();
+	{
+		glEnableVertexAttribArray(0);
+		glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(float) * 3,  reinterpret_cast<const GLvoid*>(0)); // POSITON
+
+		m_checkerboardScreenSizeUniform = glGetUniformLocation(*m_checkerboardProgram, "g_screenSize");
+	}
+
+	m_pixelBufferViewProgram = GeneratePixelBufferViewProgram();
+	{
+		glEnableVertexAttribArray(0);
+		glEnableVertexAttribArray(1);
+		glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(float) * 5,  reinterpret_cast<const GLvoid*>(0)); // POSITON
+		glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 5,  reinterpret_cast<const GLvoid*>(sizeof(float) * 3)); // texCoord
+
+		m_pixelBufferViewScreenSizeUniform = glGetUniformLocation(*m_pixelBufferViewProgram, "g_screenSize");
+		m_pixelBufferViewBufferSizeUniform = glGetUniformLocation(*m_pixelBufferViewProgram, "g_bufferSize");
+		m_pixelBufferViewPanOffsetUniform = glGetUniformLocation(*m_pixelBufferViewProgram, "g_panOffset");
+		m_pixelBufferViewZoomFactorUniform = glGetUniformLocation(*m_pixelBufferViewProgram, "g_zoomFactor");
+		m_pixelBufferViewtextureUniform = glGetUniformLocation(*m_pixelBufferViewProgram, "g_bufferTextureSampler");
+	}
+}
+
+Framework::OpenGl::CVertexArray CGSH_OpenGLFramedebugger::GenerateVertexArray()
+{
+	auto vertexArray = Framework::OpenGl::CVertexArray::Create();
+	glBindVertexArray(vertexArray);
+
+	CHECKGLERROR();
+
+	return vertexArray;
+}
+
+Framework::OpenGl::CBuffer CGSH_OpenGLFramedebugger::GenerateVertexBuffer()
+{
+	auto buffer = Framework::OpenGl::CBuffer::Create();
+
+	// clang-format off
+	static float vertices[] =
+	{
+		 1.0f,  1.0f, 0.0f,		1.0f, 1.0f,
+		 1.0f, -1.0f, 0.0f,		1.0f, 0.0f,
+		-1.0f, -1.0f, 0.0f,		0.0f, 0.0f,
+
+		-1.0f, -1.0f, 0.0f,		0.0f, 0.0f,
+		-1.0f,  1.0f, 0.0f,		0.0f, 1.0f,
+		 1.0f,  1.0f, 0.0f,		1.0f, 1.0f,
+
+	};
+	// clang-format on
+
+	glBindBuffer(GL_ARRAY_BUFFER, buffer);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+
+	CHECKGLERROR();
+
+	return buffer;
+}
+
+Framework::OpenGl::ProgramPtr CGSH_OpenGLFramedebugger::GenerateCheckerboardProgram()
+{
+	auto vertexShader = GenerateCheckerboardVertexShader();
+	auto fragmentShader = GenerateCheckerboardFragmentShader();
+
+	auto result = std::make_shared<Framework::OpenGl::CProgram>();
+
+	result->AttachShader(vertexShader);
+	result->AttachShader(fragmentShader);
+
+	FRAMEWORK_MAYBE_UNUSED bool linkResult = result->Link();
+	assert(linkResult);
+
+	CHECKGLERROR();
+
+	return result;
+}
+
+Framework::OpenGl::CShader CGSH_OpenGLFramedebugger::GenerateCheckerboardVertexShader()
+{
+
+	std::stringstream shaderBuilder;
+	shaderBuilder << GLSL_VERSION << std::endl;
+	shaderBuilder << "#extension GL_ARB_explicit_attrib_location : enable" << std::endl << std::endl;
+
+	shaderBuilder << "layout (location = 0) in vec3 g_position;" << std::endl;
+	shaderBuilder << "out vec2 a_texCoord;" << std::endl;
+	shaderBuilder << "uniform vec2 g_screenSize;" << std::endl;
+
+
+	shaderBuilder << "void main()" << std::endl;
+	shaderBuilder << "{" << std::endl;
+	shaderBuilder << "	gl_Position = vec4(g_position, 1.0);" << std::endl;
+	shaderBuilder << "	a_texCoord = ((g_position.xy + 1.0f) / 2.0f) * g_screenSize / 10.f;" << std::endl;
+	shaderBuilder << "}" << std::endl;
+
+	auto shaderSource = shaderBuilder.str();
+
+	Framework::OpenGl::CShader result(GL_VERTEX_SHADER);
+	result.SetSource(shaderSource.c_str(), shaderSource.size());
+	FRAMEWORK_MAYBE_UNUSED bool compilationResult = result.Compile();
+	assert(compilationResult);
+
+	CHECKGLERROR();
+
+	return result;
+}
+
+Framework::OpenGl::CShader CGSH_OpenGLFramedebugger::GenerateCheckerboardFragmentShader()
+{
+	std::stringstream shaderBuilder;
+
+	shaderBuilder << GLSL_VERSION << std::endl << std::endl;
+
+	shaderBuilder << "precision mediump float;" << std::endl;
+
+	shaderBuilder << "out vec4 fragColor;" << std::endl;
+	shaderBuilder << "in vec2 a_texCoord;" << std::endl;
+
+	shaderBuilder << "float fmod(float x, float y) { return x - y * trunc(x/y); }" << std::endl;
+	shaderBuilder << "void main()" << std::endl;
+	shaderBuilder << "{" << std::endl;
+
+	shaderBuilder << "	if(fmod(floor(a_texCoord.x) + floor(a_texCoord.y), 2.0) < 1.0)" << std::endl;
+	shaderBuilder << "	{" << std::endl;
+	shaderBuilder << "		fragColor =  vec4(1, 1, 1, 1);" << std::endl;
+	shaderBuilder << "	}" << std::endl;
+	shaderBuilder << "	else" << std::endl;
+	shaderBuilder << "	{" << std::endl;
+	shaderBuilder << "		fragColor =  vec4(0.75, 0.75, 0.75, 1.0);" << std::endl;
+	shaderBuilder << "	}" << std::endl;
+
+	shaderBuilder << "}" << std::endl;
+
+	auto shaderSource = shaderBuilder.str();
+
+	Framework::OpenGl::CShader result(GL_FRAGMENT_SHADER);
+	result.SetSource(shaderSource.c_str(), shaderSource.size());
+	FRAMEWORK_MAYBE_UNUSED bool compilationResult = result.Compile();
+	assert(compilationResult);
+
+	CHECKGLERROR();
+
+	return result;
+}
+
+void CGSH_OpenGLFramedebugger::DrawCheckerboard(float* dim)
+{
+	glViewport(0, 0, dim[0], dim[1]);
+
+	glUseProgram(*m_checkerboardProgram);
+
+	glBindVertexArray(m_vertexArray);
+	glBindBuffer(GL_ARRAY_BUFFER, m_vertexBufferFramedebugger);
+
+	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+
+	glUniform2f(m_checkerboardScreenSizeUniform, dim[0], dim[1]);
+
+	glDrawArrays(GL_TRIANGLES, 0, 6);
+
+}
+
+Framework::OpenGl::ProgramPtr CGSH_OpenGLFramedebugger::GeneratePixelBufferViewProgram()
+{
+	auto vertexShader = GeneratePixelBufferViewVertexShader();
+	auto fragmentShader = GeneratePixelBufferViewFragmentShader();
+
+	auto result = std::make_shared<Framework::OpenGl::CProgram>();
+
+	result->AttachShader(vertexShader);
+	result->AttachShader(fragmentShader);
+
+	FRAMEWORK_MAYBE_UNUSED bool linkResult = result->Link();
+	assert(linkResult);
+
+	CHECKGLERROR();
+
+	return result;
+}
+
+Framework::OpenGl::CShader CGSH_OpenGLFramedebugger::GeneratePixelBufferViewVertexShader()
+{
+
+	std::stringstream shaderBuilder;
+	shaderBuilder << GLSL_VERSION << std::endl << std::endl;
+	shaderBuilder << "#extension GL_ARB_explicit_attrib_location : enable" << std::endl << std::endl;
+
+	shaderBuilder << "layout (location = 0) in vec3 g_position;" << std::endl;
+	shaderBuilder << "layout (location = 1) in vec2 g_texCoord;" << std::endl;
+	shaderBuilder << "uniform vec2 g_screenSize;" << std::endl;
+	shaderBuilder << "uniform vec2 g_bufferSize;" << std::endl;
+	shaderBuilder << "uniform vec2 g_panOffset;" << std::endl;
+	shaderBuilder << "uniform float g_zoomFactor;" << std::endl;
+	shaderBuilder << "out vec2 a_texCoord;" << std::endl;
+	shaderBuilder << "" << std::endl;
+	shaderBuilder << "void main()" << std::endl;
+	shaderBuilder << "{" << std::endl;
+	shaderBuilder << "	gl_Position = ((vec4(g_position, 1.0) * vec4(g_bufferSize / g_screenSize, 0, 1)) + vec4(g_panOffset, 0, 0)) * vec4(g_zoomFactor, g_zoomFactor, 0, 1);" << std::endl;
+	shaderBuilder << "	a_texCoord = g_texCoord;" << std::endl;
+	shaderBuilder << "}" << std::endl;
+
+
+	auto shaderSource = shaderBuilder.str();
+
+	Framework::OpenGl::CShader result(GL_VERTEX_SHADER);
+	result.SetSource(shaderSource.c_str(), shaderSource.size());
+	FRAMEWORK_MAYBE_UNUSED bool compilationResult = result.Compile();
+	assert(compilationResult);
+
+	CHECKGLERROR();
+
+	return result;
+}
+
+Framework::OpenGl::CShader CGSH_OpenGLFramedebugger::GeneratePixelBufferViewFragmentShader()
+{
+	std::stringstream shaderBuilder;
+
+	shaderBuilder << GLSL_VERSION << std::endl << std::endl;
+
+	shaderBuilder << "precision mediump float;" << std::endl;
+
+	shaderBuilder << "uniform sampler2D g_bufferTextureSampler;" << std::endl;
+	shaderBuilder << "in vec2 a_texCoord;" << std::endl;
+	shaderBuilder << "out vec4 fragColor;" << std::endl;
+
+	shaderBuilder << "void main()" << std::endl;
+	shaderBuilder << "{" << std::endl;
+	shaderBuilder << "	fragColor = texture(g_bufferTextureSampler, a_texCoord);" << std::endl;
+	shaderBuilder << "}" << std::endl;
+
+
+	auto shaderSource = shaderBuilder.str();
+
+	Framework::OpenGl::CShader result(GL_FRAGMENT_SHADER);
+	result.SetSource(shaderSource.c_str(), shaderSource.size());
+	FRAMEWORK_MAYBE_UNUSED bool compilationResult = result.Compile();
+	assert(compilationResult);
+
+	CHECKGLERROR();
+
+	return result;
+}
+
+void CGSH_OpenGLFramedebugger::DrawPixelBuffer(float* screenSizeVector, float* bufferSizeVector, float panX, float panY, float zoomFactor)
+{
+	if(m_activeTexture == -1)
+		return;
+
+	float panOffsetVector[2] = {panX, panY};
+
+	glUseProgram(*m_pixelBufferViewProgram);
+	glBindVertexArray(m_vertexArray);
+	glBindBuffer(GL_ARRAY_BUFFER, m_vertexBufferFramedebugger);
+
+	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+
+	glUniform2f(m_pixelBufferViewScreenSizeUniform, screenSizeVector[0], screenSizeVector[1]);
+
+	glUniform2f(m_pixelBufferViewBufferSizeUniform, bufferSizeVector[0], bufferSizeVector[1]);
+	glUniform2f(m_pixelBufferViewPanOffsetUniform, panOffsetVector[0], panOffsetVector[1]);
+	glUniform1f(m_pixelBufferViewZoomFactorUniform, zoomFactor);
+
+	glActiveTexture(GL_TEXTURE0+4);
+	glBindTexture(GL_TEXTURE_2D, m_activeTexture);
+	glUniform1i(m_pixelBufferViewtextureUniform, 4);
+
+	glDrawArrays(GL_TRIANGLES, 0, 6);
+}
+
+void CGSH_OpenGLFramedebugger::LoadTextureFromBitmap(const Framework::CBitmap& bitmap)
+{
+	if(!bitmap.IsEmpty())
+	{
+		std::vector<GLint> textureFormat =
+		    [bitmap]()->std::vector<GLint>
+			{
+			    switch(bitmap.GetBitsPerPixel())
+			    {
+			    case 8:
+				    return {GL_R8, GL_RED};
+			    case 16:
+			    case 32:
+			    default:
+				    return {GL_RGBA8, GL_BGRA};
+			    }
+		    }();
+
+		glActiveTexture(GL_TEXTURE0+4);
+		glGenTextures(1, &m_activeTexture);
+		glBindTexture(GL_TEXTURE_2D, m_activeTexture);
+		glTexImage2D(GL_TEXTURE_2D, 0, textureFormat[0], bitmap.GetWidth(), bitmap.GetHeight(), 0, textureFormat[1], GL_UNSIGNED_BYTE, bitmap.GetPixels());
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glBindTexture(GL_TEXTURE_2D, 0);
+		CHECKGLERROR();
+	}
+}

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/GSH_OpenGL_Framedebugger.h
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/GSH_OpenGL_Framedebugger.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "gs/GSH_OpenGL/GSH_OpenGL.h"
+#include "win32/Window.h"
+
+class CGSH_OpenGLFramedebugger
+{
+public:
+	CGSH_OpenGLFramedebugger(Framework::Win32::CWindow*);
+	virtual ~CGSH_OpenGLFramedebugger() = default;
+
+	void InitializeImpl();
+	void ReleaseImpl();
+	void PresentBackbuffer();
+	void Begin();
+
+	void DrawCheckerboard(float*);
+	void DrawPixelBuffer(float*, float*, float, float, float);
+	void LoadTextureFromBitmap(const Framework::CBitmap&);
+
+
+private:
+	Framework::Win32::CWindow* m_outputWnd = nullptr;
+
+	HGLRC m_context = nullptr;
+	HDC m_dc = nullptr;
+	static PIXELFORMATDESCRIPTOR m_pfd;
+
+	Framework::OpenGl::CBuffer m_vertexBufferFramedebugger;
+	Framework::OpenGl::ProgramPtr m_checkerboardProgram;
+	Framework::OpenGl::ProgramPtr m_pixelBufferViewProgram;
+	Framework::OpenGl::CVertexArray m_vertexArray;
+
+	GLint m_checkerboardScreenSizeUniform = -1 ;
+	GLint m_pixelBufferViewScreenSizeUniform = -1 ;
+	GLint m_pixelBufferViewBufferSizeUniform = -1 ;
+	GLint m_pixelBufferViewPanOffsetUniform = -1 ;
+	GLint m_pixelBufferViewZoomFactorUniform = -1 ;
+	GLint m_pixelBufferViewtextureUniform = -1 ;
+
+	Framework::OpenGl::CVertexArray GenerateVertexArray();
+
+	void PrepareFramedebugger();
+	Framework::OpenGl::CBuffer GenerateVertexBuffer();
+
+	Framework::OpenGl::ProgramPtr GenerateCheckerboardProgram();
+	Framework::OpenGl::CShader GenerateCheckerboardVertexShader();
+	Framework::OpenGl::CShader GenerateCheckerboardFragmentShader();
+
+	Framework::OpenGl::ProgramPtr GeneratePixelBufferViewProgram();
+	Framework::OpenGl::CShader GeneratePixelBufferViewVertexShader();
+	Framework::OpenGl::CShader GeneratePixelBufferViewFragmentShader();
+
+
+	GLuint m_activeTexture;
+
+};

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/GsContextView.cpp
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/GsContextView.cpp
@@ -103,7 +103,7 @@ void CGsContextView::UpdateBufferView()
 
 		if(mipLevel <= tex1.nMaxMip)
 		{
-			texture = static_cast<CGSH_OpenGLWin32*>(m_gs)->GetTexture(tex0Reg, tex1.nMaxMip, miptbp1Reg, miptbp2Reg, mipLevel).FlipVertical();
+			texture = static_cast<CGSH_OpenGLWin32*>(m_gs)->GetTexture(tex0Reg, tex1.nMaxMip, miptbp1Reg, miptbp2Reg, mipLevel);
 		}
 
 		if(!texture.IsEmpty() && CGsPixelFormats::IsPsmIDTEX(tex0.nPsm))
@@ -136,7 +136,7 @@ void CGsContextView::UpdateFramebufferView()
 	uint64 frameReg = m_gs->GetRegisters()[GS_REG_FRAME_1 + m_contextId];
 	auto frame = make_convertible<CGSHandler::FRAME>(frameReg);
 
-	auto framebuffer = static_cast<CGSH_OpenGLWin32*>(m_gs)->GetFramebuffer(frame).FlipVertical();
+	auto framebuffer = static_cast<CGSH_OpenGLWin32*>(m_gs)->GetFramebuffer(frame);
 	if(framebuffer.IsEmpty())
 	{
 		m_bufferView->SetPixelBuffers(CPixelBufferView::PixelBufferArray());

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/GsContextView.cpp
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/GsContextView.cpp
@@ -239,6 +239,15 @@ void CGsContextView::BrightenBitmap(Framework::CBitmap& bitmap)
 	}
 }
 
+uint32 CGsContextView::Color_Ps2ToRGBA(uint32 color)
+{
+	uint8 r = (color & 0xFF);
+	uint8 b = (color & 0xFF00) >> 8;
+	uint8 g = (color & 0xFF0000) >> 16;
+	uint8 a = (color & 0xFF000000) >> 24;
+	return g << 0 | b << 8 | r << 16 | a << 24;
+}
+
 Framework::CBitmap CGsContextView::LookupBitmap(const Framework::CBitmap& srcBitmap, const ColorArray& clut)
 {
 	assert(!srcBitmap.IsEmpty());
@@ -252,7 +261,7 @@ Framework::CBitmap CGsContextView::LookupBitmap(const Framework::CBitmap& srcBit
 		{
 			uint8 index = srcPixels[x];
 			uint32 color = clut[index];
-			uint32 newColor = color;
+			uint32 newColor = Color_Ps2ToRGBA(color);
 			dstPixels[x] = newColor;
 		}
 		srcPixels += srcBitmap.GetPitch();

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/GsContextView.h
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/GsContextView.h
@@ -38,6 +38,7 @@ private:
 	void UpdateFramebufferView();
 	void RenderDrawKick(Framework::CBitmap&);
 
+	static uint32 Color_Ps2ToRGBA(uint32);
 	static void BrightenBitmap(Framework::CBitmap&);
 	static Framework::CBitmap LookupBitmap(const Framework::CBitmap&, const ColorArray&);
 	static Framework::CBitmap ExtractAlpha32(const Framework::CBitmap&);

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/GsStateUtils.cpp
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/GsStateUtils.cpp
@@ -1,6 +1,6 @@
 #include "GsStateUtils.h"
 #include "string_format.h"
-#include "gs/GSH_Direct3D9/GSH_Direct3D9.h"
+#include "gs/GSH_OpenGLWin32/GSH_OpenGLWin32.h"
 
 static const char* g_yesNoString[2] =
     {
@@ -215,7 +215,7 @@ std::string CGsStateUtils::GetInputState(CGSHandler* gs)
 
 	result += "\r\n";
 
-	auto vertices = static_cast<CGSH_Direct3D9*>(gs)->GetInputVertices();
+	auto vertices = static_cast<CGSH_OpenGLWin32*>(gs)->GetInputVertices();
 
 	result += string_format("Positions:\r\n");
 	result += string_format("\t                 PosX        PosY        PosZ        OfsX        OfsY\r\n");

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/PixelBufferView.h
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/PixelBufferView.h
@@ -1,12 +1,14 @@
 #pragma once
 
-#include "../DirectXControl.h"
+#include "win32/Window.h"
 #include "bitmap/Bitmap.h"
 #include "PixelBufferViewOverlay.h"
 #include <memory>
 #include <vector>
+#include "GSH_OpenGL_Framedebugger.h"
+#include "../OutputWnd.h"
 
-class CPixelBufferView : public CDirectXControl
+class CPixelBufferView : public Framework::Win32::CWindow
 {
 public:
 	typedef std::pair<std::string, Framework::CBitmap> PixelBuffer;
@@ -18,9 +20,12 @@ public:
 	void SetPixelBuffers(PixelBufferArray);
 
 	void FitBitmap();
-
+	bool m_init = false;
 protected:
-	void Refresh() override;
+	void Refresh();
+	long OnPaint() override;
+	long OnEraseBkgnd() override;
+
 
 	long OnCommand(unsigned short, unsigned short, HWND) override;
 	long OnSize(unsigned int, unsigned int, unsigned int) override;
@@ -32,15 +37,8 @@ protected:
 
 	long OnMouseWheel(int, int, short) override;
 
-	void OnDeviceReset() override;
-	void OnDeviceResetting() override;
 
 private:
-	typedef Framework::Win32::CComPtr<IDirect3DTexture9> TexturePtr;
-	typedef Framework::Win32::CComPtr<IDirect3DVertexBuffer9> VertexBufferPtr;
-	typedef Framework::Win32::CComPtr<IDirect3DVertexDeclaration9> VertexDeclarationPtr;
-	typedef Framework::Win32::CComPtr<IDirect3DVertexShader9> VertexShaderPtr;
-	typedef Framework::Win32::CComPtr<IDirect3DPixelShader9> PixelShaderPtr;
 
 	struct VERTEX
 	{
@@ -54,22 +52,11 @@ private:
 	void OnSaveBitmap();
 	static Framework::CBitmap ConvertBGRToRGB(Framework::CBitmap);
 
-	void CreateResources();
 	void DrawCheckerboard();
 	void DrawPixelBuffer();
 
-	VertexShaderPtr CreateVertexShaderFromResource(const TCHAR*);
-	PixelShaderPtr CreatePixelShaderFromResource(const TCHAR*);
-	TexturePtr CreateTextureFromBitmap(const Framework::CBitmap&);
 
-	TexturePtr m_pixelBufferTexture;
 	PixelBufferArray m_pixelBuffers;
-	VertexDeclarationPtr m_quadVertexDecl;
-	VertexBufferPtr m_quadVertexBuffer;
-	VertexShaderPtr m_checkerboardVertexShader;
-	PixelShaderPtr m_checkerboardPixelShader;
-	VertexShaderPtr m_pixelBufferViewVertexShader;
-	PixelShaderPtr m_pixelBufferViewPixelShader;
 
 	std::unique_ptr<CPixelBufferViewOverlay> m_overlay;
 
@@ -83,4 +70,8 @@ private:
 
 	float m_panXDragBase;
 	float m_panYDragBase;
+
+	std::unique_ptr<CGSH_OpenGLFramedebugger> m_gs;
+	std::unique_ptr<COutputWnd> m_handlerOutputWindow;
+
 };

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/PixelBufferViewShader.ps
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/PixelBufferViewShader.ps
@@ -14,3 +14,9 @@ float4 main(VertexOutput input) : COLOR
 {
 	return tex2D(g_bufferTextureSampler, input.texCoord);
 }
+
+shaderBuilder << "in vec2 a_texCoord;" << std::end;
+shaderBuilder << "void main()" << std::end;
+shaderBuilder << "{" << std::end;
+shaderBuilder << "	gl_FragColor = texture(0, a_texCoord.st);" << std::end;
+shaderBuilder << "}" << std::end;

--- a/Source/ui_qt/win32/DebugSupport/FrameDebugger/PixelBufferViewShader.vs
+++ b/Source/ui_qt/win32/DebugSupport/FrameDebugger/PixelBufferViewShader.vs
@@ -22,3 +22,18 @@ VertexOutput main(VertexInput input)
 	output.texCoord = input.texCoord;
 	return output;
 }
+
+
+vec2	g_screenSize;
+vec2	g_bufferSize;
+vec2	g_panOffset;
+float	g_zoomFactor;
+uniform vec2 g_texCoord;
+out vec4 a_position;
+out vec2 a_texCoord;
+
+void main()
+{
+	gl_Position = ((a_position * vec4(g_bufferSize / g_screenSize, 0, 1)) + vec4(g_panOffset, 0, 0)) * vec4(g_zoomFactor, g_zoomFactor, 0, 1);
+	a_texCoord = g_texCoord;
+}


### PR DESCRIPTION
this PR is phase 1 of porting the frame debugger, aka moving frame debugger to OpenGL (this PR)
phase 2, moving it to Qt to make it multi-platform (will either be it's own PR or part of #836)

TODO:

- [x] Texture coloring, currently displaying as shades of red
- [ ] Switching context renders a blank texture/framebuffer, but changing packet fixes the render (will ignore this for now, since this is likely a ui issue, which will be removed anyway )

~~I'd need to focus on my exam that start next week, so i though I'd post my progress so far~~