### PR TITLE
travis linux parallel build

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -87,7 +87,7 @@ travis_script()
             export VULKAN_SDK=$(pwd)/../${VULKAN_SDK_VERSION}/x86_64
             export PATH=$PATH:/opt/qt512/lib/cmake
             cmake .. -G"$BUILD_TYPE" -DCMAKE_INSTALL_PREFIX=./appdir/usr -DBUILD_LIBRETRO_CORE=yes;
-            cmake --build .
+            cmake --build . -j $(nproc)
             ctest
             cmake --build . --target install
             if [ "$TARGET_ARCH" = "x86_64" ]; then


### PR DESCRIPTION
the arm64 build seem to have 32 threads at their disposal, so why not use them :)

I checked other builds, this doesn't seem to have any effect, likely due default parallel building.
edit: didn't test android, though I'm not sure how we'd pass this to it, or if we even should, since we don't interact with cmake directly.