### PR TITLE
Fix symbol error when building libretro core with gcc-8

### DIFF
--- a/Source/ui_libretro/CMakeLists.txt
+++ b/Source/ui_libretro/CMakeLists.txt
@@ -45,6 +45,11 @@ elseif(TARGET_PLATFORM_UNIX)
 	list(APPEND PROJECT_LIBS "-static-libstdc++")
 endif()
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 8 AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++fs")
+	list(APPEND PROJECT_LIBS "libstdc++fs.a")
+endif()
+
 add_library(play_libretro SHARED ${SRC})
 target_include_directories(play_libretro PRIVATE
 	./


### PR DESCRIPTION
As mentioned in #891 a Linux build of the Play libretro core with gcc-8 will crash because of an unknown symbol

`retroarch: symbol lookup error: /usr/local/lib/libretro/play_libretro.so: undefined symbol: _ZNSt10filesystem7__cxx114path14_M_split_cmptsEv`

The issue seems to be specific to gcc-8 and the attached changes fix it.