### PR TITLE
Account for textures with 0 buffer width

### DIFF
--- a/Source/gs/GSH_Direct3D9/GSH_Direct3D9.cpp
+++ b/Source/gs/GSH_Direct3D9/GSH_Direct3D9.cpp
@@ -83,7 +83,15 @@ void CGSH_Direct3D9::ProcessHostToLocalTransfer()
 		//Find the pages that are touched by this transfer
 		auto transferPageSize = CGsPixelFormats::GetPsmPageSize(bltBuf.nDstPsm);
 
-		uint32 pageCountX = (bltBuf.GetDstWidth() + transferPageSize.first - 1) / transferPageSize.first;
+		// DBZ Budokai Tenkaichi 2 and 3 use invalid (empty) buffer sizes
+		// Account for that, by assuming trxReg.nRRW.
+		auto width = bltBuf.GetDstWidth();
+		if(width == 0)
+		{
+			width = trxReg.nRRW;
+		}
+
+		uint32 pageCountX = (width + transferPageSize.first - 1) / transferPageSize.first;
 		uint32 pageCountY = (trxReg.nRRH + transferPageSize.second - 1) / transferPageSize.second;
 
 		uint32 pageCount = pageCountX * pageCountY;

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -1980,7 +1980,15 @@ void CGSH_OpenGL::ProcessHostToLocalTransfer()
 		//Find the pages that are touched by this transfer
 		auto transferPageSize = CGsPixelFormats::GetPsmPageSize(bltBuf.nDstPsm);
 
-		uint32 pageCountX = (bltBuf.GetDstWidth() + transferPageSize.first - 1) / transferPageSize.first;
+		// DBZ Budokai Tenkaichi 2 and 3 use invalid (empty) buffer sizes
+		// Account for that, by assuming trxReg.nRRW.
+		auto width = bltBuf.GetDstWidth();
+		if(width == 0)
+		{
+			width = trxReg.nRRW;
+		}
+
+		uint32 pageCountX = (width + transferPageSize.first - 1) / transferPageSize.first;
 		uint32 pageCountY = (trxReg.nRRH + transferPageSize.second - 1) / transferPageSize.second;
 
 		uint32 pageCount = pageCountX * pageCountY;

--- a/Source/gs/GsTextureCache.h
+++ b/Source/gs/GsTextureCache.h
@@ -64,7 +64,14 @@ public:
 		auto texture = *m_textureCache.rbegin();
 		texture->Reset();
 
-		texture->m_cachedArea.SetArea(tex0.nPsm, tex0.GetBufPtr(), tex0.GetBufWidth(), tex0.GetHeight());
+        // DBZ Budokai Tenkaichi 2 and 3 use invalid (empty) buffer sizes.
+        // Account for that, by assuming image width.
+        uint32 bufSize = tex0.GetBufWidth();
+		if (bufSize == 0) {
+			bufSize = tex0.GetWidth();
+		}
+
+		texture->m_cachedArea.SetArea(tex0.nPsm, tex0.GetBufPtr(), bufSize, tex0.GetHeight());
 
 		texture->m_tex0 = static_cast<uint64>(tex0) & TEX0_CLUTINFO_MASK;
 		texture->m_textureHandle = std::move(textureHandle);


### PR DESCRIPTION
The problem fixed here is the following:

DBZ Budokai Tenkaichi 2 and 3 (at least) use textures, which have a buffer width of 0. This caused the texture cache to get confused, as it effectively build a 0 pixel wide rect.

The other thing that baffled me was the fact that these games also use 0 length "host to local" data transfers. This triggered an assert downstream (since it found an dirty page, but due to the 0 transfer width, there was nothing to actually set dirty).

I don't really see how these textures even work with a 0 buffer size, but they seem to (note, the textures in the menu of Tenkaichi 2 are also kinda animated).

Unrelated: Unfortunately, Tenkaichi 2 still has the all-black texture for characters problem... But I have a hunch what the problem is.

**Screenshots (Tenkaichi 2):**

![tenkaichi_2_menu_broken](https://user-images.githubusercontent.com/1338408/80402965-0effd600-88bf-11ea-8170-b77f9cf55979.png)

![tenkaichi_2_menu_broken_2](https://user-images.githubusercontent.com/1338408/80402970-10c99980-88bf-11ea-9867-2053c9a09a0b.png)

![tenkaichi_2_menu_fixed](https://user-images.githubusercontent.com/1338408/80402988-1921d480-88bf-11ea-88ed-72b22b15f43e.png)

![tenkaichi_2_ingame_broken](https://user-images.githubusercontent.com/1338408/80403839-8eda7000-88c0-11ea-9eb9-420170630401.png)

![tenkaichi_2_ingame_fixed](https://user-images.githubusercontent.com/1338408/80403843-913cca00-88c0-11ea-8208-b77f626a2296.png)

**Screenshots (Tenkaichi 3):**

![tenkaichi_3_menu_broken](https://user-images.githubusercontent.com/1338408/80403659-3d31e580-88c0-11ea-91ec-647540645ee7.png)

![tenkaichi_3_menu_fixed](https://user-images.githubusercontent.com/1338408/80403664-3e631280-88c0-11ea-88e9-3ec8cf6e42b9.png)

![tenkaichi_3_ingame_broken](https://user-images.githubusercontent.com/1338408/80403805-808c5400-88c0-11ea-8158-46018265d2c9.png)

![tenkaichi_3_ingame_fixed](https://user-images.githubusercontent.com/1338408/80403807-82561780-88c0-11ea-83cc-cf7f489f9832.png)