### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -49,17 +49,39 @@ jobs:
         export ANDROID_TOOLCHAIN_FILE=${ANDROID_NDK}/build/cmake/android.toolchain.cmake
         cd build_retro
         ./android_build.sh
-    - name: Prepare APKs for Distribution
-      if: ${{ github.event_name != 'pull_request' && matrix.build-type == 'apk' }}
+    - name: Prepare Unsigned APKs for Distribution
+      if: ${{ matrix.build-type == 'apk'}}
       run: |
+        export ANDROID_BUILD_TOOLS=$ANDROID_HOME/build-tools/29.0.3
         cp build_android/build/outputs/apk/release/Play-release-unsigned.apk .
         cp Play-release-unsigned.apk Play-release.apk
+        $ANDROID_BUILD_TOOLS/zipalign -c -v 4 Play-release-unsigned.apk
+    - name: Prepare Signed APKs for Distribution
+      if: ${{ github.event_name != 'pull_request' && matrix.build-type == 'apk'}}
+      run: |
         export ANDROID_BUILD_TOOLS=$ANDROID_HOME/build-tools/29.0.3
         $ANDROID_BUILD_TOOLS/apksigner sign --ks installer_android/deploy.keystore --ks-key-alias deploy --ks-pass env:ANDROID_KEYSTORE_PASS --key-pass env:ANDROID_KEYSTORE_PASS Play-release.apk
         $ANDROID_BUILD_TOOLS/zipalign -c -v 4 Play-release.apk
-        $ANDROID_BUILD_TOOLS/zipalign -c -v 4 Play-release-unsigned.apk
       env:
         ANDROID_KEYSTORE_PASS: ${{ secrets.ANDROID_KEYSTORE_PASS }}
+    - name: Upload a Build Artifact Android APK Signed
+      if: ${{ github.event_name != 'pull_request' && matrix.build-type == 'apk'}}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Play_Android_Signed
+        path: Play-release.apk
+    - name: Upload a Build Artifact Android APK Unsigned
+      if: ${{ matrix.build-type == 'apk' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Play_Android_APK_Unsigned
+        path: Play-release-unsigned.apk
+    - name: Upload a Build Artifact Android libretro
+      if: ${{ matrix.build-type == 'libretro' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: Play_Android_libretro
+        path: build_retro/play_libretro_*_android.so
     - name: Upload APKs to S3
       if: ${{ github.event_name != 'pull_request' && matrix.build-type == 'apk' }}
       run: |

--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -57,7 +57,7 @@ jobs:
         cp Play-release-unsigned.apk Play-release.apk
         $ANDROID_BUILD_TOOLS/zipalign -c -v 4 Play-release-unsigned.apk
     - name: Prepare Signed APKs for Distribution
-      if: ${{ github.event_name != 'pull_request' && matrix.build-type == 'apk'}}
+      if: ${{ matrix.build-type == 'apk'  && env.ANDROID_KEYSTORE_PASS != null}}
       run: |
         export ANDROID_BUILD_TOOLS=$ANDROID_HOME/build-tools/29.0.3
         $ANDROID_BUILD_TOOLS/apksigner sign --ks installer_android/deploy.keystore --ks-key-alias deploy --ks-pass env:ANDROID_KEYSTORE_PASS --key-pass env:ANDROID_KEYSTORE_PASS Play-release.apk
@@ -65,7 +65,7 @@ jobs:
       env:
         ANDROID_KEYSTORE_PASS: ${{ secrets.ANDROID_KEYSTORE_PASS }}
     - name: Upload a Build Artifact Android APK Signed
-      if: ${{ github.event_name != 'pull_request' && matrix.build-type == 'apk'}}
+      if: ${{ matrix.build-type == 'apk' && env.AWS_ACCESS_KEY_ID != null}}
       uses: actions/upload-artifact@v2
       with:
         name: Play_Android_Signed
@@ -83,7 +83,7 @@ jobs:
         name: Play_Android_libretro
         path: build_retro/play_libretro_*_android.so
     - name: Upload APKs to S3
-      if: ${{ github.event_name != 'pull_request' && matrix.build-type == 'apk' }}
+      if: ${{ matrix.build-type == 'apk' && env.AWS_ACCESS_KEY_ID != null}}
       run: |
         aws s3 cp Play-release.apk s3://playbuilds/$SHORT_HASH/Play-release.apk --acl public-read
         aws s3 cp Play-release-unsigned.apk s3://playbuilds/$SHORT_HASH/Play-release-unsigned.apk --acl public-read
@@ -93,7 +93,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: 'us-east-2'
     - name: Upload libretro Core to S3
-      if: ${{ github.event_name != 'pull_request' && matrix.build-type == 'libretro' }}
+      if: ${{ matrix.build-type == 'libretro' && env.AWS_ACCESS_KEY_ID != null}}
       run: |
         ABI_LIST="arm64-v8a armeabi-v7a x86 x86_64"
         for ABI in $ABI_LIST

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -36,6 +36,19 @@ jobs:
       run: |
         cd installer_ios
         ./build_cydia.sh
+    - name: Upload a Build Artifact ipa/deb/bz2
+      uses: actions/upload-artifact@v2
+      with:
+        name: Play_iOS
+        path: |
+          installer_ios/Play.ipa
+          installer_ios/Play.deb
+          installer_ios/Packages.bz2
+    - name: Upload a Build Artifact libretro
+      uses: actions/upload-artifact@v2
+      with:
+        name: Play_iOS_libretro
+        path: build/Source/ui_libretro/Release-iphoneos/play_libretro_ios.dylib
     - name: Upload to S3
       if: ${{ github.event_name != 'pull_request'}}
       run: |

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -50,7 +50,7 @@ jobs:
         name: Play_iOS_libretro
         path: build/Source/ui_libretro/Release-iphoneos/play_libretro_ios.dylib
     - name: Upload to S3
-      if: ${{ github.event_name != 'pull_request'}}
+      if: ${{ env.AWS_ACCESS_KEY_ID != null}}
       run: |
         aws s3 cp installer_ios/Play.ipa s3://playbuilds/$SHORT_HASH/Play.ipa --acl public-read
         aws s3 cp installer_ios/Play.deb s3://playbuilds/$SHORT_HASH/Play.deb --acl public-read

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -70,6 +70,18 @@ jobs:
         ${DEPLOYQT_PATH}/linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -unsupported-allow-new-glibc
       env:
         VERSION: ${{ steps.short_hash.outputs.VALUE }}
+    - name: Upload a Build Artifact x86_64 AppImage
+      uses: actions/upload-artifact@v2
+      with:
+        name: Play_Linux_x86_64_AppImage
+        path: build/Play!-${{ env.SHORT_HASH }}-x86_64.AppImage
+      env:
+        SHORT_HASH: ${{ steps.short_hash.outputs.VALUE }}
+    - name: Upload a Build Artifact x86_64 Libretro
+      uses: actions/upload-artifact@v2
+      with:
+        name: Play_Linux_x86_64_libretro
+        path: build/Source/ui_libretro/play_libretro.so
     - name: Upload to S3
       if: ${{ github.event_name != 'pull_request'}}
       run: |

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -83,7 +83,7 @@ jobs:
         name: Play_Linux_x86_64_libretro
         path: build/Source/ui_libretro/play_libretro.so
     - name: Upload to S3
-      if: ${{ github.event_name != 'pull_request'}}
+      if: ${{ env.AWS_ACCESS_KEY_ID != null}}
       run: |
         aws s3 cp build/Play!-$SHORT_HASH-x86_64.AppImage s3://playbuilds/$SHORT_HASH/Play!-$SHORT_HASH-x86_64.AppImage --acl public-read
         aws s3 cp build/Source/ui_libretro/play_libretro.so s3://playbuilds/$SHORT_HASH/play_libretro_linux-x86_64.so --acl public-read

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -64,6 +64,16 @@ jobs:
       run: |
         cd build
         appdmg ../installer_macos/spec.json Play.dmg
+    - name: Upload a Build Artifact dmg
+      uses: actions/upload-artifact@v2
+      with:
+        name: Play_MacOS_dmg
+        path: build/Play.dmg
+    - name: Upload a Build Artifact libretro
+      uses: actions/upload-artifact@v2
+      with:
+        name: Play_MacOS_libretro
+        path: build/Source/ui_libretro/Release/play_libretro.dylib
     - name: Upload to S3
       if: ${{ github.event_name != 'pull_request'}}
       run: |

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -50,7 +50,7 @@ jobs:
         cd build
         ctest -C Release
     - name: Sign And Notarize
-      if: ${{ github.event_name != 'pull_request'}}
+      if: ${{ env.MACOS_DEVID_CERTIFICATE != null }}
       run: |
         ./.ci.macos.import_certificate.sh
         ./installer_macos/sign.sh
@@ -75,7 +75,7 @@ jobs:
         name: Play_MacOS_libretro
         path: build/Source/ui_libretro/Release/play_libretro.dylib
     - name: Upload to S3
-      if: ${{ github.event_name != 'pull_request'}}
+      if: ${{ env.AWS_ACCESS_KEY_ID != null}}
       run: |
         aws s3 cp build/Play.dmg s3://playbuilds/$SHORT_HASH/Play.dmg --acl public-read
         aws s3 cp build/Source/ui_libretro/Release/play_libretro.dylib s3://playbuilds/$SHORT_HASH/play_libretro_macOS-x86_64.dylib --acl public-read


### PR DESCRIPTION
GitHub actions fail on my fork, since it tries to upload artifcats to S3, added few checks to stop that,
I've also added action to upload to github artifacts, both useful for branches and forks.

P.S I also dont like how each job is its own workflow, because of that, each branch creates 4 different workflows, and all the artificats are inside each workflows, as oppose just 1 workflow with multiple jobs.
e.g i joined up all thwe work flows into 1, and now all the artifcats are listed under 1 workflow here https://github.com/Zer0xFF/Play-/actions and if you look at the workflow list, its 1 action for all of them https://github.com/Zer0xFF/Play-/actions/runs/421228891 with a workflow like this, you can introduce a new dependent job that you can use to automatically trigger aws update (since as you recall, when you push a change to master, if let say iOS fails, but the reset successed, then the link on the site for iOS will be dead)
e.g

```yaml
publish:
    needs: [build_linux, build_android, build_macos, build_ios]
    on:
      push:
        branches:
        - master
    runs-on: ubuntu-latest
    steps:
      - name: Trigger site update
        if: ${{ env.AWS_ACCESS_KEY_ID != null}}
        run: curl purei.org/?secret.trigger.update
    env:
        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
```

as you can tell, i already have a commit for that, though i didnt push it to this, since i suppose that falls under preference, if you'd prefer it this way, i can attach it to this, https://github.com/Zer0xFF/Play-/commit/5b27b19b4e0390987586ce4208aa1e06e88f2c2a

P.S iOS fails on m work, though i would assume thats only on my fork, since i didnt change anything related to how cmds are run.