### PR TITLE
Fix rendering issues in DBZ Budokai

### DIFF
--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -2075,6 +2075,9 @@ void CGSH_OpenGL::ProcessLocalToLocalTransfer()
 	}
 	else if(foundSrc && !foundDest)
 	{
+		FlushVertexBuffer();
+		m_renderState.isValid = false;
+
 		auto trxPos = make_convertible<TRXPOS>(m_nReg[GS_REG_TRXPOS]);
 		auto trxReg = make_convertible<TRXREG>(m_nReg[GS_REG_TRXREG]);
 		auto imgbuffer = Framework::CBitmap(trxReg.nRRW * m_fbScale, trxReg.nRRH * m_fbScale, 32);


### PR DESCRIPTION
~~This PR fixes two visual bugs in DBZ Budokai, distinct by commit:~~

~~Firstly, it implements a missing blend mode, required for some kinda minigame (dunno how to call this otherwise :D).~~

**Edit**: This PR was adjusted, to only contain the changes mentioned below. The blend-mode commit was removed, as a proper fix will be implemented elsewhere.

![Screenshot from 2020-05-03 21-03-50](https://user-images.githubusercontent.com/1338408/80923122-d14cf280-8d81-11ea-8fca-7edf994d7539.png)

![Screenshot from 2020-05-03 21-00-23](https://user-images.githubusercontent.com/1338408/80923538-b7f97580-8d84-11ea-9afd-3503135abf9e.png)

The second regards the transparent junk in the background during battle:

If we do a local to local transfer, the destination might not be a framebuffer, but a texture. This is used in the game for some "depth of field" effect during battle.

![Screenshot from 2020-05-03 21-05-13](https://user-images.githubusercontent.com/1338408/80923126-d6aa3d00-8d81-11ea-8b5b-02232e57c04f.png)

![Screenshot from 2020-05-03 20-59-19](https://user-images.githubusercontent.com/1338408/80923540-bb8cfc80-8d84-11ea-8bc0-1b83fe9adb19.png)
