### PR TITLE
Make AFAIL a bit more lenient on desktop

### DIFF
--- a/Source/gs/GSH_OpenGL/GSH_OpenGL_Shader.cpp
+++ b/Source/gs/GSH_OpenGL/GSH_OpenGL_Shader.cpp
@@ -346,8 +346,11 @@ Framework::OpenGl::CShader CGSH_OpenGL::GenerateFragmentShader(const SHADERCAPS&
 		shaderBuilder << "	textureColor = v_color;" << std::endl;
 	}
 
-	shaderBuilder << "	bool outputColor = true;" << std::endl;
-	shaderBuilder << "	bool outputAlpha = true;" << std::endl;
+	if(useFramebufferFetch)
+	{
+		shaderBuilder << "	bool outputColor = true;" << std::endl;
+		shaderBuilder << "	bool outputAlpha = true;" << std::endl;
+	}
 
 	if(caps.hasAlphaTest)
 	{
@@ -356,33 +359,52 @@ Framework::OpenGl::CShader CGSH_OpenGL::GenerateFragmentShader(const SHADERCAPS&
 
 	// ----------------------
 
-	shaderBuilder << "	if(outputColor) {" << std::endl;
+	if(useFramebufferFetch)
+	{
+		shaderBuilder << "	if(outputColor) {" << std::endl
+		              << "	";
+	}
 
 	if(caps.hasFog)
 	{
-		shaderBuilder << "		fragColor.xyz = mix(textureColor.rgb, g_fogColor, v_fog);" << std::endl;
+		shaderBuilder << "	fragColor.xyz = mix(textureColor.rgb, g_fogColor, v_fog);" << std::endl;
 	}
 	else
 	{
-		shaderBuilder << "		fragColor.xyz = textureColor.xyz;" << std::endl;
+		shaderBuilder << "	fragColor.xyz = textureColor.xyz;" << std::endl;
 	}
 
-	shaderBuilder << "	}" << std::endl;
+	if(useFramebufferFetch)
+	{
+		shaderBuilder << "	}" << std::endl;
+	}
 
 	// ----------------------
 
-	shaderBuilder << "	if(outputAlpha) {" << std::endl;
+	if(useFramebufferFetch)
+	{
+		shaderBuilder << "	if(outputAlpha) {" << std::endl
+		              << "	";
+	}
 
 	//For proper alpha blending, alpha has to be multiplied by 2 (0x80 -> 1.0)
 #ifdef USE_DUALSOURCE_BLENDING
-	shaderBuilder << "		fragColor.a = textureColor.a;" << std::endl;
-	shaderBuilder << "		blendColor.a = clamp(textureColor.a * 2.0, 0.0, 1.0);" << std::endl;
+	shaderBuilder << "	fragColor.a = textureColor.a;" << std::endl;
+	if(useFramebufferFetch)
+	{
+		// format shader nicely
+		shaderBuilder << "	";
+	}
+	shaderBuilder << "	blendColor.a = clamp(textureColor.a * 2.0, 0.0, 1.0);" << std::endl;
 #else
 	//This has the side effect of not writing a proper value in the framebuffer (should write alpha "as is")
-	shaderBuilder << "		fragColor.a = clamp(textureColor.a * 2.0, 0.0, 1.0);" << std::endl;
+	shaderBuilder << "	fragColor.a = clamp(textureColor.a * 2.0, 0.0, 1.0);" << std::endl;
 #endif
 
-	shaderBuilder << "	}" << std::endl;
+	if(useFramebufferFetch)
+	{
+		shaderBuilder << "	}" << std::endl;
+	}
 
 	if(caps.colorOutputWhite)
 	{


### PR DESCRIPTION
Currently, on master, we have two scenarios:

Firstly, if we can use the framebuffer fetch extension, alpha test fail is implemented mostly correctly (cases which should prevent writing depth are not handled correctly). If we don't have access to the extension, we discard the write on test failure completely.

This PR tackles the second case. Specifically `ALPHA_TEST_FAIL_FBONLY` (only write color and alpha, but no depth). This change allows the pixel to be written with color, alpha and depth in full. While this is not correct (it should not write depth), this is better than discarding the pixel write completely, and actually fixes quite some games (I will add screenshots later). `ALPHA_TEST_FAIL_RGBONLY` is basically the same thing (writing all three components), when it should only write color.

This also contains a minor shader cleanup, where shader code for conditional color and alpha writing (via framebuffer fetch extension) is only added to the shader if the extension is available.
