### PR TITLE
correctly use initialisation flag

### DIFF
--- a/Source/gs/GsPixelFormats.h
+++ b/Source/gs/GsPixelFormats.h
@@ -424,6 +424,8 @@ inline void CGsPixelFormats::CPixelIndexor<CGsPixelFormats::STORAGEPSMT4>::SetPi
 template <>
 inline void CGsPixelFormats::CPixelIndexor<CGsPixelFormats::STORAGEPSMT4>::BuildPageOffsetTable()
 {
+	if(m_pageOffsetsInitialized) return;
+
 	typedef STORAGEPSMT4 Storage;
 
 	for(uint32 y = 0; y < Storage::PAGEHEIGHT; y++)
@@ -458,11 +460,14 @@ inline void CGsPixelFormats::CPixelIndexor<CGsPixelFormats::STORAGEPSMT4>::Build
 			m_pageOffsets[y][x] = offset;
 		}
 	}
+	m_pageOffsetsInitialized = true;
 }
 
 template <>
 inline void CGsPixelFormats::CPixelIndexor<CGsPixelFormats::STORAGEPSMT8>::BuildPageOffsetTable()
 {
+	if(m_pageOffsetsInitialized) return;
+
 	typedef CGsPixelFormats::STORAGEPSMT8 Storage;
 
 	for(uint32 y = 0; y < Storage::PAGEHEIGHT; y++)
@@ -493,4 +498,5 @@ inline void CGsPixelFormats::CPixelIndexor<CGsPixelFormats::STORAGEPSMT8>::Build
 			m_pageOffsets[y][x] = offset;
 		}
 	}
+	m_pageOffsetsInitialized = true;
 }


### PR DESCRIPTION
The m_pageOffsetsInitialized flag is not used in the 2 template specialisation functions for 4 and 8bpp. That makes constructing the PixelIndexer object expensive.
The speedup is modest but worthwhile .. approx 10% in my testing 40fps -> 44fps in my Baldurs Gate test scene.