### PR TITLE
fix pselect usage

### DIFF
--- a/Source/ui_qt/unix/GamePadDeviceListener.cpp
+++ b/Source/ui_qt/unix/GamePadDeviceListener.cpp
@@ -101,8 +101,6 @@ void CGamePadDeviceListener::InputDeviceListenerThread()
 	ts.tv_nsec = 5e+8; // 500 millisecond
 
 	fd_set fds;
-	FD_ZERO(&fds);
-	FD_SET(fd, &fds);
 
 	sigset_t mask;
 	sigemptyset(&mask);
@@ -115,6 +113,8 @@ void CGamePadDeviceListener::InputDeviceListenerThread()
 
 	while(m_running)
 	{
+		FD_ZERO(&fds);
+		FD_SET(fd, &fds);
 		if(pselect(fd + 1, &fds, NULL, NULL, &ts, &mask) == 0) continue;
 
 		int length = read(fd, buffer, EVENT_BUF_LEN);

--- a/Source/ui_qt/unix/GamePadInputEventListener.cpp
+++ b/Source/ui_qt/unix/GamePadInputEventListener.cpp
@@ -53,8 +53,6 @@ void CGamePadInputEventListener::InputDeviceListenerThread()
 	ts.tv_nsec = 5e+8; // 500 millisecond
 
 	fd_set fds;
-	FD_ZERO(&fds);
-	FD_SET(fd, &fds);
 
 	sigset_t mask;
 	sigemptyset(&mask);
@@ -63,6 +61,8 @@ void CGamePadInputEventListener::InputDeviceListenerThread()
 
 	while(m_running)
 	{
+		FD_ZERO(&fds);
+		FD_SET(fd, &fds);
 		if(pselect(fd + 1, &fds, NULL, NULL, &ts, &mask) == 0) continue;
 
 		int rc = 0;


### PR DESCRIPTION
According to the manpage:

Note well: Upon return, each of the file descriptor sets is modified in place to indicate which file descriptors are currently "ready".  Thus, if using **select() within a loop, the sets must be reinitialized** before each call. 
The implementation of the fd_set arguments as value-result arguments is a design error that is avoided in poll(2) and epoll(7).


So, I've moved the FD_ZERO and the FD_ZET into the loop itself before the `pselect` call

