### PR TITLE
Libretro fix

### DIFF
--- a/Source/PS2VM.cpp
+++ b/Source/PS2VM.cpp
@@ -207,6 +207,17 @@ void CPS2VM::Pause()
 	OnRunningStateChange();
 }
 
+void CPS2VM::PauseAsync()
+{
+	if(m_nStatus == PAUSED) return;
+	m_mailBox.SendCall([this]()
+	{
+		PauseImpl();
+		OnMachineStateChange();
+		OnRunningStateChange();
+	});
+}
+
 void CPS2VM::Reset()
 {
 	assert(m_nStatus == PAUSED);

--- a/Source/PS2VM.cpp
+++ b/Source/PS2VM.cpp
@@ -210,8 +210,7 @@ void CPS2VM::Pause()
 void CPS2VM::PauseAsync()
 {
 	if(m_nStatus == PAUSED) return;
-	m_mailBox.SendCall([this]()
-	{
+	m_mailBox.SendCall([this]() {
 		PauseImpl();
 		OnMachineStateChange();
 		OnRunningStateChange();

--- a/Source/PS2VM.h
+++ b/Source/PS2VM.h
@@ -45,6 +45,7 @@ public:
 
 	void Resume() override;
 	void Pause() override;
+	void PauseAsync();
 	void Reset();
 
 	STATUS GetStatus() const override;

--- a/Source/ui_libretro/GSH_OpenGL_Libretro.cpp
+++ b/Source/ui_libretro/GSH_OpenGL_Libretro.cpp
@@ -69,6 +69,7 @@ void CGSH_OpenGL_Libretro::FlushMailBox()
 	bool isFlushed = false;
 	SendGSCall([&]() {
 		isFlushed = true;
+		m_flipped  = true;
 	},
 	           true);
 	while(!isFlushed)

--- a/Source/ui_libretro/GSH_OpenGL_Libretro.cpp
+++ b/Source/ui_libretro/GSH_OpenGL_Libretro.cpp
@@ -69,7 +69,7 @@ void CGSH_OpenGL_Libretro::FlushMailBox()
 	bool isFlushed = false;
 	SendGSCall([&]() {
 		isFlushed = true;
-		m_flipped  = true;
+		m_flipped = true;
 	},
 	           true);
 	while(!isFlushed)

--- a/Source/ui_libretro/main_libretro.cpp
+++ b/Source/ui_libretro/main_libretro.cpp
@@ -573,11 +573,11 @@ void retro_deinit()
 	{
 		// Note: since we're forced GS into running on this thread
 		// we need to clear its queue, to prevent it freezing the reset of the system during delete
+		m_virtualMachine->PauseAsync();
 		auto gsHandler = m_virtualMachine->GetGSHandler();
 		if(gsHandler)
 			static_cast<CGSH_OpenGL_Libretro*>(gsHandler)->Release();
 
-		m_virtualMachine->Pause();
 		m_virtualMachine->DestroyPadHandler();
 		m_virtualMachine->DestroyGSHandler();
 		m_virtualMachine->DestroySoundHandler();

--- a/Source/ui_libretro/main_libretro.cpp
+++ b/Source/ui_libretro/main_libretro.cpp
@@ -571,13 +571,18 @@ void retro_deinit()
 
 	if(m_virtualMachine)
 	{
-		// Note: since we're forced GS into running on this thread
-		// we need to clear its queue, to prevent it freezing the reset of the system during delete
 		m_virtualMachine->PauseAsync();
-		auto gsHandler = m_virtualMachine->GetGSHandler();
+		auto gsHandler = static_cast<CGSH_OpenGL_Libretro*>(m_virtualMachine->GetGSHandler());
 		if(gsHandler)
-			static_cast<CGSH_OpenGL_Libretro*>(gsHandler)->Release();
-
+		{
+			// Note: since we've forced GS into running on this/main/libretro thread
+			// we need to clear its queue, to prevent it from locking up VM
+			while(m_virtualMachine->GetStatus() != CVirtualMachine::PAUSED)
+			{
+				std::this_thread::yield();
+				gsHandler->Release();
+			}
+		}
 		m_virtualMachine->DestroyPadHandler();
 		m_virtualMachine->DestroyGSHandler();
 		m_virtualMachine->DestroySoundHandler();


### PR DESCRIPTION
to elaborate a bit on this fix,
so when running in single thread gs mode, during VM's handler destruction, the VM uses its mailbox to queue the handler destruction action, however, since the GS is not threaded, the VM mailbox can already be blocked, by a blocking call to the GS, leading to a deadlock.

so the initial solution was, to destroy the GS 1st, then start VM destruction, which worked fine for the most part, but that ran into issues, (1) between calling `gs->Release()` -> `delete gs;` a call could have already been queued up, and blocked VM mailbox (thus we needed 884ccc2)
2) we successfully delete gs, but segfault instead, since between `delete gs;` and `vm->->Pause()`, the DMA/GIF tried to send cmd to a destroyed GS...

so the easier solution was, to swap the GS on the fly, with a non-threaded null gs, that would just discard all mailbox requests,  then delete the old gs, then "regularly" destroy the VM