### PR TITLE
capture screenshot directly from display framebuffer, at rendering resolution

### DIFF
--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -128,23 +128,9 @@ void CGSH_OpenGL::FlipImpl()
 	m_renderState.isValid = false;
 	m_validGlState = 0;
 
-	DISPLAY d;
-	DISPFB fb;
-	{
-		std::lock_guard<std::recursive_mutex> registerMutexLock(m_registerMutex);
-		unsigned int readCircuit = GetCurrentReadCircuit();
-		switch(readCircuit)
-		{
-		case 0:
-			d <<= m_nDISPLAY1.value.q;
-			fb <<= m_nDISPFB1.value.q;
-			break;
-		case 1:
-			d <<= m_nDISPLAY2.value.q;
-			fb <<= m_nDISPFB2.value.q;
-			break;
-		}
-	}
+	auto dispInfo = GetCurrentDisplayInfo();
+	auto fb = make_convertible<DISPFB>(dispInfo.first);
+	auto d = make_convertible<DISPLAY>(dispInfo.second);
 
 	unsigned int dispWidth = (d.nW + 1) / (d.nMagX + 1);
 	unsigned int dispHeight = (d.nH + 1);
@@ -516,40 +502,6 @@ void CGSH_OpenGL::MakeLinearZOrtho(float* matrix, float left, float right, float
 	matrix[13] = -(top + bottom) / (top - bottom);
 	matrix[14] = 0;
 	matrix[15] = 1;
-}
-
-unsigned int CGSH_OpenGL::GetCurrentReadCircuit()
-{
-	uint32 rcMode = m_nPMODE & 0x03;
-	switch(rcMode)
-	{
-	default:
-	case 0:
-		//No read circuit enabled?
-		return 0;
-	case 1:
-		return 0;
-	case 2:
-		return 1;
-	case 3:
-	{
-		//Both are enabled... See if we can find out which one is good
-		//This happens in Capcom Classics Collection Vol. 2
-		std::lock_guard<std::recursive_mutex> registerMutexLock(m_registerMutex);
-		bool fb1Null = (m_nDISPFB1.value.q == 0);
-		bool fb2Null = (m_nDISPFB2.value.q == 0);
-		if(!fb1Null && fb2Null)
-		{
-			return 0;
-		}
-		if(fb1Null && !fb2Null)
-		{
-			return 1;
-		}
-		return 0;
-	}
-	break;
-	}
 }
 
 /////////////////////////////////////////////////////////////
@@ -2185,21 +2137,10 @@ void CGSH_OpenGL::ReadFramebuffer(uint32 width, uint32 height, void* buffer)
 
 Framework::CBitmap CGSH_OpenGL::GetScreenshot()
 {
-	DISPFB fb;
-	DISPLAY d;
-	std::lock_guard<std::recursive_mutex> registerMutexLock(m_registerMutex);
-	unsigned int readCircuit = GetCurrentReadCircuit();
-	switch(readCircuit)
-	{
-	case 0:
-		fb <<= m_nDISPFB1.value.q;
-		d <<= m_nDISPLAY1.value.q;
-		break;
-	case 1:
-		fb <<= m_nDISPFB2.value.q;
-		d <<= m_nDISPLAY2.value.q;
-		break;
-	}
+	auto dispInfo = GetCurrentDisplayInfo();
+	auto fb = make_convertible<DISPFB>(dispInfo.first);
+	auto d = make_convertible<DISPLAY>(dispInfo.second);
+
 	unsigned int dispWidth = (d.nW + 1) / (d.nMagX + 1);
 	unsigned int dispHeight = (d.nH + 1);
 

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.h
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.h
@@ -295,7 +295,6 @@ private:
 	void SetupTextureUpdaters();
 	virtual void PresentBackbuffer() = 0;
 	void MakeLinearZOrtho(float*, float, float, float, float);
-	unsigned int GetCurrentReadCircuit();
 	TEXTURE_INFO PrepareTexture(const TEX0&);
 	TEXTURE_INFO SearchTextureFramebuffer(const TEX0&);
 	GLuint PreparePalette(const TEX0&);

--- a/Source/gs/GSHandler.h
+++ b/Source/gs/GSHandler.h
@@ -761,6 +761,8 @@ public:
 	unsigned int GetCrtHeight() const;
 	bool GetCrtIsInterlaced() const;
 	bool GetCrtIsFrameMode() const;
+	std::pair<uint64, uint64> GetCurrentDisplayInfo();
+	unsigned int GetCurrentReadCircuit();
 
 	virtual Framework::CBitmap GetScreenshot();
 	void ProcessSingleFrame();


### PR DESCRIPTION
I've noticed that this PR, this code block below is now duplicated between `GetScreenshot()`, and both `FlipImpl()` in OpenGL and Vulkan, perhaps its best to abstract it into the `CGSHandler`, as these are they're graphics api independent (function name suggestions? `PopulatePS2DisplayInfo(DISPFB& fb, DISPLAY& d)`)

```cpp
	DISPFB fb;
	DISPLAY d;
	std::lock_guard<std::recursive_mutex> registerMutexLock(m_registerMutex);
	unsigned int readCircuit = GetCurrentReadCircuit();
	switch(readCircuit)
	{
	case 0:
		fb <<= m_nDISPFB1.value.q;
		d <<= m_nDISPLAY1.value.q;
		break;
	case 1:
		fb <<= m_nDISPFB2.value.q;
		d <<= m_nDISPLAY2.value.q;
		break;
	}
```