### PR TITLE
Fix some issues pointed out by running Play Vulkan validation layers …

### DIFF
--- a/Source/gs/GSH_Vulkan/GSH_VulkanDraw.cpp
+++ b/Source/gs/GSH_Vulkan/GSH_VulkanDraw.cpp
@@ -463,7 +463,7 @@ void CDraw::CreateRenderPass()
 	subpassDependency.dstSubpass = 0;
 	subpassDependency.dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 	subpassDependency.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-	subpassDependency.dependencyFlags=VK_DEPENDENCY_BY_REGION_BIT;
+	subpassDependency.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
 
 	auto renderPassCreateInfo = Framework::Vulkan::RenderPassCreateInfo();
 	renderPassCreateInfo.subpassCount = 1;

--- a/Source/gs/GSH_Vulkan/GSH_VulkanDraw.cpp
+++ b/Source/gs/GSH_Vulkan/GSH_VulkanDraw.cpp
@@ -252,7 +252,7 @@ void CDraw::FlushVertices()
 		memoryBarrier.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
 
 		m_context->device.vkCmdPipelineBarrier(commandBuffer, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-		                                       0, 1, &memoryBarrier, 0, nullptr, 0, nullptr);
+		                                       VK_DEPENDENCY_BY_REGION_BIT, 1, &memoryBarrier, 0, nullptr, 0, nullptr);
 	}
 
 	auto descriptorSetCaps = make_convertible<DESCRIPTORSET_CAPS>(0);
@@ -463,6 +463,7 @@ void CDraw::CreateRenderPass()
 	subpassDependency.dstSubpass = 0;
 	subpassDependency.dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 	subpassDependency.dstAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+	subpassDependency.dependencyFlags=VK_DEPENDENCY_BY_REGION_BIT;
 
 	auto renderPassCreateInfo = Framework::Vulkan::RenderPassCreateInfo();
 	renderPassCreateInfo.subpassCount = 1;


### PR DESCRIPTION
Aims to fix 

> VUID-VkSubpassDependency-srcSubpass-02243(ERROR / SPEC): msgNum: -435164832 - Validation Error: [ VUID-VkSubpassDependency-srcSubpass-02243 ] Object 0: handle = 0x7f3cc45e73d8, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0xe60fe960 | Dependency 0 specifies a self-dependency for subpass 0 with both stages including a framebuffer-space stage, but does not specify VK_DEPENDENCY_BY_REGION_BIT in dependencyFlags. The Vulkan spec states: If srcSubpass equals dstSubpass, and srcStageMask and dstStageMask both include a framebuffer-space stage, then dependencyFlags must include VK_DEPENDENCY_BY_REGION_BIT (https://vulkan.lunarg.com/doc/view/1.2.162.1~rc2/linux/1.2-extensions/vkspec.html#VUID-VkSubpassDependency-srcSubpass-02243)

> VUID-vkCmdPipelineBarrier-pDependencies-02285(ERROR / SPEC): msgNum: 959888396 - Validation Error: [ VUID-vkCmdPipelineBarrier-pDependencies-02285 ] Object 0: handle = 0x2d000000002d, type = VK_OBJECT_TYPE_RENDER_PASS; | MessageID = 0x3936bc0c | vkCmdPipelineBarrier(): dependencyFlags param (0x0) does not equal VkSubpassDependency dependencyFlags value for any self-dependency of subpass 0 of VkRenderPass 0x2d000000002d[]. Candidate VkSubpassDependency are pDependencies entries [0]. The Vulkan spec states: If fname:vkCmdPipelineBarrier is called within a render pass instance, the render pass must have been created with at least one VkSubpassDependency instance in VkRenderPassCreateInfo::pDependencies that expresses a dependency from the current subpass to itself, with synchronization scopes and access scopes that are all supersets of the scopes defined in this command (https://vulkan.lunarg.com/doc/view/1.2.162.1~rc2/linux/1.2-extensions/vkspec.html#VUID-vkCmdPipelineBarrier-pDependencies-02285)

Not sure if it can fix anything graphically however it seems it can affect ARM - https://stackoverflow.com/questions/65471677/the-meaning-and-implications-of-vk-dependency-by-region-bit