### PR TITLE
dynamically set host/host0 path when directly executing elf

### DIFF
--- a/Source/PS2VM.cpp
+++ b/Source/PS2VM.cpp
@@ -25,6 +25,7 @@
 #include "iop/IopBios.h"
 #include "iop/ioman/HardDiskDevice.h"
 #include "iop/ioman/OpticalMediaDevice.h"
+#include "iop/ioman/PathDirectoryDevice.h"
 #include "iop/ioman/PreferenceDirectoryDevice.h"
 #include "Log.h"
 #include "ISO9660/BlockProvider.h"
@@ -753,6 +754,15 @@ void CPS2VM::RegisterModulesInPadHandler()
 	m_pad->RemoveAllListeners();
 	m_pad->InsertListener(iopOs->GetPadman());
 	m_pad->InsertListener(&m_iop->m_sio2);
+}
+
+void CPS2VM::BootFromFile(const fs::path& execPath)
+{
+	auto iopOs = dynamic_cast<CIopBios*>(m_iop->m_bios.get());
+
+	iopOs->GetIoman()->RegisterDevice("host", std::make_shared<Iop::Ioman::CPathDirectoryDevice>(execPath.parent_path()));
+	iopOs->GetIoman()->RegisterDevice("host0", std::make_shared<Iop::Ioman::CPathDirectoryDevice>(execPath.parent_path()));
+	m_ee->m_os->BootFromFile(execPath);
 }
 
 void CPS2VM::ReloadExecutable(const char* executablePath, const CPS2OS::ArgumentList& arguments)

--- a/Source/PS2VM.h
+++ b/Source/PS2VM.h
@@ -75,6 +75,7 @@ public:
 	void TriggerFrameDump(const FrameDumpCallback&);
 
 	CPU_UTILISATION_INFO GetCpuUtilisationInfo() const;
+	void BootFromFile(const fs::path&);
 
 #ifdef DEBUGGER_INCLUDED
 	std::string MakeDebugTagsPackagePath(const char*);

--- a/Source/ui_android/NativeInterop.cpp
+++ b/Source/ui_android/NativeInterop.cpp
@@ -141,7 +141,7 @@ extern "C" JNIEXPORT void JNICALL Java_com_virtualapplications_play_NativeIntero
 	ResetVirtualMachine();
 	try
 	{
-		g_virtualMachine->m_ee->m_os->BootFromFile(GetStringFromJstring(env, selectedFilePath));
+		g_virtualMachine->BootFromFile(GetStringFromJstring(env, selectedFilePath));
 	}
 	catch(const std::exception& exception)
 	{

--- a/Source/ui_ios/EmulatorViewController.mm
+++ b/Source/ui_ios/EmulatorViewController.mm
@@ -102,7 +102,7 @@ CPS2VM::ProfileFrameDoneSignal::Connection g_profileFrameDoneConnection;
 	auto bootablePath = fs::path([self.bootablePath fileSystemRepresentation]);
 	if(IsBootableExecutablePath(bootablePath))
 	{
-		g_virtualMachine->m_ee->m_os->BootFromFile(bootablePath);
+		g_virtualMachine->BootFromFile(bootablePath);
 	}
 	else
 	{

--- a/Source/ui_qt/mainwindow.cpp
+++ b/Source/ui_qt/mainwindow.cpp
@@ -374,7 +374,7 @@ void MainWindow::BootElf(fs::path filePath)
 {
 	m_virtualMachine->Pause();
 	m_virtualMachine->Reset();
-	m_virtualMachine->m_ee->m_os->BootFromFile(filePath);
+	m_virtualMachine->BootFromFile(filePath);
 #ifndef DEBUGGER_INCLUDED
 	m_virtualMachine->Resume();
 #endif


### PR DESCRIPTION
homebrews expects host to be set to the location of the elf file, as some include other modules that requires loading (e.g https://github.com/jpd002/Play-Compatibility/issues/632).

related #1001 (radshell can progress further, aka no error msg, but still doesnt fully boot)


notes: uLaunchElf (newer version is called wLaunchELF) can launch other elf which will also cause host to change again (however, launching elf doesnt work, but when it does, we'd need to make sure host is updated)