### PR TITLE
Fix: Windows S3 AWS BIN

### DIFF
--- a/Source/DiskUtils.cpp
+++ b/Source/DiskUtils.cpp
@@ -33,6 +33,7 @@ static Framework::CStream* CreateImageStream(const fs::path& imagePath)
 	{
 #ifdef HAS_AMAZON_S3
 		auto fullObjectPath = std::string(imagePathString.c_str() + strlen(s3ImagePathPrefix));
+		std::replace(fullObjectPath.begin(), fullObjectPath.end(), '\\', '/');
 		auto objectPathPos = fullObjectPath.find('/');
 		if(objectPathPos == std::string::npos)
 		{


### PR DESCRIPTION
 fix cue/bin path concat on windows for S3, on windows the path will look like /s3/bucket\game.bin so aws s3 can't find the game

