### PR TITLE
Vulkan toggle

### DIFF
--- a/Source/PS2VM.cpp
+++ b/Source/PS2VM.cpp
@@ -512,15 +512,7 @@ void CPS2VM::CreateGsHandlerImpl(const CGSHandler::FactoryFunction& factoryFunct
 	m_ee->m_gs->Initialize();
 	if(gs)
 	{
-		Framework::CZipArchiveWriter archive;
-		gs->SaveState(archive);
-
-		Framework::CMemStream stateStream;
-		archive.Write(stateStream);
-		stateStream.Seek(0, Framework::STREAM_SEEK_DIRECTION::STREAM_SEEK_SET);
-
-		Framework::CZipArchiveReader readArchive(stateStream);
-		m_ee->m_gs->LoadState(readArchive);
+		m_ee->m_gs->Copy(gs);
 		gs->Release();
 		delete gs;
 	}

--- a/Source/PS2VM.cpp
+++ b/Source/PS2VM.cpp
@@ -100,7 +100,6 @@ CPS2VM::CPS2VM()
 
 void CPS2VM::CreateGSHandler(const CGSHandler::FactoryFunction& factoryFunction)
 {
-	if(m_ee->m_gs != nullptr) return;
 	m_mailBox.SendCall([this, factoryFunction]() { CreateGsHandlerImpl(factoryFunction); }, true);
 }
 
@@ -507,9 +506,24 @@ void CPS2VM::DestroyImpl()
 
 void CPS2VM::CreateGsHandlerImpl(const CGSHandler::FactoryFunction& factoryFunction)
 {
+	auto gs = m_ee->m_gs;
 	m_ee->m_gs = factoryFunction();
 	m_ee->m_gs->SetIntc(&m_ee->m_intc);
 	m_ee->m_gs->Initialize();
+	if(gs)
+	{
+		Framework::CZipArchiveWriter archive;
+		gs->SaveState(archive);
+
+		Framework::CMemStream stateStream;
+		archive.Write(stateStream);
+		stateStream.Seek(0, Framework::STREAM_SEEK_DIRECTION::STREAM_SEEK_SET);
+
+		Framework::CZipArchiveReader readArchive(stateStream);
+		m_ee->m_gs->LoadState(readArchive);
+		gs->Release();
+		delete gs;
+	}
 	m_OnNewFrameConnection = m_ee->m_gs->OnNewFrame.Connect(std::bind(&CPS2VM::OnGsNewFrame, this));
 }
 

--- a/Source/gs/GSHandler.cpp
+++ b/Source/gs/GSHandler.cpp
@@ -279,6 +279,26 @@ void CGSHandler::LoadState(Framework::CZipArchiveReader& archive)
 	}
 }
 
+void CGSHandler::Copy(CGSHandler* gs)
+{
+	memcpy(GetRam(), gs->GetRam(), RAMSIZE);
+	memcpy(m_nReg, gs->m_nReg, sizeof(uint64) * CGSHandler::REGISTER_MAX);
+	m_trxCtx = gs->m_trxCtx;
+
+	{
+		m_nPMODE = gs->m_nPMODE;
+		m_nSMODE2 = gs->m_nSMODE2;
+		m_nDISPFB1.value.q = gs->m_nDISPFB1.value.q;
+		m_nDISPLAY1.value.q = gs->m_nDISPLAY1.value.q;
+		m_nDISPFB2.value.q = gs->m_nDISPFB2.value.q;
+		m_nDISPLAY2.value.q = gs->m_nDISPLAY2.value.q;
+		m_nCSR = gs->m_nCSR;
+		m_nIMR = gs->m_nIMR;
+		m_nSIGLBLID = gs->m_nSIGLBLID;
+		m_nCrtMode = gs->m_nCrtMode;
+	}
+}
+
 void CGSHandler::SetFrameDump(CFrameDump* frameDump)
 {
 	m_frameDump = frameDump;

--- a/Source/gs/GSHandler.h
+++ b/Source/gs/GSHandler.h
@@ -771,6 +771,7 @@ public:
 
 	virtual void SaveState(Framework::CZipArchiveWriter&);
 	virtual void LoadState(Framework::CZipArchiveReader&);
+	void Copy(CGSHandler*);
 
 	void SetFrameDump(CFrameDump*);
 

--- a/Source/ui_qt/PreferenceDefs.h
+++ b/Source/ui_qt/PreferenceDefs.h
@@ -2,4 +2,4 @@
 
 #define PREFERENCE_AUDIO_ENABLEOUTPUT "audio.enableoutput"
 #define PREF_UI_PAUSEWHENFOCUSLOST "ui.pausewhenfocuslost"
-#define PREF_VIDEO_USEVULKAN "video.usevulkan"
+#define PREF_VIDEO_GS_HANDLER "video.gshandler"

--- a/Source/ui_qt/Qt_ui/settingsdialog.ui
+++ b/Source/ui_qt/Qt_ui/settingsdialog.ui
@@ -205,42 +205,60 @@
         </widget>
        </item>
        <item>
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>GS Handler:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="comboBox_gs_selection">
-         <item>
-          <property name="text">
-           <string>OpenGL</string>
+        <widget class="QWidget" name="gs_option_widget" native="true">
+         <layout class="QGridLayout" name="gridLayout_2">
+          <property name="leftMargin">
+           <number>0</number>
           </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Vulkan</string>
+          <property name="topMargin">
+           <number>0</number>
           </property>
-         </item>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_5">
-         <property name="text">
-          <string>Warning: The Vulkan GS handler requires the VK_EXT_fragment_shader_interlock extension to work properly.
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>GS Handler:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QComboBox" name="comboBox_gs_selection">
+            <item>
+             <property name="text">
+              <string>OpenGL</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Vulkan</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Warning: The Vulkan GS handler requires the VK_EXT_fragment_shader_interlock extension to work properly.
 
 Changing this setting during gameplay can produce unexpected results.</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::AutoText</enum>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::AutoText</enum>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>

--- a/Source/ui_qt/Qt_ui/settingsdialog.ui
+++ b/Source/ui_qt/Qt_ui/settingsdialog.ui
@@ -205,10 +205,24 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="checkBox_enable_vulkan">
+        <widget class="QLabel" name="label_6">
          <property name="text">
-          <string>Enable Vulkan GS Handler</string>
+          <string>GS Handler:</string>
          </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="comboBox_gs_selection">
+         <item>
+          <property name="text">
+           <string>OpenGL</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Vulkan</string>
+          </property>
+         </item>
         </widget>
        </item>
        <item>
@@ -216,7 +230,7 @@
          <property name="text">
           <string>Warning: The Vulkan GS handler requires the VK_EXT_fragment_shader_interlock extension to work properly.
 
-This setting will take effect next time the emulator is restarted.</string>
+Changing this setting during gameplay can produce unexpected results.</string>
          </property>
          <property name="textFormat">
           <enum>Qt::AutoText</enum>

--- a/Source/ui_qt/Qt_ui/settingsdialog.ui
+++ b/Source/ui_qt/Qt_ui/settingsdialog.ui
@@ -227,18 +227,7 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QComboBox" name="comboBox_gs_selection">
-            <item>
-             <property name="text">
-              <string>OpenGL</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Vulkan</string>
-             </property>
-            </item>
-           </widget>
+           <widget class="QComboBox" name="comboBox_gs_selection"/>
           </item>
           <item row="2" column="0">
            <widget class="QLabel" name="label_5">

--- a/Source/ui_qt/mainwindow.cpp
+++ b/Source/ui_qt/mainwindow.cpp
@@ -83,6 +83,7 @@ MainWindow::MainWindow(QWidget* parent)
 	}
 
 	QWidget* container = QWidget::createWindowContainer(m_outputwindow);
+	m_outputwindow->create();
 	ui->gridLayout->addWidget(container, 0, 0);
 
 	connect(m_outputwindow, SIGNAL(heightChanged(int)), this, SLOT(outputWindow_resized()));
@@ -123,6 +124,7 @@ MainWindow::MainWindow(QWidget* parent)
 	ui->actionBoot_DiscImage_S3->setVisible(S3FileBrowser::IsAvailable());
 
 	InitVirtualMachine();
+	SetupGsHandler();
 
 #ifdef DEBUGGER_INCLUDED
 	m_debugger = std::make_unique<CDebugger>(*m_virtualMachine);
@@ -160,12 +162,6 @@ MainWindow::~MainWindow()
 		m_virtualMachine = nullptr;
 	}
 	delete ui;
-}
-
-void MainWindow::showEvent(QShowEvent* event)
-{
-	QMainWindow::showEvent(event);
-	SetupGsHandler();
 }
 
 void MainWindow::InitVirtualMachine()

--- a/Source/ui_qt/mainwindow.cpp
+++ b/Source/ui_qt/mainwindow.cpp
@@ -71,32 +71,6 @@ MainWindow::MainWindow(QWidget* parent)
 
 	m_continuationChecker = new CContinuationChecker(this);
 
-#ifdef HAS_GSH_VULKAN
-	if(CAppConfig::GetInstance().GetPreferenceBoolean(PREF_VIDEO_USEVULKAN))
-	{
-		m_outputwindow = new VulkanWindow;
-	}
-	else
-#endif
-	{
-		m_outputwindow = new OpenGLWindow;
-	}
-
-	QWidget* container = QWidget::createWindowContainer(m_outputwindow);
-	m_outputwindow->create();
-	ui->gridLayout->addWidget(container, 0, 0);
-
-	connect(m_outputwindow, SIGNAL(heightChanged(int)), this, SLOT(outputWindow_resized()));
-	connect(m_outputwindow, SIGNAL(widthChanged(int)), this, SLOT(outputWindow_resized()));
-
-	connect(m_outputwindow, SIGNAL(keyUp(QKeyEvent*)), this, SLOT(keyReleaseEvent(QKeyEvent*)));
-	connect(m_outputwindow, SIGNAL(keyDown(QKeyEvent*)), this, SLOT(keyPressEvent(QKeyEvent*)));
-
-	connect(m_outputwindow, SIGNAL(focusOut(QFocusEvent*)), this, SLOT(focusOutEvent(QFocusEvent*)));
-	connect(m_outputwindow, SIGNAL(focusIn(QFocusEvent*)), this, SLOT(focusInEvent(QFocusEvent*)));
-
-	connect(m_outputwindow, SIGNAL(doubleClick(QMouseEvent*)), this, SLOT(doubleClickEvent(QMouseEvent*)));
-
 #ifdef PROFILE
 	{
 		m_profileStatsLabel = new QLabel(this);
@@ -215,15 +189,35 @@ void MainWindow::SetupGsHandler()
 {
 	assert(m_virtualMachine);
 #ifdef HAS_GSH_VULKAN
-	if(CAppConfig::GetInstance().GetPreferenceBoolean(PREF_VIDEO_USEVULKAN))
+	if(CAppConfig::GetInstance().GetPreferenceInteger(PREF_VIDEO_GS_HANDLER) == 1)
 	{
+		m_outputwindow = new VulkanWindow;
+		QWidget* container = QWidget::createWindowContainer(m_outputwindow);
+		m_outputwindow->create();
+		ui->gridLayout->addWidget(container, 0, 0);
 		m_virtualMachine->CreateGSHandler(CGSH_VulkanQt::GetFactoryFunction(m_outputwindow));
 	}
 	else
 #endif
 	{
+		m_outputwindow = new OpenGLWindow;
+		QWidget* container = QWidget::createWindowContainer(m_outputwindow);
+		m_outputwindow->create();
+		ui->gridLayout->addWidget(container, 0, 0);
 		m_virtualMachine->CreateGSHandler(CGSH_OpenGLQt::GetFactoryFunction(m_outputwindow));
 	}
+
+	connect(m_outputwindow, SIGNAL(heightChanged(int)), this, SLOT(outputWindow_resized()));
+	connect(m_outputwindow, SIGNAL(widthChanged(int)), this, SLOT(outputWindow_resized()));
+
+	connect(m_outputwindow, SIGNAL(keyUp(QKeyEvent*)), this, SLOT(keyReleaseEvent(QKeyEvent*)));
+	connect(m_outputwindow, SIGNAL(keyDown(QKeyEvent*)), this, SLOT(keyPressEvent(QKeyEvent*)));
+
+	connect(m_outputwindow, SIGNAL(focusOut(QFocusEvent*)), this, SLOT(focusOutEvent(QFocusEvent*)));
+	connect(m_outputwindow, SIGNAL(focusIn(QFocusEvent*)), this, SLOT(focusInEvent(QFocusEvent*)));
+
+	connect(m_outputwindow, SIGNAL(doubleClick(QMouseEvent*)), this, SLOT(doubleClickEvent(QMouseEvent*)));
+
 	m_OnNewFrameConnection = m_virtualMachine->m_ee->m_gs->OnNewFrame.Connect(std::bind(&CStatsManager::OnNewFrame, &CStatsManager::GetInstance(), std::placeholders::_1));
 }
 
@@ -433,7 +427,37 @@ void MainWindow::CreateStatusBar()
 
 	statusBar()->addWidget(m_msgLabel, 1);
 	statusBar()->addWidget(m_fpsLabel);
+#ifdef HAS_GSH_VULKAN
+	auto gsLabel = new QLabel("");
+	auto gs_index = CAppConfig::GetInstance().GetPreferenceInteger(PREF_VIDEO_GS_HANDLER);
 
+	if(gs_index == 0)
+	{
+		gsLabel->setText("OpenGL");
+	}
+	else
+	{
+		gsLabel->setText("Vulkan");
+	}
+	gsLabel->setAlignment(Qt::AlignHCenter);
+	gsLabel->setMinimumSize(gsLabel->sizeHint());
+	//QLabel have no click event, so we're using ContextMenu event aka rightClick to toggle GS
+	gsLabel->setContextMenuPolicy(Qt::CustomContextMenu);
+	connect(gsLabel, &QLabel::customContextMenuRequested, [&, gsLabel]() {
+		auto gs_index = CAppConfig::GetInstance().GetPreferenceInteger(PREF_VIDEO_GS_HANDLER);
+		CAppConfig::GetInstance().SetPreferenceInteger(PREF_VIDEO_GS_HANDLER, 1 - gs_index);
+		SetupGsHandler();
+		if(1 - gs_index == 0)
+		{
+			gsLabel->setText("OpenGL");
+		}
+		else
+		{
+			gsLabel->setText("Vulkan");
+		}
+	});
+	statusBar()->addWidget(gsLabel);
+#endif
 	m_msgLabel->setText(QString("Play! v%1 - %2").arg(PLAY_VERSION).arg(__DATE__));
 
 	m_fpsTimer = new QTimer(this);
@@ -455,17 +479,26 @@ void MainWindow::updateStats()
 
 void MainWindow::on_actionSettings_triggered()
 {
+	auto gs_index = CAppConfig::GetInstance().GetPreferenceInteger(PREF_VIDEO_GS_HANDLER);
 	SettingsDialog sd;
 	sd.exec();
 	SetupSoundHandler();
 	if(m_virtualMachine != nullptr)
 	{
 		m_virtualMachine->ReloadSpuBlockCount();
-		outputWindow_resized();
-		auto gsHandler = m_virtualMachine->GetGSHandler();
-		if(gsHandler)
+		auto new_gs_index = CAppConfig::GetInstance().GetPreferenceInteger(PREF_VIDEO_GS_HANDLER);
+		if(gs_index != new_gs_index)
 		{
-			gsHandler->NotifyPreferencesChanged();
+			SetupGsHandler();
+		}
+		else
+		{
+			outputWindow_resized();
+			auto gsHandler = m_virtualMachine->GetGSHandler();
+			if(gsHandler)
+			{
+				gsHandler->NotifyPreferencesChanged();
+			}
 		}
 	}
 }
@@ -615,7 +648,7 @@ void MainWindow::RegisterPreferences()
 {
 	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREFERENCE_AUDIO_ENABLEOUTPUT, true);
 	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREF_UI_PAUSEWHENFOCUSLOST, true);
-	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREF_VIDEO_USEVULKAN, false);
+	CAppConfig::GetInstance().RegisterPreferenceInteger(PREF_VIDEO_GS_HANDLER, 1);
 }
 
 void MainWindow::focusOutEvent(QFocusEvent* event)

--- a/Source/ui_qt/mainwindow.cpp
+++ b/Source/ui_qt/mainwindow.cpp
@@ -214,21 +214,17 @@ void MainWindow::SetOutputWindowSize()
 void MainWindow::SetupGsHandler()
 {
 	assert(m_virtualMachine);
-	auto gsHandler = m_virtualMachine->GetGSHandler();
-	if(!gsHandler)
-	{
 #ifdef HAS_GSH_VULKAN
-		if(CAppConfig::GetInstance().GetPreferenceBoolean(PREF_VIDEO_USEVULKAN))
-		{
-			m_virtualMachine->CreateGSHandler(CGSH_VulkanQt::GetFactoryFunction(m_outputwindow));
-		}
-		else
-#endif
-		{
-			m_virtualMachine->CreateGSHandler(CGSH_OpenGLQt::GetFactoryFunction(m_outputwindow));
-		}
-		m_OnNewFrameConnection = m_virtualMachine->m_ee->m_gs->OnNewFrame.Connect(std::bind(&CStatsManager::OnNewFrame, &CStatsManager::GetInstance(), std::placeholders::_1));
+	if(CAppConfig::GetInstance().GetPreferenceBoolean(PREF_VIDEO_USEVULKAN))
+	{
+		m_virtualMachine->CreateGSHandler(CGSH_VulkanQt::GetFactoryFunction(m_outputwindow));
 	}
+	else
+#endif
+	{
+		m_virtualMachine->CreateGSHandler(CGSH_OpenGLQt::GetFactoryFunction(m_outputwindow));
+	}
+	m_OnNewFrameConnection = m_virtualMachine->m_ee->m_gs->OnNewFrame.Connect(std::bind(&CStatsManager::OnNewFrame, &CStatsManager::GetInstance(), std::placeholders::_1));
 }
 
 void MainWindow::SetupSoundHandler()

--- a/Source/ui_qt/mainwindow.h
+++ b/Source/ui_qt/mainwindow.h
@@ -120,7 +120,6 @@ private:
 
 protected:
 	void closeEvent(QCloseEvent*) Q_DECL_OVERRIDE;
-	void showEvent(QShowEvent*) Q_DECL_OVERRIDE;
 
 signals:
 	void onExecutableChange();

--- a/Source/ui_qt/settingsdialog.cpp
+++ b/Source/ui_qt/settingsdialog.cpp
@@ -14,6 +14,10 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 	//Not needed, as it can be set in the ui editor, but left for ease of ui edit.
 	ui->stackedWidget->setCurrentIndex(0);
 
+#ifndef HAS_GSH_VULKAN
+	ui->gs_option_widget->hide();
+#endif
+
 	LoadPreferences();
 	connect(ui->listWidget, &QListWidget::currentItemChanged, this, &SettingsDialog::changePage);
 }

--- a/Source/ui_qt/settingsdialog.cpp
+++ b/Source/ui_qt/settingsdialog.cpp
@@ -3,6 +3,7 @@
 #include "PS2VM_Preferences.h"
 #include "PreferenceDefs.h"
 #include "../gs/GSH_OpenGL/GSH_OpenGL.h"
+#include <cassert>
 #include <cmath>
 
 SettingsDialog::SettingsDialog(QWidget* parent)
@@ -14,9 +15,15 @@ SettingsDialog::SettingsDialog(QWidget* parent)
 	//Not needed, as it can be set in the ui editor, but left for ease of ui edit.
 	ui->stackedWidget->setCurrentIndex(0);
 
-#ifndef HAS_GSH_VULKAN
+	ui->comboBox_gs_selection->insertItem(SettingsDialog::GS_HANDLERS::OPENGL, "OpenGL");
+#ifdef HAS_GSH_VULKAN
+	ui->comboBox_gs_selection->insertItem(SettingsDialog::GS_HANDLERS::VULKAN, "Vulkan");
+#else
 	ui->gs_option_widget->hide();
 #endif
+
+	// this assert is to ensure no one adds an item to the combobox through qt creator by accident
+	assert(ui->comboBox_gs_selection->count() == SettingsDialog::GS_HANDLERS::MAX_HANDLER);
 
 	LoadPreferences();
 	connect(ui->listWidget, &QListWidget::currentItemChanged, this, &SettingsDialog::changePage);

--- a/Source/ui_qt/settingsdialog.cpp
+++ b/Source/ui_qt/settingsdialog.cpp
@@ -38,7 +38,7 @@ void SettingsDialog::LoadPreferences()
 	int factor_index = std::log2(factor);
 	ui->comboBox_res_multiplyer->setCurrentIndex(factor_index);
 	ui->checkBox_force_bilinear_filtering->setChecked(CAppConfig::GetInstance().GetPreferenceBoolean(PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES));
-	ui->checkBox_enable_vulkan->setChecked(CAppConfig::GetInstance().GetPreferenceBoolean(PREF_VIDEO_USEVULKAN));
+	ui->comboBox_gs_selection->setCurrentIndex(CAppConfig::GetInstance().GetPreferenceInteger(PREF_VIDEO_GS_HANDLER));
 
 	ui->checkBox_enable_audio->setChecked(CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_AUDIO_ENABLEOUTPUT));
 	ui->spinBox_spuBlockCount->setValue(CAppConfig::GetInstance().GetPreferenceInteger(PREF_AUDIO_SPUBLOCKCOUNT));
@@ -50,9 +50,9 @@ void SettingsDialog::on_checkBox_force_bilinear_filtering_clicked(bool checked)
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES, checked);
 }
 
-void SettingsDialog::on_checkBox_enable_vulkan_clicked(bool checked)
+void SettingsDialog::on_comboBox_gs_selection_currentIndexChanged(int index)
 {
-	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_VIDEO_USEVULKAN, checked);
+	CAppConfig::GetInstance().SetPreferenceInteger(PREF_VIDEO_GS_HANDLER, index);
 }
 
 void SettingsDialog::on_checkBox_enable_audio_clicked(bool checked)

--- a/Source/ui_qt/settingsdialog.h
+++ b/Source/ui_qt/settingsdialog.h
@@ -16,6 +16,15 @@ class SettingsDialog : public QDialog
 	Q_OBJECT
 
 public:
+	enum GS_HANDLERS
+	{
+		OPENGL,
+#ifdef HAS_GSH_VULKAN
+		VULKAN,
+#endif
+		MAX_HANDLER
+	};
+
 	explicit SettingsDialog(QWidget* parent = 0);
 	~SettingsDialog();
 	void LoadPreferences();

--- a/Source/ui_qt/settingsdialog.h
+++ b/Source/ui_qt/settingsdialog.h
@@ -22,7 +22,7 @@ public:
 
 private slots:
 	void on_checkBox_force_bilinear_filtering_clicked(bool checked);
-	void on_checkBox_enable_vulkan_clicked(bool checked);
+	void on_comboBox_gs_selection_currentIndexChanged(int index);
 	void on_checkBox_enable_audio_clicked(bool checked);
 	void on_comboBox_presentation_mode_currentIndexChanged(int index);
 	void changePage(QListWidgetItem* current, QListWidgetItem* previous);


### PR DESCRIPTION
Note:
```I think ideally we'd have a function `CGSHandler::Swap(gs)` that would copy memory/regs over, and swap the reset of the states, however, right now, all of these are protected, so this was the easiest way, without moving everything around.```
edit: it seems i misunderstood how protected members work, they can actually be accessed just fine by another instance of the same class.

Tested:Win32
Games: KH, FF12, MX8
MX8 produces weird artifacts at the bottom when swapped during dialog
videos on discord

overlay is MSI afterburn