### PR TITLE
[WIP] Correctly implement TEST_1/2 AFAIL

### DIFF
--- a/Source/gs/GSH_OpenGL/GSH_OpenGL_Shader.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL_Shader.cpp
@@ -347,11 +347,12 @@ Framework::OpenGl::CShader CGSH_OpenGL::GenerateFragmentShader(const SHADERCAPS&
 	}
 
 	shaderBuilder << "	bool outputColor = true;" << std::endl;
+	shaderBuilder << "	bool outputDepth = true;" << std::endl;
 	shaderBuilder << "	bool outputAlpha = true;" << std::endl;
 
 	if(caps.hasAlphaTest)
 	{
-		shaderBuilder << GenerateAlphaTestSection(static_cast<ALPHA_TEST_METHOD>(caps.alphaTestMethod), static_cast<ALPHA_TEST_FAIL_METHOD>(m_hasFramebufferFetchExtension ? caps.alphaFailMethod : ALPHA_TEST_FAIL_KEEP));
+		shaderBuilder << GenerateAlphaTestSection(static_cast<ALPHA_TEST_METHOD>(caps.alphaTestMethod), static_cast<ALPHA_TEST_FAIL_METHOD>(caps.alphaFailMethod));
 	}
 
 	// ----------------------
@@ -391,7 +392,11 @@ Framework::OpenGl::CShader CGSH_OpenGL::GenerateFragmentShader(const SHADERCAPS&
 
 	// ----------------------
 
-	shaderBuilder << "	gl_FragDepth = v_depth;" << std::endl;
+	shaderBuilder << "	if(outputDepth) {" << std::endl;
+
+	shaderBuilder << "		gl_FragDepth = v_depth;" << std::endl;
+
+	shaderBuilder << "	}" << std::endl;
 
 	// ----------------------
 
@@ -487,6 +492,7 @@ std::string CGSH_OpenGL::GenerateAlphaTestSection(ALPHA_TEST_METHOD testMethod, 
 		break;
 	case ALPHA_TEST_FAIL_FBONLY:
 		// Only write color and alpha
+        shaderBuilder << "	outputDepth = false;" << std::endl;
 		// TODO: We cannot prevent depth from being written at the moment
 		assert(0);
 		break;
@@ -498,6 +504,7 @@ std::string CGSH_OpenGL::GenerateAlphaTestSection(ALPHA_TEST_METHOD testMethod, 
 	case ALPHA_TEST_FAIL_RGBONLY:
 		// Only write color
 		shaderBuilder << "	outputAlpha = false;" << std::endl;
+        shaderBuilder << "	outputDepth = false;" << std::endl;
 		// TODO: We cannot prevent depth from being written at the moment
 		assert(0);
 		break;


### PR DESCRIPTION
When a alpha test fail method is set, and the trivial cases cannot be handled via color mask, we need to handle it in shader code.

### Full Metal Alchemist

#### SLUS-20994

Did not render anything before (besides intro)

![fma_fixed](https://user-images.githubusercontent.com/1338408/80726452-af930780-8b04-11ea-8f96-f12deb26ed10.png)
![fma_fixed_1](https://user-images.githubusercontent.com/1338408/80726456-b02b9e00-8b04-11ea-812e-54b1e1aa606c.png)
![Screenshot from 2020-04-30 16-54-31](https://user-images.githubusercontent.com/1338408/80726037-32679280-8b04-11ea-801c-122745deaa51.png)
![Screenshot from 2020-04-30 16-55-12](https://user-images.githubusercontent.com/1338408/80726040-33002900-8b04-11ea-99fd-4d82491cd55f.png)

#### SLUS-21166

Only rendered intro and garbage ingame.

![Screenshot from 2020-04-30 16-59-25](https://user-images.githubusercontent.com/1338408/80726050-35628300-8b04-11ea-8597-83649a76c111.png)

![Screenshot from 2020-04-30 16-55-34](https://user-images.githubusercontent.com/1338408/80726041-3398bf80-8b04-11ea-8aa2-632f90d775db.png)
![Screenshot from 2020-04-30 16-55-49](https://user-images.githubusercontent.com/1338408/80726044-34c9ec80-8b04-11ea-8bec-832704e23269.png)

### Katamari Damacy

Sprites fixed

![Screenshot from 2020-04-30 16-59-06](https://user-images.githubusercontent.com/1338408/80726047-34c9ec80-8b04-11ea-8427-a32be7b079af.png)

![katamari_damacy_fixed](https://user-images.githubusercontent.com/1338408/80726347-92f6cf80-8b04-11ea-8cd0-da5c01f6793a.png)