### PR TITLE
Add CIFS mount support for Android clients

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
@@ -35,7 +35,7 @@ public class GameIndexer
 					continue;
 				if (StringUtils.containsIgnoreCase(line, "asec"))
 					continue;
-				if((StringUtils.containsIgnoreCase(line, "/mnt/runtime")
+				if ((StringUtils.containsIgnoreCase(line, "/mnt/runtime")
 						|| StringUtils.containsIgnoreCase(line, "/mnt/remote")) && StringUtils.containsIgnoreCase(line, "cifs"))
 					continue;
 

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
@@ -35,8 +35,8 @@ public class GameIndexer
 					continue;
 				if (StringUtils.containsIgnoreCase(line, "asec"))
 					continue;
-				if(StringUtils.containsIgnoreCase(line, "/mnt/runtime")
-						|| (StringUtils.containsIgnoreCase(line, "/mnt/remote") && StringUtils.containsIgnoreCase(line, "cifs")))
+				if((StringUtils.containsIgnoreCase(line, "/mnt/runtime")
+						|| StringUtils.containsIgnoreCase(line, "/mnt/remote")) && StringUtils.containsIgnoreCase(line, "cifs"))
 					continue;
 
 				if (line.matches(reg))

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
@@ -17,7 +17,7 @@ public class GameIndexer
 	private static HashSet<String> getExternalMounts()
 	{
 		final HashSet<String> out = new HashSet<String>();
-		String reg = "(?i).*vold.*(vfat|ntfs|exfat|fat32|ext3|ext4|fuse|sdfat).*rw.*";
+		String reg = "(?i).*(//|vold).*(vfat|ntfs|exfat|fat32|ext3|ext4|fuse|sdfat|cifs).*rw.*";
 		try
 		{
 			final java.lang.Process process = new ProcessBuilder().command("mount")
@@ -35,13 +35,16 @@ public class GameIndexer
 					continue;
 				if (StringUtils.containsIgnoreCase(line, "asec"))
 					continue;
+				if(StringUtils.containsIgnoreCase(line, "/mnt/runtime") || StringUtils.containsIgnoreCase(line, "/mnt/remote"))
+					continue;
+
 				if (line.matches(reg))
 				{
 					String[] parts = line.split(" ");
 					for (String part : parts)
 					{
 						if (part.startsWith("/"))
-							if (!StringUtils.containsIgnoreCase(part, "vold"))
+							if (!StringUtils.containsIgnoreCase(part, "vold") && !StringUtils.containsIgnoreCase(part, "//"))
 								out.add(part);
 					}
 				}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameIndexer.java
@@ -35,7 +35,8 @@ public class GameIndexer
 					continue;
 				if (StringUtils.containsIgnoreCase(line, "asec"))
 					continue;
-				if(StringUtils.containsIgnoreCase(line, "/mnt/runtime") || StringUtils.containsIgnoreCase(line, "/mnt/remote"))
+				if(StringUtils.containsIgnoreCase(line, "/mnt/runtime")
+						|| (StringUtils.containsIgnoreCase(line, "/mnt/remote") && StringUtils.containsIgnoreCase(line, "cifs")))
 					continue;
 
 				if (line.matches(reg))


### PR DESCRIPTION
This should add support to discover games that are saved on a CIFS share folder mounted to the android device(Nvidia Shields have this functionality).

My shield(32 bit not fast enough?) is not good at running this emulator so this may need more testing before merge to ensure CIFS has the speed needed to load the ROMs fast enough for the emulator.