### PR TITLE
FreeBSD CI

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -39,6 +39,8 @@ travis_before_install()
     elif [ "$TARGET_OS" = "Android" ]; then
         echo y | sdkmanager 'ndk;21.0.6113669'
         echo y | sdkmanager 'cmake;3.10.2.4988404'
+    elif [ "$TARGET_OS" = "FREEBSD" ]; then
+        su -m root -c 'pkg install -y cmake qt5 gcc9 evdev-proto'
     fi;
 
     git submodule update -q --init --recursive
@@ -117,6 +119,10 @@ travis_script()
             ./build_ipa.sh
             popd
             popd
+        elif [ "$TARGET_OS" = "FREEBSD" ]; then
+            export CXX="g++9" CC="gcc9"
+            cmake ..
+            cmake --build . -j$(sysctl -n hw.ncpu)
         fi;
         
         popd

--- a/.travis.sh
+++ b/.travis.sh
@@ -40,7 +40,7 @@ travis_before_install()
         echo y | sdkmanager 'ndk;21.0.6113669'
         echo y | sdkmanager 'cmake;3.10.2.4988404'
     elif [ "$TARGET_OS" = "FREEBSD" ]; then
-        su -m root -c 'pkg install -y cmake qt5 gcc9 evdev-proto'
+        su -m root -c 'pkg install -y cmake qt5 evdev-proto'
     fi;
 
     git submodule update -q --init --recursive
@@ -120,7 +120,7 @@ travis_script()
             popd
             popd
         elif [ "$TARGET_OS" = "FREEBSD" ]; then
-            export CXX="g++9" CC="gcc9"
+            export CXX="g++" CC="gcc"
             cmake ..
             cmake --build . -j$(sysctl -n hw.ncpu)
         fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,11 @@ matrix:
         - build-tools-28.0.3
         - android-28
         - extra-android-m2repository
+    - os: freebsd
+      dist: trusty
+      env:
+        - TARGET_OS=FREEBSD
+      sudo: require
 
 language: cpp
 

--- a/Source/ui_qt/CMakeLists.txt
+++ b/Source/ui_qt/CMakeLists.txt
@@ -64,6 +64,9 @@ if(TARGET_PLATFORM_UNIX)
 
 	list(APPEND PROJECT_LIBS "-static-libgcc")
 	list(APPEND PROJECT_LIBS "-static-libstdc++")
+
+	# most unix system seem to implicitly link to libinotify, but not BSD
+	list(APPEND PROJECT_LIBS "libinotify.so")
 endif()
 
 if(TARGET_PLATFORM_MACOS OR TARGET_PLATFORM_UNIX)

--- a/Source/ui_qt/CMakeLists.txt
+++ b/Source/ui_qt/CMakeLists.txt
@@ -65,8 +65,10 @@ if(TARGET_PLATFORM_UNIX)
 	list(APPEND PROJECT_LIBS "-static-libgcc")
 	list(APPEND PROJECT_LIBS "-static-libstdc++")
 
-	# most unix system seem to implicitly link to libinotify, but not BSD
-	list(APPEND PROJECT_LIBS "libinotify.so")
+	if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+		# most unix system seem to implicitly link to libinotify, but not FreeBSD
+		list(APPEND PROJECT_LIBS "libinotify.so")
+	endif()
 endif()
 
 if(TARGET_PLATFORM_MACOS OR TARGET_PLATFORM_UNIX)

--- a/Source/ui_qt/unix/GamePadDeviceListener.cpp
+++ b/Source/ui_qt/unix/GamePadDeviceListener.cpp
@@ -3,6 +3,7 @@
 #include "GamePadDeviceListener.h"
 #include <fcntl.h>
 #include <sys/select.h>
+#include <sys/time.h>
 #include <poll.h>
 #include <sys/inotify.h>
 #include <csignal>
@@ -96,6 +97,9 @@ void CGamePadDeviceListener::InputDeviceListenerThread()
 		return;
 	}
 
+	struct timespec ts;
+	ts.tv_nsec = 5e+8; // 500 millisecond
+
 	fd_set fds;
 	FD_ZERO(&fds);
 	FD_SET(fd, &fds);
@@ -111,7 +115,7 @@ void CGamePadDeviceListener::InputDeviceListenerThread()
 
 	while(m_running)
 	{
-		if(pselect(fd + 1, &fds, NULL, NULL, 500, &mask) == 0) continue;
+		if(pselect(fd + 1, &fds, NULL, NULL, &ts, &mask) == 0) continue;
 
 		int length = read(fd, buffer, EVENT_BUF_LEN);
 		if(length < 0)

--- a/Source/ui_qt/unix/GamePadInputEventListener.cpp
+++ b/Source/ui_qt/unix/GamePadInputEventListener.cpp
@@ -1,6 +1,7 @@
 #include "GamePadInputEventListener.h"
 #include <fcntl.h>
 #include <sys/select.h>
+#include <sys/time.h>
 #include <poll.h>
 #include <csignal>
 #include <cstring>
@@ -48,6 +49,9 @@ void CGamePadInputEventListener::InputDeviceListenerThread()
 
 	auto device = CGamePadUtils::GetDeviceID(dev);
 
+	struct timespec ts;
+	ts.tv_nsec = 5e+8; // 500 millisecond
+
 	fd_set fds;
 	FD_ZERO(&fds);
 	FD_SET(fd, &fds);
@@ -59,7 +63,7 @@ void CGamePadInputEventListener::InputDeviceListenerThread()
 
 	while(m_running)
 	{
-		if(pselect(fd + 1, &fds, NULL, NULL, 500, &mask) == 0) continue;
+		if(pselect(fd + 1, &fds, NULL, NULL, &ts, &mask) == 0) continue;
 
 		int rc = 0;
 		do


### PR DESCRIPTION
Muahaha a lucky break as Travis has recently added FreeBSD support (even documentation isn't up yet) 👿 BSD
few notes
- FreeBSD travis image seems to contain gcc 10, which is causing build problems, mostly due to ["Reduced header dependencies, leading to faster compilation for some code"](https://gcc.gnu.org/gcc-10/changes.html), which we will need to address eventually.
- I don't really know how the packaging system work on FreeBSD systems yet, so for now, CI will just be used to ensure no breaking changes are introduced

TODOs:
- [x] Test the changes on GhostBSD (local setup)
  - we crash when opening controller dialog, Qt 5.14 issue, caused by `QGroupBox` replacing it with `QFrame` fixes the crash (not sure if we should just drop `QGroupBox` or wait and see if its fixed upstream?)(since we're not doing releases, this is a non issue)
  -  issue has been reported already and seems to effect all OSes https://bugreports.qt.io/browse/QTBUG-82287 I think we should just wait for a fix, since `QGroupBox` and `QFrame` aren't the same, I only used it for a quick test
  - Note: GhostBSD repo seem more upto date than travis FreeBSD, because of that, travis is using older Qt which isn't effect by the issue, but we also can't build Vulkan yet since its using an older header version (so im removing 208486a)
  - Gamepad doesnt work, but it doesnt work on Firefox as well, i suspect its kernel/OS config issue, and im not familiar with FreeBSD to diagnose/fix
- [x] Test the changes on linux
- [x] Check, the status of Vulkan on FreeBSD

Side note:
it seems that clang default compiler is actually clang, not gcc.