### PR TITLE
Fixes for Darkwatch

### DIFF
--- a/Source/ee/PS2OS.cpp
+++ b/Source/ee/PS2OS.cpp
@@ -492,6 +492,7 @@ void CPS2OS::LoadExecutableInternal()
 	}
 
 	m_ee.m_State.nPC = header.nEntryPoint;
+	m_ee.m_State.nGPR[CMIPS::A0].nV[0] = header.nEntryPoint;
 
 #ifdef DEBUGGER_INCLUDED
 	std::pair<uint32, uint32> executableRange = GetExecutableRange();


### PR DESCRIPTION
Includes two fixes:

- Adjustment for `CIopBios::TryGetImageVersionFromPath` to be case insensitive, as the game calls it with `rom0:UDNL host0:ioprp300.img` - note the lowercase
- ~Basic re-mapping in `Ioman::PreOpen` to try to find files in cdrom0, if they cannot be found in host0. The game expects to find its data files in host0.~
- Upon loading the executable, A0 is set to the entrypoint address. The game relies on this (undefined behavior).