### PR TITLE
Don't care for mode on reading files from optical media

### DIFF
--- a/Source/iop/OpticalMediaDevice.cpp
+++ b/Source/iop/OpticalMediaDevice.cpp
@@ -17,7 +17,6 @@ char COpticalMediaDevice::FixSlashes(char input)
 
 Framework::CStream* COpticalMediaDevice::GetFile(uint32 mode, const char* devicePath)
 {
-	if((mode & OPEN_FLAG_ACCMODE) != OPEN_FLAG_RDONLY) return nullptr;
 	if(!m_opticalMedia) return nullptr;
 	std::string fixedString(devicePath);
 	transform(fixedString.begin(), fixedString.end(), fixedString.begin(), &COpticalMediaDevice::FixSlashes);


### PR DESCRIPTION
Mafia tries to open a file on disc as RW, and expects it to work.

This PR allows the game to save, and thus get into gameplay. Altho there are still other issues with the game.