### PR TITLE
Small mc improvements

### DIFF
--- a/Source/iop/DirectoryDevice.cpp
+++ b/Source/iop/DirectoryDevice.cpp
@@ -75,3 +75,13 @@ Directory CDirectoryDevice::GetDirectory(const char* devicePath)
 	}
 	return fs::directory_iterator(path);
 }
+
+void CDirectoryDevice::CreateDirectory(const char* devicePath)
+{
+	auto basePath = CAppConfig::GetInstance().GetPreferencePath(m_basePathPreferenceName.c_str());
+	auto path = Iop::PathUtils::MakeHostPath(basePath, devicePath);
+	if(!fs::create_directory(path))
+	{
+		throw std::runtime_error("Failed to create directory.");
+	}
+}

--- a/Source/iop/DirectoryDevice.h
+++ b/Source/iop/DirectoryDevice.h
@@ -15,6 +15,7 @@ namespace Iop
 
 			Framework::CStream* GetFile(uint32, const char*) override;
 			Directory GetDirectory(const char*) override;
+			void CreateDirectory(const char*) override;
 
 		private:
 			std::string m_basePathPreferenceName;

--- a/Source/iop/Ioman_Device.h
+++ b/Source/iop/Ioman_Device.h
@@ -26,6 +26,9 @@ namespace Iop
 			virtual ~CDevice() = default;
 			virtual Framework::CStream* GetFile(uint32, const char*) = 0;
 			virtual Directory GetDirectory(const char*) = 0;
+			virtual void CreateDirectory(const char*)
+			{
+			}
 		};
 	}
 }

--- a/Source/iop/Iop_FileIoHandler1000.cpp
+++ b/Source/iop/Iop_FileIoHandler1000.cpp
@@ -79,6 +79,10 @@ bool CFileIoHandler1000::Invoke(uint32 method, uint32* args, uint32 argsSize, ui
 		LaunchSeekRequest(args, argsSize, ret, retSize, ram);
 		return false;
 		break;
+	case 7:
+		assert(retSize == 4);
+		*ret = m_ioman->Mkdir(reinterpret_cast<const char*>(&args[0]));
+		break;
 	case 9:
 		assert(retSize == 4);
 		*ret = m_ioman->Dopen(reinterpret_cast<const char*>(&args[0]));

--- a/Source/iop/Iop_Ioman.cpp
+++ b/Source/iop/Iop_Ioman.cpp
@@ -318,6 +318,28 @@ uint32 CIoman::Seek(uint32 handle, uint32 position, uint32 whence)
 	return result;
 }
 
+int32 CIoman::Mkdir(const char* path)
+{
+	CLog::GetInstance().Print(LOG_NAME, "Mkdir(path = '%s');\r\n",
+	                          path);
+	auto pathInfo = SplitPath(path);
+	auto deviceIterator = m_devices.find(pathInfo.deviceName);
+	if(deviceIterator == m_devices.end())
+	{
+		throw std::runtime_error("Device not found.");
+	}
+
+	try
+	{
+		deviceIterator->second->CreateDirectory(pathInfo.devicePath.c_str());
+		return 0;
+	}
+	catch(...)
+	{
+		return -1;
+	}
+}
+
 int32 CIoman::Dopen(const char* path)
 {
 	CLog::GetInstance().Print(LOG_NAME, "Dopen(path = '%s');\r\n",

--- a/Source/iop/Iop_Ioman.h
+++ b/Source/iop/Iop_Ioman.h
@@ -48,6 +48,7 @@ namespace Iop
 		uint32 Read(uint32, uint32, void*);
 		uint32 Write(uint32, uint32, const void*);
 		uint32 Seek(uint32, uint32, uint32);
+		int32 Mkdir(const char* path);
 		int32 Dopen(const char*);
 		int32 Dread(uint32, Ioman::DIRENTRY*);
 		int32 Dclose(uint32);

--- a/Source/iop/OpticalMediaDevice.cpp
+++ b/Source/iop/OpticalMediaDevice.cpp
@@ -29,3 +29,8 @@ Directory COpticalMediaDevice::GetDirectory(const char* devicePath)
 {
 	throw std::runtime_error("Not supported.");
 }
+
+void COpticalMediaDevice::CreateDirectory(const char* devicePath)
+{
+	throw std::runtime_error("Not supported.");
+}

--- a/Source/iop/OpticalMediaDevice.h
+++ b/Source/iop/OpticalMediaDevice.h
@@ -18,6 +18,7 @@ namespace Iop
 
 			Framework::CStream* GetFile(uint32, const char*) override;
 			Directory GetDirectory(const char*) override;
+			void CreateDirectory(const char* devicePath) override;
 
 		private:
 			static char FixSlashes(char);


### PR DESCRIPTION
Implements some small memory card related improvements.

The 0 / -1 switch on CMcServ::GetInfo is just niceness - I don't think any game or homebrew actually relies on this behavior.

The Mkdir call is used by the PS2SDK memory card example, and partially fixes that example.