### PR TITLE
remove assertion code in release

### DIFF
--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -1802,8 +1802,7 @@ void CGSH_OpenGL::DrawToDepth(unsigned int primitiveType, uint64 primReg)
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthbuffer->m_depthBuffer);
 	CHECKGLERROR();
 
-	GLenum result = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-	assert(result == GL_FRAMEBUFFER_COMPLETE);
+	assert(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
 
 	glDepthMask(GL_TRUE);
 	glClearDepthf(0);
@@ -2374,8 +2373,7 @@ CGSH_OpenGL::CFramebuffer::CFramebuffer(uint32 basePtr, uint32 width, uint32 hei
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0);
 		CHECKGLERROR();
 
-		auto status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-		assert(status == GL_FRAMEBUFFER_COMPLETE);
+		assert(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
 	}
 
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -976,8 +976,7 @@ void CGSH_OpenGL::SetupFramebuffer(uint64 frameReg, uint64 zbufReg, uint64 sciss
 	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthbuffer->m_depthBuffer);
 	CHECKGLERROR();
 
-	GLenum result = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-	assert(result == GL_FRAMEBUFFER_COMPLETE);
+	assert(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
 
 	m_renderState.framebufferHandle = framebuffer->m_framebuffer;
 	m_validGlState |= GLSTATE_FRAMEBUFFER; //glBindFramebuffer used to set just above


### PR DESCRIPTION
glCheckFramebufferStatus is called in release when the result is only used for an assertion.
Moving this into the assertion gives a noticeable speed increase.

In Baldurs Gate Dark Alliance, on the bartender dialog scene (first dialog of the game) this give an FPS increase from 40fps to 53 fps on my machine.

