### PR TITLE
[WIP] Fix vertical lines

### DIFF
--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -640,6 +640,12 @@ void CGSH_OpenGL::SetRenderingContext(uint64 primReg)
 	m_nPrimOfsX = offset.GetX();
 	m_nPrimOfsY = offset.GetY();
 
+	// Account for the fact that PS2 assumes the pixel center at the bottom left,
+	// but OpenGL at the center of the screen. On even resolutions this causes a slight
+	// discrepancy.
+	m_nPrimOfsX -= 0.5f;
+	m_nPrimOfsY -= 0.5f;
+
 	CHECKGLERROR();
 
 	m_renderState.isValid = true;

--- a/Source/gs/GSHandler.cpp
+++ b/Source/gs/GSHandler.cpp
@@ -658,6 +658,9 @@ void CGSHandler::WriteRegisterImpl(uint8 nRegister, uint64 nData)
 
 	switch(nRegister)
 	{
+	case GS_REG_ST:
+		m_nReg[nRegister] &= 0xFFFFFF00FFFFFF00;
+		break;
 	case GS_REG_TEX0_1:
 	case GS_REG_TEX0_2:
 	{


### PR DESCRIPTION
Didn't know what to call this PR - it fixes quite a bit more then than the title suggests.

The PS2 assumes the 0,0 pixel at the center of the screen. OpenGL (at least) assumes the 0,0 pixel at the top left. When the screen width/height is even, this causes a slight discrepancy of half a pixel.

In all games I tested this yields very neat results, and fixes all kinds of slight visual artifacts. For me, notable text rendering and text boxes in Suikoden 5, as well as briefings in Ring of Red.

This needs more testing with different games. Together with https://github.com/jpd002/Play-/pull/895, this fixes most visual problems of the games that start for me. But for cleanness purposes, the following screenshots are without the fixes in https://github.com/jpd002/Play-/pull/895.

**Lego Star Wars II**
<details>
  <summary>Click to expand!</summary>


**This issue is only visible in tandem with https://github.com/jpd002/Play-/pull/895, so differences are show to this PR here!**

![Screenshot from 2020-05-03 01-35-49](https://user-images.githubusercontent.com/1338408/80894769-7f06c580-8cde-11ea-9854-866d48e793a0.png)
![Screenshot from 2020-05-03 01-34-43](https://user-images.githubusercontent.com/1338408/80894770-8037f280-8cde-11ea-8c96-66b80a11f54d.png)

</details>

**Ring of Red**
<details>
  <summary>Click to expand!</summary>

  ![Screenshot from 2020-05-03 01-31-17](https://user-images.githubusercontent.com/1338408/80894736-115a9980-8cde-11ea-9eac-5131eda688f1.png)

  ![Screenshot from 2020-05-03 01-21-30](https://user-images.githubusercontent.com/1338408/80894707-aa3ce500-8cdd-11ea-90c7-14f6f83806ec.png)
</details>

**Suikoden 5**
<details>
  <summary>Click to expand!</summary>

Look especially at the question mark at the bottom!

![Screenshot from 2020-05-03 01-39-19](https://user-images.githubusercontent.com/1338408/80894816-ff2d2b00-8cde-11ea-9760-d01300bc758e.png)
![Screenshot from 2020-05-03 01-38-10](https://user-images.githubusercontent.com/1338408/80894819-00f6ee80-8cdf-11ea-8ba6-829e5c814ff5.png)

  ![Screenshot from 2020-05-03 01-20-01](https://user-images.githubusercontent.com/1338408/80894700-9d1ff600-8cdd-11ea-9aa7-57994d74f058.png)
![Screenshot from 2020-05-03 01-20-28](https://user-images.githubusercontent.com/1338408/80894705-a610c780-8cdd-11ea-8a37-796d5db78ada.png)

</details>