### PR TITLE
document CCdvdfsv::Invoke592 method 0 structure

### DIFF
--- a/Source/iop/Iop_Cdvdfsv.cpp
+++ b/Source/iop/Iop_Cdvdfsv.cpp
@@ -166,6 +166,8 @@ bool CCdvdfsv::Invoke592(uint32 method, uint32* args, uint32 argsSize, uint32* r
 		if(retSize != 0)
 		{
 			assert(retSize >= 0x10);
+			ret[1]; // cdvdfsv Ver
+			ret[2]; // cdvdman Ver
 			ret[0x03] = 0xFF;
 		}
 		CLog::GetInstance().Print(LOG_NAME, "Init(mode = %d);\r\n", mode);


### PR DESCRIPTION
I found this through logs, if you try to run OSDSYS from bios, it will print these details.

`sceCdInit: cdvdfsv Ver 0000 cdvdman Ver 0000`