### PR TITLE
[Android] Preference and theming improvements

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/Constants.java
+++ b/Source/ui_android/java/com/virtualapplications/play/Constants.java
@@ -10,9 +10,6 @@ public class Constants
 	 */
 	public static final String PREF_EMU_GENERAL_SHOWFPS = "ui.showfps";
 	public static final String PREF_EMU_GENERAL_SHOWVIRTUALPAD = "ui.showvirtualpad";
-	public static final String PREF_EMU_VIDEO_RESFACTOR = "renderer.opengl.resfactor";
-	public static final String PREF_EMU_VIDEO_PRESENTATIONMODE = "renderer.presentationmode";
-	public static final String PREF_EMU_AUDIO_BUFFERSIZE = "audio.spublockcount";
 
 	public static final String PREF_UI_CATEGORY_STORAGE = "ui.storage";
 	public static final String PREF_UI_RESCAN = "ui.rescan";

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
@@ -6,6 +6,7 @@ import android.view.MenuItem;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.app.ActivityCompat;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
 
@@ -30,12 +31,20 @@ public class SettingsActivity extends AppCompatActivity
 		setSupportActionBar(toolbar);
 		toolbar.setNavigationOnClickListener(v -> onBackPressed());
 
+		setDefaultValues(R.xml.preferences_emu);
+		setDefaultValues(R.xml.preferences_ui);
+
 		if(savedInstanceState == null)
 		{
 			getSupportFragmentManager().beginTransaction()
 					.replace(R.id.settings_fragment_holder, new MainSettingsFragment())
 					.commit();
 		}
+	}
+
+	private void setDefaultValues(final int resId)
+	{
+		PreferenceManager.setDefaultValues(this, resId, true);
 	}
 
 	@Override
@@ -78,6 +87,7 @@ public class SettingsActivity extends AppCompatActivity
 		if(key.equals(PREF_UI_THEME_SELECTION))
 		{
 			ThemeManager.applyTheme(this, toolbar);
+			ActivityCompat.recreate(this);
 		}
 	}
 

--- a/Source/ui_android/java/com/virtualapplications/play/settings/EmulatorSettingsFragment.java
+++ b/Source/ui_android/java/com/virtualapplications/play/settings/EmulatorSettingsFragment.java
@@ -11,10 +11,6 @@ import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceGroup;
 import androidx.preference.SwitchPreferenceCompat;
 
-import static com.virtualapplications.play.Constants.PREF_EMU_AUDIO_BUFFERSIZE;
-import static com.virtualapplications.play.Constants.PREF_EMU_VIDEO_PRESENTATIONMODE;
-import static com.virtualapplications.play.Constants.PREF_EMU_VIDEO_RESFACTOR;
-
 public class EmulatorSettingsFragment extends PreferenceFragmentCompat
 {
 	@Override
@@ -22,31 +18,6 @@ public class EmulatorSettingsFragment extends PreferenceFragmentCompat
 	{
 		addPreferencesFromResource(R.xml.preferences_emu);
 		writeToPreferences(getPreferenceScreen());
-
-		final ListPreference resFactorPref = findPreference(PREF_EMU_VIDEO_RESFACTOR);
-		resFactorPref.setOnPreferenceChangeListener((preference, value) -> {
-			final String stringValue = value.toString();
-			final ListPreference listBoxPref = (ListPreference)preference;
-			listBoxPref.setSummary(stringValue + "x");
-			return true;
-		});
-		resFactorPref.setSummary(resFactorPref.getEntry());
-
-		final ListPreference presentationModePref = findPreference(PREF_EMU_VIDEO_PRESENTATIONMODE);
-		presentationModePref.setOnPreferenceChangeListener((preference, value) -> {
-			final int index = Integer.parseInt(value.toString());
-			final ListPreference listBoxPref = (ListPreference)preference;
-			listBoxPref.setSummary(listBoxPref.getEntries()[index]);
-			return true;
-		});
-		presentationModePref.setSummary(presentationModePref.getEntry());
-
-		final ListPreference bufferSizePref = findPreference(PREF_EMU_AUDIO_BUFFERSIZE);
-		bufferSizePref.setOnPreferenceChangeListener((preference, value) -> {
-			preference.setSummary(value.toString());
-			return true;
-		});
-		bufferSizePref.setSummary(bufferSizePref.getEntry());
 	}
 
 	@Override
@@ -63,8 +34,8 @@ public class EmulatorSettingsFragment extends PreferenceFragmentCompat
 			final Preference pref = prefGroup.getPreference(i);
 			if(pref instanceof SwitchPreferenceCompat)
 			{
-				final SwitchPreferenceCompat checkBoxPref = (SwitchPreferenceCompat)pref;
-				SettingsManager.setPreferenceBoolean(checkBoxPref.getKey(), checkBoxPref.isChecked());
+				final SwitchPreferenceCompat switchPref = (SwitchPreferenceCompat)pref;
+				SettingsManager.setPreferenceBoolean(switchPref.getKey(), switchPref.isChecked());
 			}
 			else if(pref instanceof ListPreference)
 			{
@@ -86,8 +57,8 @@ public class EmulatorSettingsFragment extends PreferenceFragmentCompat
 			final Preference pref = prefGroup.getPreference(i);
 			if(pref instanceof SwitchPreferenceCompat)
 			{
-				final SwitchPreferenceCompat checkBoxPref = (SwitchPreferenceCompat)pref;
-				checkBoxPref.setChecked(SettingsManager.getPreferenceBoolean(checkBoxPref.getKey()));
+				final SwitchPreferenceCompat switchPref = (SwitchPreferenceCompat)pref;
+				switchPref.setChecked(SettingsManager.getPreferenceBoolean(switchPref.getKey()));
 			}
 			else if(pref instanceof ListPreference)
 			{

--- a/Source/ui_android/java/com/virtualapplications/play/settings/UISettingsFragment.java
+++ b/Source/ui_android/java/com/virtualapplications/play/settings/UISettingsFragment.java
@@ -8,7 +8,6 @@ import com.virtualapplications.play.R;
 
 import java.io.File;
 
-import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
@@ -18,7 +17,6 @@ import static com.virtualapplications.play.Constants.PREF_UI_CATEGORY_STORAGE;
 import static com.virtualapplications.play.Constants.PREF_UI_CLEAR_CACHE;
 import static com.virtualapplications.play.Constants.PREF_UI_CLEAR_UNAVAILABLE;
 import static com.virtualapplications.play.Constants.PREF_UI_RESCAN;
-import static com.virtualapplications.play.Constants.PREF_UI_THEME_SELECTION;
 
 public class UISettingsFragment extends PreferenceFragmentCompat
 		implements Preference.OnPreferenceClickListener
@@ -31,16 +29,6 @@ public class UISettingsFragment extends PreferenceFragmentCompat
 		findPreference(PREF_UI_RESCAN).setOnPreferenceClickListener(this);
 		findPreference(PREF_UI_CLEAR_UNAVAILABLE).setOnPreferenceClickListener(this);
 		findPreference(PREF_UI_CLEAR_CACHE).setOnPreferenceClickListener(this);
-
-		final ListPreference themeSelectionPref = findPreference(PREF_UI_THEME_SELECTION);
-		themeSelectionPref.setOnPreferenceChangeListener((preference, value) -> {
-			final int index = Integer.parseInt(value.toString());
-			final ListPreference listBoxPref = (ListPreference)preference;
-
-			listBoxPref.setSummary(listBoxPref.getEntries()[index]);
-			return true;
-		});
-		themeSelectionPref.setSummary(themeSelectionPref.getEntry());
 	}
 
 	private void clearCoverCache()

--- a/build_android/src/main/res/values/styles.xml
+++ b/build_android/src/main/res/values/styles.xml
@@ -3,40 +3,47 @@
     <!-- colorPrimary is used for the default action bar background and to create background gradient -->
     <!-- colorPrimaryDark is used for the status bar and navigation drawer background -->
 
-    <style name="Purple" parent="Theme.AppCompat.NoActionBar">
+    <style name="BaseTheme" parent="Theme.AppCompat.NoActionBar" />
+
+    <style name="Purple" parent="BaseTheme">
         <item name="colorPrimary">#9C27B0</item>
         <item name="colorPrimaryDark">#7B1FA2</item>
+        <item name="colorAccent">#9C27B0</item>
     </style>
 
-    <style name="Pink" parent="Theme.AppCompat.NoActionBar">
+    <style name="Pink" parent="BaseTheme">
         <item name="colorPrimary">#E91E63</item>
         <item name="colorPrimaryDark">#C2185B</item>
+        <item name="colorAccent">#E91E63</item>
     </style>
 
-    <style name="Amber" parent="Theme.AppCompat.NoActionBar">
+    <style name="Amber" parent="BaseTheme">
         <item name="colorPrimary">#FFC107</item>
         <item name="colorPrimaryDark">#FFA000</item>
+        <item name="colorAccent">#FFC107</item>
     </style>
 
-
-    <style name="Blue" parent="Theme.AppCompat.NoActionBar">
+    <style name="Blue" parent="BaseTheme">
         <item name="colorPrimary">#2196f3</item>
         <item name="colorPrimaryDark">#1976d2</item>
+        <item name="colorAccent">#2196f3</item>
     </style>
 
-
-    <style name="Teal" parent="Theme.AppCompat.NoActionBar">
+    <style name="Teal" parent="BaseTheme">
         <item name="colorPrimary">#009688</item>
         <item name="colorPrimaryDark">#00796b</item>
-    </style>
-	
-	<style name="Dark_Purple" parent="Theme.AppCompat.NoActionBar">
-        <item name="colorPrimary">#673AB7</item>
-        <item name="colorPrimaryDark">#512DA8</item>
+        <item name="colorAccent">#009688</item>
     </style>
 
-    <style name="Green" parent="Theme.AppCompat.NoActionBar">
+    <style name="Dark_Purple" parent="BaseTheme">
+        <item name="colorPrimary">#673AB7</item>
+        <item name="colorPrimaryDark">#512DA8</item>
+        <item name="colorAccent">#673AB7</item>
+    </style>
+
+    <style name="Green" parent="BaseTheme">
         <item name="colorPrimary">#4CAF50</item>
         <item name="colorPrimaryDark">#388E3C</item>
+        <item name="colorAccent">#4CAF50</item>
     </style>
 </resources>

--- a/build_android/src/main/res/xml/preferences_emu.xml
+++ b/build_android/src/main/res/xml/preferences_emu.xml
@@ -24,6 +24,16 @@
         android:title="@string/pref_emu_video"
         app:iconSpaceReserved="false">
 
+        <ListPreference
+            android:defaultValue="1"
+            android:entries="@array/pref_emu_video_res_factor_entries"
+            android:entryValues="@array/pref_emu_video_res_factor_values"
+            android:key="renderer.opengl.resfactor"
+            android:negativeButtonText="@null"
+            android:positiveButtonText="@null"
+            android:title="@string/pref_emu_video_res_factor_title"
+            app:iconSpaceReserved="false" />
+
         <SwitchPreferenceCompat
             android:key="renderer.widescreen"
             android:persistent="false"
@@ -36,16 +46,6 @@
             android:persistent="false"
             android:summary="@string/pref_emu_video_force_bilinear_summary"
             android:title="@string/pref_emu_video_force_bilinear_title"
-            app:iconSpaceReserved="false" />
-
-        <ListPreference
-            android:defaultValue="1"
-            android:entries="@array/pref_emu_video_res_factor_entries"
-            android:entryValues="@array/pref_emu_video_res_factor_values"
-            android:key="renderer.opengl.resfactor"
-            android:negativeButtonText="@null"
-            android:positiveButtonText="@null"
-            android:title="@string/pref_emu_video_res_factor_title"
             app:iconSpaceReserved="false" />
 
         <ListPreference

--- a/build_android/src/main/res/xml/preferences_emu.xml
+++ b/build_android/src/main/res/xml/preferences_emu.xml
@@ -32,7 +32,8 @@
             android:negativeButtonText="@null"
             android:positiveButtonText="@null"
             android:title="@string/pref_emu_video_res_factor_title"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true" />
 
         <SwitchPreferenceCompat
             android:key="renderer.widescreen"
@@ -56,7 +57,8 @@
             android:negativeButtonText="@null"
             android:positiveButtonText="@null"
             android:title="@string/pref_emu_video_presentation_mode_title"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 
     <PreferenceCategory
@@ -78,7 +80,7 @@
             android:negativeButtonText="@null"
             android:positiveButtonText="@null"
             android:title="@string/pref_emu_audio_spublockcount_title"
-            app:iconSpaceReserved="false" />
-
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/build_android/src/main/res/xml/preferences_ui.xml
+++ b/build_android/src/main/res/xml/preferences_ui.xml
@@ -42,7 +42,7 @@
             android:negativeButtonText="@null"
             android:positiveButtonText="@null"
             android:title="@string/pref_title_theme_selection"
-            app:iconSpaceReserved="false" />
-
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
### 1st commit
- Fix preference that somehow got itself out of order during my AndroidX Preference PR

### 2nd commit
- Use the (relatively) new simple summary provider feature (introduced in [this](https://developer.android.com/jetpack/androidx/releases/preference#version_110_3) version)
- Rename old checkBox names to switch

### 3rd commit
- Make all themes use one common parent
- Create a colorAccent, which will theme stuff like dialogs and settings. This gets rid of the outdated holo blue that's still visible in several locations.
  - For the above to apply correctly to settings, the settings activity needs to be recreated with the new theme whenever it is changed. The `setDefaultValues` is for this reason:
    - The settings' default values are first set when its XML layout is inflated for the first time. So when the UI settings layout is inflated for the first time, it causes `onSharedPreferenceChanged` to trigger (its interface method notes say "Called when a shared preference is changed, added, or removed. This may be called **even if a preference is set to its existing value**"). Consequently, the screen will flash black for half a second because the activity will be recreated. However, this could likely be confusing to an end user. So what `setDefaultValues` does is initialize the preferences to be set to their default value on the setting activity's first launch (THIS DOES NOT RESET PREFERENCES; this only officially sets their values in the layout if they haven't already been set). So now, because the theme preference value has already been initialized, the screen will not flash when the user goes into the UI settings for the first time.
    - NOTE: If this isn't done, the screen will not flash on future inflations of UI settings. It is only on the first inflation. However, with `setDefaultValues` as explained above, the activity will still be recreated when the theme is changed. We use `setDefaultValues` simply so users will not confused by the flashing when they haven't actually changed the theme yet.
    - We do all this in the first place because if the activity is not recreated, certain stuff within settings (like switches) will not have been updated to reflect the new chosen theme.

Sorry that last bit was so long, hopefully it made sense lol.
