### PR TITLE
Set correct defaults for SMODE, DISPLAY 1 and 2.

### DIFF
--- a/Source/gs/GSHandler.cpp
+++ b/Source/gs/GSHandler.cpp
@@ -147,15 +147,15 @@ void CGSHandler::ResetBase()
 	memset(m_pRAM, 0, RAMSIZE);
 	memset(m_pCLUT, 0, CLUTSIZE);
 	m_nPMODE = 0;
-	m_nSMODE2 = 0;
+	m_nSMODE2 = 0x3; // Interlacing with fullframe
 	m_nDISPFB1.heldValue = 0;
 	m_nDISPFB1.value.q = 0;
 	m_nDISPLAY1.heldValue = 0;
-	m_nDISPLAY1.value.q = 0;
+	m_nDISPLAY1.value.q = 0x1BF9FF72617467;
 	m_nDISPFB2.heldValue = 0;
 	m_nDISPFB2.value.q = 0;
 	m_nDISPLAY2.heldValue = 0;
-	m_nDISPLAY2.value.q = 0;
+	m_nDISPLAY2.value.q = 0x1BF9FF72617467;
 	m_nCSR = CSR_FIFO_EMPTY | (GS_REVISION << 16);
 	m_nIMR = ~0;
 	m_nBUSDIR = 0;


### PR DESCRIPTION
Fixes the ["PS2 Coding is good for you" Homebrew Demo](http://www.pouet.net/prod.php?which=32469).

Turns out, the game never sets any of the 3 mentioned registers, and assumes them to be set correctly. My guess is, that this happens via the BIOS on console, either implicitly (not getting reset) or explicitly (based on PAL/NTSC of game, etc.).

The values are calculated via [GsSetDefaultDisplayEnv from ps2sdk](https://github.com/ps2dev/ps2sdk/blob/3c4e3ef0df01c49bdb4620c32d3496eeab5f7f81/ee/libgs/src/draw.c#L74), and is correct for NTSC, interlacing and fullframe.