### PR TITLE
Partially implement TEST_1/2 AFAIL on mobile via framebuffer fetch

### DIFF
--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.cpp
@@ -1125,6 +1125,7 @@ void CGSH_OpenGL::FillShaderCapsFromTest(SHADERCAPS& shaderCaps, const uint64& t
 		{
 			shaderCaps.hasAlphaTest = m_alphaTestingEnabled ? 1 : 0;
 			shaderCaps.alphaTestMethod = test.nAlphaMethod;
+			shaderCaps.alphaFailMethod = test.nAlphaFail;
 		}
 	}
 	else

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL.h
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL.h
@@ -88,7 +88,8 @@ private:
 		unsigned int hasDestAlphaTest : 1;
 		unsigned int destAlphaTestRef : 1;
 		unsigned int colorOutputWhite : 1;
-		unsigned int padding : 10;
+		unsigned int alphaFailMethod : 2;
+		unsigned int padding : 8;
 
 		bool isIndexedTextureSource() const
 		{
@@ -316,7 +317,7 @@ private:
 	Framework::OpenGl::CShader GenerateVertexShader(const SHADERCAPS&);
 	Framework::OpenGl::CShader GenerateFragmentShader(const SHADERCAPS&);
 	std::string GenerateTexCoordClampingSection(TEXTURE_CLAMP_MODE, const char*);
-	std::string GenerateAlphaTestSection(ALPHA_TEST_METHOD);
+	std::string GenerateAlphaTestSection(ALPHA_TEST_METHOD, ALPHA_TEST_FAIL_METHOD);
 
 	Framework::OpenGl::ProgramPtr GeneratePresentProgram();
 	Framework::OpenGl::CBuffer GeneratePresentVertexBuffer();

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL_Shader.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL_Shader.cpp
@@ -138,7 +138,7 @@ Framework::OpenGl::CShader CGSH_OpenGL::GenerateFragmentShader(const SHADERCAPS&
 	std::stringstream shaderBuilder;
 
 	bool writeDestAlphaTest = caps.hasDestAlphaTest && m_hasFramebufferFetchExtension;
-	bool useFramebufferFetch = (caps.hasDestAlphaTest || (caps.hasAlphaTest && caps.alphaFailMethod != ALPHA_TEST_FAIL_KEEP)) && m_hasFramebufferFetchExtension;
+	bool useFramebufferFetch = (caps.hasDestAlphaTest || caps.hasAlphaTest) && m_hasFramebufferFetchExtension;
 
 	shaderBuilder << GLSL_VERSION << std::endl;
 

--- a/Source/gs/GSH_OpenGL/GSH_OpenGL_Shader.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL_Shader.cpp
@@ -138,7 +138,7 @@ Framework::OpenGl::CShader CGSH_OpenGL::GenerateFragmentShader(const SHADERCAPS&
 	std::stringstream shaderBuilder;
 
 	bool writeDestAlphaTest = caps.hasDestAlphaTest && m_hasFramebufferFetchExtension;
-	bool useFramebufferFetch = writeDestAlphaTest;
+	bool useFramebufferFetch = (caps.hasDestAlphaTest || (caps.hasAlphaTest && caps.alphaFailMethod != ALPHA_TEST_FAIL_KEEP)) && m_hasFramebufferFetchExtension;
 
 	shaderBuilder << GLSL_VERSION << std::endl;
 
@@ -346,35 +346,54 @@ Framework::OpenGl::CShader CGSH_OpenGL::GenerateFragmentShader(const SHADERCAPS&
 		shaderBuilder << "	textureColor = v_color;" << std::endl;
 	}
 
+	shaderBuilder << "	bool outputColor = true;" << std::endl;
+	shaderBuilder << "	bool outputAlpha = true;" << std::endl;
+
 	if(caps.hasAlphaTest)
 	{
-		shaderBuilder << GenerateAlphaTestSection(static_cast<ALPHA_TEST_METHOD>(caps.alphaTestMethod));
+		shaderBuilder << GenerateAlphaTestSection(static_cast<ALPHA_TEST_METHOD>(caps.alphaTestMethod), static_cast<ALPHA_TEST_FAIL_METHOD>(m_hasFramebufferFetchExtension ? caps.alphaFailMethod : ALPHA_TEST_FAIL_KEEP));
 	}
+
+	// ----------------------
+
+	shaderBuilder << "	if(outputColor) {" << std::endl;
 
 	if(caps.hasFog)
 	{
-		shaderBuilder << "	fragColor.xyz = mix(textureColor.rgb, g_fogColor, v_fog);" << std::endl;
+		shaderBuilder << "		fragColor.xyz = mix(textureColor.rgb, g_fogColor, v_fog);" << std::endl;
 	}
 	else
 	{
-		shaderBuilder << "	fragColor.xyz = textureColor.xyz;" << std::endl;
+		shaderBuilder << "		fragColor.xyz = textureColor.xyz;" << std::endl;
 	}
+
+	shaderBuilder << "	}" << std::endl;
+
+	// ----------------------
+
+	shaderBuilder << "	if(outputAlpha) {" << std::endl;
 
 	//For proper alpha blending, alpha has to be multiplied by 2 (0x80 -> 1.0)
 #ifdef USE_DUALSOURCE_BLENDING
-	shaderBuilder << "	fragColor.a = textureColor.a;" << std::endl;
-	shaderBuilder << "	blendColor.a = clamp(textureColor.a * 2.0, 0.0, 1.0);" << std::endl;
+	shaderBuilder << "		fragColor.a = textureColor.a;" << std::endl;
+	shaderBuilder << "		blendColor.a = clamp(textureColor.a * 2.0, 0.0, 1.0);" << std::endl;
 #else
 	//This has the side effect of not writing a proper value in the framebuffer (should write alpha "as is")
-	shaderBuilder << "	fragColor.a = clamp(textureColor.a * 2.0, 0.0, 1.0);" << std::endl;
+	shaderBuilder << "		fragColor.a = clamp(textureColor.a * 2.0, 0.0, 1.0);" << std::endl;
 #endif
+
+	shaderBuilder << "	}" << std::endl;
 
 	if(caps.colorOutputWhite)
 	{
 		shaderBuilder << "	fragColor.xyz = vec3(1, 1, 1);" << std::endl;
 	}
 
+	// ----------------------
+
 	shaderBuilder << "	gl_FragDepth = v_depth;" << std::endl;
+
+	// ----------------------
 
 	shaderBuilder << "}" << std::endl;
 
@@ -418,7 +437,7 @@ std::string CGSH_OpenGL::GenerateTexCoordClampingSection(TEXTURE_CLAMP_MODE clam
 	return shaderSource;
 }
 
-std::string CGSH_OpenGL::GenerateAlphaTestSection(ALPHA_TEST_METHOD testMethod)
+std::string CGSH_OpenGL::GenerateAlphaTestSection(ALPHA_TEST_METHOD testMethod, ALPHA_TEST_FAIL_METHOD failMethod)
 {
 	std::stringstream shaderBuilder;
 
@@ -459,7 +478,31 @@ std::string CGSH_OpenGL::GenerateAlphaTestSection(ALPHA_TEST_METHOD testMethod)
 	shaderBuilder << "uint textureColorAlphaInt = uint(textureColor.a * 255.0);" << std::endl;
 	shaderBuilder << test << std::endl;
 	shaderBuilder << "{" << std::endl;
-	shaderBuilder << "	discard;" << std::endl;
+
+	switch(failMethod)
+	{
+	case ALPHA_TEST_FAIL_KEEP:
+		// No write at all
+		shaderBuilder << "	discard;" << std::endl;
+		break;
+	case ALPHA_TEST_FAIL_FBONLY:
+		// Only write color and alpha
+		// TODO: We cannot prevent depth from being written at the moment
+		assert(0);
+		break;
+	case ALPHA_TEST_FAIL_ZBONLY:
+		// Only write depth
+		shaderBuilder << "	outputColor = false;" << std::endl;
+		shaderBuilder << "	outputAlpha = false;" << std::endl;
+		break;
+	case ALPHA_TEST_FAIL_RGBONLY:
+		// Only write color
+		shaderBuilder << "	outputAlpha = false;" << std::endl;
+		// TODO: We cannot prevent depth from being written at the moment
+		assert(0);
+		break;
+	}
+
 	shaderBuilder << "}" << std::endl;
 
 	std::string shaderSource = shaderBuilder.str();


### PR DESCRIPTION
When a alpha test fail method is set, and the trivial cases cannot be handled via color mask, we need to handle it in shader code.

TODO: This implementation based on framebuffer fetch, and thus only works on mobile. Also, this does not correctly handle cases where no depth should be written to the framebuffer.