### PR TITLE
[iOS] Quality of Life Improvements: Virtual Pad transparency/auto-hide, L3/R3/Select/Start buttons for controllers

### DIFF
--- a/Source/ui_ios/Base.lproj/Main.storyboard
+++ b/Source/ui_ios/Base.lproj/Main.storyboard
@@ -173,12 +173,34 @@
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="YEL-cU-ets">
+                                        <rect key="frame" x="0.0" y="275.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="YEL-cU-ets" id="3rj-Aa-mC4">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Haptic Feedback" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="vjX-eA-S0S">
+                                                    <rect key="frame" x="8" y="11" width="247" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qfP-0v-aSk">
+                                                    <rect key="frame" x="354" y="6" width="51" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                                </switch>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Video" id="9eF-GH-FHV">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="ywd-g7-QKt">
-                                        <rect key="frame" x="0.0" y="325.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="369.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ywd-g7-QKt" id="HWx-Hq-NSE">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -207,7 +229,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="aKd-pO-wvH">
-                                        <rect key="frame" x="0.0" y="369.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="413.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="aKd-pO-wvH" id="Fvc-Vb-9Op">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -236,7 +258,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="88Y-Rs-Qwh">
-                                        <rect key="frame" x="0.0" y="413.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="457.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="88Y-Rs-Qwh" id="2Pp-XU-NUJ">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -258,7 +280,7 @@
                                         <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="43Z-1v-KCU">
-                                        <rect key="frame" x="0.0" y="457.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="501.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="43Z-1v-KCU" id="U6X-5o-YfP">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -284,7 +306,7 @@
                             <tableViewSection headerTitle="Audio" id="K0b-oh-ls1" userLabel="Audio">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="2yl-0q-ezn">
-                                        <rect key="frame" x="0.0" y="551.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="595.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2yl-0q-ezn" id="y1A-mp-vkH">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -310,7 +332,7 @@
                             <tableViewSection headerTitle="Version Information" id="d6N-kI-BBa">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="bUB-Fr-n0c">
-                                        <rect key="frame" x="0.0" y="645.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="689.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="bUB-Fr-n0c" id="VCQ-yX-pIE">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -352,6 +374,7 @@
                         <outlet property="showFpsSwitch" destination="5Wo-ch-s5J" id="Ius-gD-fIr"/>
                         <outlet property="showVirtualPadSwitch" destination="hMN-wf-jlB" id="1Sb-Wi-cwa"/>
                         <outlet property="versionInfoLabel" destination="w2T-id-DC8" id="Sk7-qJ-alx"/>
+                        <outlet property="virtualPadHapticFeedbackSwitch" destination="qfP-0v-aSk" id="6fp-ig-9BT"/>
                         <outlet property="virtualPadOpacitySlider" destination="0UW-7S-cud" id="t5c-av-qcT"/>
                     </connections>
                 </tableViewController>

--- a/Source/ui_ios/Base.lproj/Main.storyboard
+++ b/Source/ui_ios/Base.lproj/Main.storyboard
@@ -143,17 +143,11 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.10000000000000001" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="0UW-7S-cud">
-                                                    <rect key="frame" x="252" y="7" width="154" height="31"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="150" id="U76-Cw-a8S"/>
-                                                    </constraints>
+                                                <slider opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.10000000000000001" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="0UW-7S-cud">
+                                                    <rect key="frame" x="250" y="6" width="150" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                 </slider>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="0UW-7S-cud" secondAttribute="trailing" constant="10" id="IQO-DZ-Man"/>
-                                                <constraint firstItem="0UW-7S-cud" firstAttribute="centerY" secondItem="WgC-iP-76Q" secondAttribute="centerY" id="rnV-GD-piL"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
                                     </tableViewCell>
@@ -171,14 +165,11 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fu4-Lk-Wep">
-                                                    <rect key="frame" x="355" y="6.5" width="51" height="31"/>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fu4-Lk-Wep">
+                                                    <rect key="frame" x="354" y="6" width="51" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                                 </switch>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="fu4-Lk-Wep" secondAttribute="trailing" constant="10" id="3nv-9c-cOO"/>
-                                                <constraint firstItem="fu4-Lk-Wep" firstAttribute="centerY" secondItem="M7q-nh-nJU" secondAttribute="centerY" id="IPa-Dr-kqW"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
                                     </tableViewCell>

--- a/Source/ui_ios/Base.lproj/Main.storyboard
+++ b/Source/ui_ios/Base.lproj/Main.storyboard
@@ -103,8 +103,12 @@
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
                                     </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="Virtual Pad" id="Be4-8e-Pbg">
+                                <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="rOH-Uw-qJJ">
-                                        <rect key="frame" x="0.0" y="93.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="143.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rOH-Uw-qJJ" id="qXs-M0-cy0">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -125,12 +129,65 @@
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="zZz-l1-WBm">
+                                        <rect key="frame" x="0.0" y="187.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zZz-l1-WBm" id="WgC-iP-76Q">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Virtual Pad Opacity" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="Hev-dD-SoY">
+                                                    <rect key="frame" x="8" y="11" width="247" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.10000000000000001" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="0UW-7S-cud">
+                                                    <rect key="frame" x="252" y="7" width="154" height="31"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="150" id="U76-Cw-a8S"/>
+                                                    </constraints>
+                                                </slider>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="0UW-7S-cud" secondAttribute="trailing" constant="10" id="IQO-DZ-Man"/>
+                                                <constraint firstItem="0UW-7S-cud" firstAttribute="centerY" secondItem="WgC-iP-76Q" secondAttribute="centerY" id="rnV-GD-piL"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="3rU-6u-N4Z">
+                                        <rect key="frame" x="0.0" y="231.5" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3rU-6u-N4Z" id="M7q-nh-nJU">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Hide When Controller Connected" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="7xz-nH-u4O">
+                                                    <rect key="frame" x="8" y="11" width="247" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fu4-Lk-Wep">
+                                                    <rect key="frame" x="355" y="6.5" width="51" height="31"/>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="fu4-Lk-Wep" secondAttribute="trailing" constant="10" id="3nv-9c-cOO"/>
+                                                <constraint firstItem="fu4-Lk-Wep" firstAttribute="centerY" secondItem="M7q-nh-nJU" secondAttribute="centerY" id="IPa-Dr-kqW"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Video" id="9eF-GH-FHV">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="ywd-g7-QKt">
-                                        <rect key="frame" x="0.0" y="187.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="325.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ywd-g7-QKt" id="HWx-Hq-NSE">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -159,7 +216,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="aKd-pO-wvH">
-                                        <rect key="frame" x="0.0" y="231.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="369.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="aKd-pO-wvH" id="Fvc-Vb-9Op">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -188,7 +245,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="88Y-Rs-Qwh">
-                                        <rect key="frame" x="0.0" y="275.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="413.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="88Y-Rs-Qwh" id="2Pp-XU-NUJ">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -210,7 +267,7 @@
                                         <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="43Z-1v-KCU">
-                                        <rect key="frame" x="0.0" y="319.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="457.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="43Z-1v-KCU" id="U6X-5o-YfP">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -236,7 +293,7 @@
                             <tableViewSection headerTitle="Audio" id="K0b-oh-ls1" userLabel="Audio">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="2yl-0q-ezn">
-                                        <rect key="frame" x="0.0" y="413.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="551.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2yl-0q-ezn" id="y1A-mp-vkH">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -262,7 +319,7 @@
                             <tableViewSection headerTitle="Version Information" id="d6N-kI-BBa">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="bUB-Fr-n0c">
-                                        <rect key="frame" x="0.0" y="507.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="645.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="bUB-Fr-n0c" id="VCQ-yX-pIE">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -298,11 +355,13 @@
                         <outlet property="enableAudioOutput" destination="h83-A2-2Ax" id="B29-zr-Rdh"/>
                         <outlet property="forceBilinearFiltering" destination="RW9-T7-1NA" id="IOT-Cx-rrp"/>
                         <outlet property="gsHandlerName" destination="639-fP-HSU" id="s2g-Go-bTy"/>
+                        <outlet property="hideVirtualPadWhenControllerConnected" destination="fu4-Lk-Wep" id="WwJ-Bd-f3M"/>
                         <outlet property="resizeOutputToWidescreen" destination="1qD-ob-b3P" id="XER-MB-smw"/>
                         <outlet property="resolutionFactor" destination="aiY-EV-WhA" id="BNd-7Q-xpD"/>
                         <outlet property="showFpsSwitch" destination="5Wo-ch-s5J" id="Ius-gD-fIr"/>
                         <outlet property="showVirtualPadSwitch" destination="hMN-wf-jlB" id="1Sb-Wi-cwa"/>
                         <outlet property="versionInfoLabel" destination="w2T-id-DC8" id="Sk7-qJ-alx"/>
+                        <outlet property="virtualPadOpacitySlider" destination="0UW-7S-cud" id="t5c-av-qcT"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DlU-rA-yok" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Source/ui_ios/EmulatorViewController.mm
+++ b/Source/ui_ios/EmulatorViewController.mm
@@ -32,8 +32,8 @@ CPS2VM::ProfileFrameDoneSignal::Connection g_profileFrameDoneConnection;
 	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREFERENCE_UI_SHOWVIRTUALPAD, true);
 	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREFERENCE_AUDIO_ENABLEOUTPUT, true);
 	CAppConfig::GetInstance().RegisterPreferenceInteger(PREFERENCE_VIDEO_GS_HANDLER, PREFERENCE_VALUE_VIDEO_GS_HANDLER_OPENGL);
-    CAppConfig::GetInstance().RegisterPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY, 100);
-    CAppConfig::GetInstance().RegisterPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED, true);
+	CAppConfig::GetInstance().RegisterPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY, 100);
+	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED, true);
 }
 
 - (void)viewDidLoad
@@ -180,22 +180,22 @@ CPS2VM::ProfileFrameDoneSignal::Connection g_profileFrameDoneConnection;
 					                                    padHandler->SetAxisState(PS2::CControllerInfo::ANALOG_RIGHT_Y, -gamepad.rightThumbstick.yAxis.value);
 				                                    }
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 120100
-                                                    if (@available(iOS 12.1, *))
-                                                    {
-                                                        if(element == gamepad.leftThumbstickButton)
-                                                            padHandler->SetButtonState(PS2::CControllerInfo::L3, gamepad.leftThumbstickButton.pressed);
-                                                        else if(element == gamepad.rightThumbstickButton)
-                                                            padHandler->SetButtonState(PS2::CControllerInfo::R3, gamepad.rightThumbstickButton.pressed);
-                                                    }
+				                                    if(@available(iOS 12.1, *))
+				                                    {
+					                                    if(element == gamepad.leftThumbstickButton)
+						                                    padHandler->SetButtonState(PS2::CControllerInfo::L3, gamepad.leftThumbstickButton.pressed);
+					                                    else if(element == gamepad.rightThumbstickButton)
+						                                    padHandler->SetButtonState(PS2::CControllerInfo::R3, gamepad.rightThumbstickButton.pressed);
+				                                    }
 #endif
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
-                                                    if (@available(iOS 13.0, *))
-                                                    {
-                                                        if(element == gamepad.buttonOptions)
-                                                            padHandler->SetButtonState(PS2::CControllerInfo::SELECT, gamepad.buttonOptions.pressed);
-                                                        else if(element == gamepad.buttonMenu)
-                                                            padHandler->SetButtonState(PS2::CControllerInfo::START, gamepad.buttonMenu.pressed);
-                                                    }
+				                                    if(@available(iOS 13.0, *))
+				                                    {
+					                                    if(element == gamepad.buttonOptions)
+						                                    padHandler->SetButtonState(PS2::CControllerInfo::SELECT, gamepad.buttonOptions.pressed);
+					                                    else if(element == gamepad.buttonMenu)
+						                                    padHandler->SetButtonState(PS2::CControllerInfo::START, gamepad.buttonMenu.pressed);
+				                                    }
 #endif
 			                                      }];
 		}
@@ -204,7 +204,7 @@ CPS2VM::ProfileFrameDoneSignal::Connection g_profileFrameDoneConnection;
 	{
 		self.gController = nil;
 	}
-    [self updateOnScreenWidgets];
+	[self updateOnScreenWidgets];
 }
 
 - (void)resetStatsTimer
@@ -249,14 +249,14 @@ CPS2VM::ProfileFrameDoneSignal::Connection g_profileFrameDoneConnection;
 	[self resetStatsTimer];
 
 	if(CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_SHOWVIRTUALPAD) &&
-       !(self.gController && CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED)))
+	   !(self.gController && CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED)))
 	{
 		auto padHandler = static_cast<CPH_Generic*>(g_virtualMachine->GetPadHandler());
 		self.virtualPadView = [[VirtualPadView alloc] initWithFrame:screenBounds padHandler:padHandler];
 		[self.view addSubview:self.virtualPadView];
 		[self.view sendSubviewToBack:self.virtualPadView];
-        int prefTransparency = CAppConfig::GetInstance().GetPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY);
-        self.virtualPadView.alpha = CGFloat(prefTransparency / 100.0);
+		int prefTransparency = CAppConfig::GetInstance().GetPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY);
+		self.virtualPadView.alpha = CGFloat(prefTransparency / 100.0);
 	}
 
 	if(CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_SHOWFPS))

--- a/Source/ui_ios/EmulatorViewController.mm
+++ b/Source/ui_ios/EmulatorViewController.mm
@@ -34,6 +34,7 @@ CPS2VM::ProfileFrameDoneSignal::Connection g_profileFrameDoneConnection;
 	CAppConfig::GetInstance().RegisterPreferenceInteger(PREFERENCE_VIDEO_GS_HANDLER, PREFERENCE_VALUE_VIDEO_GS_HANDLER_OPENGL);
 	CAppConfig::GetInstance().RegisterPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY, 100);
 	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED, true);
+    CAppConfig::GetInstance().RegisterPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK, true);
 }
 
 - (void)viewDidLoad

--- a/Source/ui_ios/EmulatorViewController.mm
+++ b/Source/ui_ios/EmulatorViewController.mm
@@ -34,7 +34,7 @@ CPS2VM::ProfileFrameDoneSignal::Connection g_profileFrameDoneConnection;
 	CAppConfig::GetInstance().RegisterPreferenceInteger(PREFERENCE_VIDEO_GS_HANDLER, PREFERENCE_VALUE_VIDEO_GS_HANDLER_OPENGL);
 	CAppConfig::GetInstance().RegisterPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY, 100);
 	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED, true);
-    CAppConfig::GetInstance().RegisterPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK, true);
+	CAppConfig::GetInstance().RegisterPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK, true);
 }
 
 - (void)viewDidLoad

--- a/Source/ui_ios/EmulatorViewController.mm
+++ b/Source/ui_ios/EmulatorViewController.mm
@@ -53,30 +53,6 @@ CPS2VM::ProfileFrameDoneSignal::Connection g_profileFrameDoneConnection;
 		                                            [self appBecameActive];
 	                                              }];
 
-	self.connectObserver = [[NSNotificationCenter defaultCenter] addObserverForName:GCControllerDidConnectNotification
-	                                                                         object:nil
-	                                                                          queue:[NSOperationQueue mainQueue]
-	                                                                     usingBlock:^(NSNotification* note) {
-		                                                                   if([[GCController controllers] count] == 1)
-		                                                                   {
-			                                                                   [self toggleHardwareController:YES];
-		                                                                   }
-	                                                                     }];
-	self.disconnectObserver = [[NSNotificationCenter defaultCenter] addObserverForName:GCControllerDidDisconnectNotification
-	                                                                            object:nil
-	                                                                             queue:[NSOperationQueue mainQueue]
-	                                                                        usingBlock:^(NSNotification* note) {
-		                                                                      if(![[GCController controllers] count])
-		                                                                      {
-			                                                                      [self toggleHardwareController:NO];
-		                                                                      }
-	                                                                        }];
-
-	if([[GCController controllers] count])
-	{
-		[self toggleHardwareController:YES];
-	}
-
 	self.iCadeReader = [[iCadeReaderView alloc] init];
 	[self.view addSubview:self.iCadeReader];
 	self.iCadeReader.delegate = self;
@@ -112,6 +88,30 @@ CPS2VM::ProfileFrameDoneSignal::Connection g_profileFrameDoneConnection;
 	case PREFERENCE_VALUE_VIDEO_GS_HANDLER_VULKAN:
 		g_virtualMachine->CreateGSHandler(CGSH_VulkaniOS::GetFactoryFunction((CAMetalLayer*)self.view.layer));
 		break;
+	}
+
+	self.connectObserver = [[NSNotificationCenter defaultCenter] addObserverForName:GCControllerDidConnectNotification
+	                                                                         object:nil
+	                                                                          queue:[NSOperationQueue mainQueue]
+	                                                                     usingBlock:^(NSNotification* note) {
+		                                                                   if([[GCController controllers] count] == 1)
+		                                                                   {
+			                                                                   [self toggleHardwareController:YES];
+		                                                                   }
+	                                                                     }];
+	self.disconnectObserver = [[NSNotificationCenter defaultCenter] addObserverForName:GCControllerDidDisconnectNotification
+	                                                                            object:nil
+	                                                                             queue:[NSOperationQueue mainQueue]
+	                                                                        usingBlock:^(NSNotification* note) {
+		                                                                      if(![[GCController controllers] count])
+		                                                                      {
+			                                                                      [self toggleHardwareController:NO];
+		                                                                      }
+	                                                                        }];
+
+	if([[GCController controllers] count])
+	{
+		[self toggleHardwareController:YES];
 	}
 
 	g_virtualMachine->CreatePadHandler(CPH_Generic::GetFactoryFunction());

--- a/Source/ui_ios/PreferenceDefs.h
+++ b/Source/ui_ios/PreferenceDefs.h
@@ -2,6 +2,8 @@
 
 #define PREFERENCE_UI_SHOWFPS "ui.showfps"
 #define PREFERENCE_UI_SHOWVIRTUALPAD "ui.showvirtualpad"
+#define PREFERENCE_UI_VIRTUALPADOPACITY "ui.virtualpadopacity"
+#define PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED "ui.virtualpad.hide.when.controller.connected"
 
 #define PREFERENCE_AUDIO_ENABLEOUTPUT "audio.enableoutput"
 

--- a/Source/ui_ios/PreferenceDefs.h
+++ b/Source/ui_ios/PreferenceDefs.h
@@ -4,6 +4,7 @@
 #define PREFERENCE_UI_SHOWVIRTUALPAD "ui.showvirtualpad"
 #define PREFERENCE_UI_VIRTUALPADOPACITY "ui.virtualpadopacity"
 #define PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED "ui.virtualpad.hide.when.controller.connected"
+#define PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK "ui.virtualpad.hapticfeedback"
 
 #define PREFERENCE_AUDIO_ENABLEOUTPUT "audio.enableoutput"
 

--- a/Source/ui_ios/SettingsViewController.h
+++ b/Source/ui_ios/SettingsViewController.h
@@ -4,8 +4,8 @@
 {
 	IBOutlet UISwitch* showFpsSwitch;
 	IBOutlet UISwitch* showVirtualPadSwitch;
-    IBOutlet UISlider* virtualPadOpacitySlider;
-    IBOutlet UISwitch* hideVirtualPadWhenControllerConnected;
+	IBOutlet UISlider* virtualPadOpacitySlider;
+	IBOutlet UISwitch* hideVirtualPadWhenControllerConnected;
 
 	IBOutlet UILabel* gsHandlerName;
 	IBOutlet UILabel* resolutionFactor;

--- a/Source/ui_ios/SettingsViewController.h
+++ b/Source/ui_ios/SettingsViewController.h
@@ -6,6 +6,7 @@
 	IBOutlet UISwitch* showVirtualPadSwitch;
 	IBOutlet UISlider* virtualPadOpacitySlider;
 	IBOutlet UISwitch* hideVirtualPadWhenControllerConnected;
+    IBOutlet UISwitch* virtualPadHapticFeedbackSwitch;
 
 	IBOutlet UILabel* gsHandlerName;
 	IBOutlet UILabel* resolutionFactor;

--- a/Source/ui_ios/SettingsViewController.h
+++ b/Source/ui_ios/SettingsViewController.h
@@ -6,7 +6,7 @@
 	IBOutlet UISwitch* showVirtualPadSwitch;
 	IBOutlet UISlider* virtualPadOpacitySlider;
 	IBOutlet UISwitch* hideVirtualPadWhenControllerConnected;
-    IBOutlet UISwitch* virtualPadHapticFeedbackSwitch;
+	IBOutlet UISwitch* virtualPadHapticFeedbackSwitch;
 
 	IBOutlet UILabel* gsHandlerName;
 	IBOutlet UILabel* resolutionFactor;

--- a/Source/ui_ios/SettingsViewController.h
+++ b/Source/ui_ios/SettingsViewController.h
@@ -4,6 +4,8 @@
 {
 	IBOutlet UISwitch* showFpsSwitch;
 	IBOutlet UISwitch* showVirtualPadSwitch;
+    IBOutlet UISlider* virtualPadOpacitySlider;
+    IBOutlet UISwitch* hideVirtualPadWhenControllerConnected;
 
 	IBOutlet UILabel* gsHandlerName;
 	IBOutlet UILabel* resolutionFactor;

--- a/Source/ui_ios/SettingsViewController.mm
+++ b/Source/ui_ios/SettingsViewController.mm
@@ -34,7 +34,7 @@
 	[showVirtualPadSwitch setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_SHOWVIRTUALPAD)];
 	[virtualPadOpacitySlider setValue:float(CAppConfig::GetInstance().GetPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY) / 100.0)];
 	[hideVirtualPadWhenControllerConnected setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED)];
-    [virtualPadHapticFeedbackSwitch setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK)];
+	[virtualPadHapticFeedbackSwitch setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK)];
 
 	[self updateGsHandlerNameLabel];
 	[self updateResolutionFactorLabel];
@@ -54,7 +54,7 @@
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED, showVirtualPadSwitch.isOn);
 	int prefValue = int(virtualPadOpacitySlider.value * 100.0);
 	CAppConfig::GetInstance().SetPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY, prefValue);
-    CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK, virtualPadHapticFeedbackSwitch.isOn);
+	CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK, virtualPadHapticFeedbackSwitch.isOn);
 
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_CGSHANDLER_WIDESCREEN, resizeOutputToWidescreen.isOn);
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES, forceBilinearFiltering.isOn);

--- a/Source/ui_ios/SettingsViewController.mm
+++ b/Source/ui_ios/SettingsViewController.mm
@@ -32,8 +32,8 @@
 {
 	[showFpsSwitch setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_SHOWFPS)];
 	[showVirtualPadSwitch setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_SHOWVIRTUALPAD)];
-    [virtualPadOpacitySlider setValue:float(CAppConfig::GetInstance().GetPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY) / 100.0)];
-    [hideVirtualPadWhenControllerConnected setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED)];
+	[virtualPadOpacitySlider setValue:float(CAppConfig::GetInstance().GetPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY) / 100.0)];
+	[hideVirtualPadWhenControllerConnected setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED)];
 
 	[self updateGsHandlerNameLabel];
 	[self updateResolutionFactorLabel];
@@ -50,9 +50,9 @@
 {
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_SHOWFPS, showFpsSwitch.isOn);
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_SHOWVIRTUALPAD, showVirtualPadSwitch.isOn);
-    CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED, showVirtualPadSwitch.isOn);
-    int prefValue = int(virtualPadOpacitySlider.value * 100.0);
-    CAppConfig::GetInstance().SetPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY, prefValue);
+	CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED, showVirtualPadSwitch.isOn);
+	int prefValue = int(virtualPadOpacitySlider.value * 100.0);
+	CAppConfig::GetInstance().SetPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY, prefValue);
 
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_CGSHANDLER_WIDESCREEN, resizeOutputToWidescreen.isOn);
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES, forceBilinearFiltering.isOn);

--- a/Source/ui_ios/SettingsViewController.mm
+++ b/Source/ui_ios/SettingsViewController.mm
@@ -32,6 +32,8 @@
 {
 	[showFpsSwitch setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_SHOWFPS)];
 	[showVirtualPadSwitch setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_SHOWVIRTUALPAD)];
+    [virtualPadOpacitySlider setValue:float(CAppConfig::GetInstance().GetPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY) / 100.0)];
+    [hideVirtualPadWhenControllerConnected setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED)];
 
 	[self updateGsHandlerNameLabel];
 	[self updateResolutionFactorLabel];
@@ -48,6 +50,9 @@
 {
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_SHOWFPS, showFpsSwitch.isOn);
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_SHOWVIRTUALPAD, showVirtualPadSwitch.isOn);
+    CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED, showVirtualPadSwitch.isOn);
+    int prefValue = int(virtualPadOpacitySlider.value * 100.0);
+    CAppConfig::GetInstance().SetPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY, prefValue);
 
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_CGSHANDLER_WIDESCREEN, resizeOutputToWidescreen.isOn);
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES, forceBilinearFiltering.isOn);

--- a/Source/ui_ios/SettingsViewController.mm
+++ b/Source/ui_ios/SettingsViewController.mm
@@ -34,6 +34,7 @@
 	[showVirtualPadSwitch setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_SHOWVIRTUALPAD)];
 	[virtualPadOpacitySlider setValue:float(CAppConfig::GetInstance().GetPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY) / 100.0)];
 	[hideVirtualPadWhenControllerConnected setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED)];
+    [virtualPadHapticFeedbackSwitch setOn:CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK)];
 
 	[self updateGsHandlerNameLabel];
 	[self updateResolutionFactorLabel];
@@ -53,6 +54,7 @@
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_HIDEVIRTUALPAD_CONTROLLER_CONNECTED, showVirtualPadSwitch.isOn);
 	int prefValue = int(virtualPadOpacitySlider.value * 100.0);
 	CAppConfig::GetInstance().SetPreferenceInteger(PREFERENCE_UI_VIRTUALPADOPACITY, prefValue);
+    CAppConfig::GetInstance().SetPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK, virtualPadHapticFeedbackSwitch.isOn);
 
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_CGSHANDLER_WIDESCREEN, resizeOutputToWidescreen.isOn);
 	CAppConfig::GetInstance().SetPreferenceBoolean(PREF_CGSH_OPENGL_FORCEBILINEARTEXTURES, forceBilinearFiltering.isOn);

--- a/Source/ui_ios/VirtualPadButton.mm
+++ b/Source/ui_ios/VirtualPadButton.mm
@@ -1,20 +1,21 @@
 #import "VirtualPadButton.h"
 
 @interface VirtualPadButton ()
-@property (strong, nonatomic) UIImpactFeedbackGenerator* impactFeedback;
-@property (strong, nonatomic) UISelectionFeedbackGenerator* selectionFeedback;
+@property(strong, nonatomic) UIImpactFeedbackGenerator* impactFeedback;
+@property(strong, nonatomic) UISelectionFeedbackGenerator* selectionFeedback;
 @end
 
 @implementation VirtualPadButton
 
-- (id)init {
-    self = [super init];
-    if (self)
-    {
-        _impactFeedback = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
-        _selectionFeedback = [[UISelectionFeedbackGenerator alloc] init];
-    }
-    return self;
+- (id)init
+{
+	self = [super init];
+	if(self)
+	{
+		_impactFeedback = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
+		_selectionFeedback = [[UISelectionFeedbackGenerator alloc] init];
+	}
+	return self;
 }
 
 - (void)draw:(CGContextRef)context
@@ -49,26 +50,27 @@
 {
 	self.pressed = YES;
 	self.padHandler->SetButtonState(self.code, true);
-    switch (self.code) {
-        case PS2::CControllerInfo::BUTTON::START:
-        case PS2::CControllerInfo::BUTTON::SELECT:
-        case PS2::CControllerInfo::BUTTON::SQUARE:
-        case PS2::CControllerInfo::BUTTON::TRIANGLE:
-        case PS2::CControllerInfo::BUTTON::CROSS:
-        case PS2::CControllerInfo::BUTTON::CIRCLE:
-        case PS2::CControllerInfo::BUTTON::L1:
-        case PS2::CControllerInfo::BUTTON::L2:
-        case PS2::CControllerInfo::BUTTON::L3:
-        case PS2::CControllerInfo::BUTTON::R1:
-        case PS2::CControllerInfo::BUTTON::R2:
-        case PS2::CControllerInfo::BUTTON::R3:
-            [self.impactFeedback impactOccurred];
-            break;
-            
-        default:
-            [self.selectionFeedback selectionChanged];
-            break;
-    }
+	switch(self.code)
+	{
+	case PS2::CControllerInfo::BUTTON::START:
+	case PS2::CControllerInfo::BUTTON::SELECT:
+	case PS2::CControllerInfo::BUTTON::SQUARE:
+	case PS2::CControllerInfo::BUTTON::TRIANGLE:
+	case PS2::CControllerInfo::BUTTON::CROSS:
+	case PS2::CControllerInfo::BUTTON::CIRCLE:
+	case PS2::CControllerInfo::BUTTON::L1:
+	case PS2::CControllerInfo::BUTTON::L2:
+	case PS2::CControllerInfo::BUTTON::L3:
+	case PS2::CControllerInfo::BUTTON::R1:
+	case PS2::CControllerInfo::BUTTON::R2:
+	case PS2::CControllerInfo::BUTTON::R3:
+		[self.impactFeedback impactOccurred];
+		break;
+
+	default:
+		[self.selectionFeedback selectionChanged];
+		break;
+	}
 	[super onPointerDown:position];
 }
 

--- a/Source/ui_ios/VirtualPadButton.mm
+++ b/Source/ui_ios/VirtualPadButton.mm
@@ -1,6 +1,21 @@
 #import "VirtualPadButton.h"
 
+@interface VirtualPadButton ()
+@property (strong, nonatomic) UIImpactFeedbackGenerator* impactFeedback;
+@property (strong, nonatomic) UISelectionFeedbackGenerator* selectionFeedback;
+@end
+
 @implementation VirtualPadButton
+
+- (id)init {
+    self = [super init];
+    if (self)
+    {
+        _impactFeedback = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
+        _selectionFeedback = [[UISelectionFeedbackGenerator alloc] init];
+    }
+    return self;
+}
 
 - (void)draw:(CGContextRef)context
 {
@@ -34,6 +49,26 @@
 {
 	self.pressed = YES;
 	self.padHandler->SetButtonState(self.code, true);
+    switch (self.code) {
+        case PS2::CControllerInfo::BUTTON::START:
+        case PS2::CControllerInfo::BUTTON::SELECT:
+        case PS2::CControllerInfo::BUTTON::SQUARE:
+        case PS2::CControllerInfo::BUTTON::TRIANGLE:
+        case PS2::CControllerInfo::BUTTON::CROSS:
+        case PS2::CControllerInfo::BUTTON::CIRCLE:
+        case PS2::CControllerInfo::BUTTON::L1:
+        case PS2::CControllerInfo::BUTTON::L2:
+        case PS2::CControllerInfo::BUTTON::L3:
+        case PS2::CControllerInfo::BUTTON::R1:
+        case PS2::CControllerInfo::BUTTON::R2:
+        case PS2::CControllerInfo::BUTTON::R3:
+            [self.impactFeedback impactOccurred];
+            break;
+            
+        default:
+            [self.selectionFeedback selectionChanged];
+            break;
+    }
 	[super onPointerDown:position];
 }
 

--- a/Source/ui_ios/VirtualPadButton.mm
+++ b/Source/ui_ios/VirtualPadButton.mm
@@ -1,3 +1,5 @@
+#import "../AppConfig.h"
+#import "PreferenceDefs.h"
 #import "VirtualPadButton.h"
 
 @interface VirtualPadButton ()
@@ -50,27 +52,30 @@
 {
 	self.pressed = YES;
 	self.padHandler->SetButtonState(self.code, true);
-	switch(self.code)
-	{
-	case PS2::CControllerInfo::BUTTON::START:
-	case PS2::CControllerInfo::BUTTON::SELECT:
-	case PS2::CControllerInfo::BUTTON::SQUARE:
-	case PS2::CControllerInfo::BUTTON::TRIANGLE:
-	case PS2::CControllerInfo::BUTTON::CROSS:
-	case PS2::CControllerInfo::BUTTON::CIRCLE:
-	case PS2::CControllerInfo::BUTTON::L1:
-	case PS2::CControllerInfo::BUTTON::L2:
-	case PS2::CControllerInfo::BUTTON::L3:
-	case PS2::CControllerInfo::BUTTON::R1:
-	case PS2::CControllerInfo::BUTTON::R2:
-	case PS2::CControllerInfo::BUTTON::R3:
-		[self.impactFeedback impactOccurred];
-		break;
-
-	default:
-		[self.selectionFeedback selectionChanged];
-		break;
-	}
+    if (CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK))
+    {
+        switch(self.code)
+        {
+            case PS2::CControllerInfo::BUTTON::START:
+            case PS2::CControllerInfo::BUTTON::SELECT:
+            case PS2::CControllerInfo::BUTTON::SQUARE:
+            case PS2::CControllerInfo::BUTTON::TRIANGLE:
+            case PS2::CControllerInfo::BUTTON::CROSS:
+            case PS2::CControllerInfo::BUTTON::CIRCLE:
+            case PS2::CControllerInfo::BUTTON::L1:
+            case PS2::CControllerInfo::BUTTON::L2:
+            case PS2::CControllerInfo::BUTTON::L3:
+            case PS2::CControllerInfo::BUTTON::R1:
+            case PS2::CControllerInfo::BUTTON::R2:
+            case PS2::CControllerInfo::BUTTON::R3:
+                [self.impactFeedback impactOccurred];
+                break;
+                
+            default:
+                [self.selectionFeedback selectionChanged];
+                break;
+        }
+    }
 	[super onPointerDown:position];
 }
 

--- a/Source/ui_ios/VirtualPadButton.mm
+++ b/Source/ui_ios/VirtualPadButton.mm
@@ -52,30 +52,30 @@
 {
 	self.pressed = YES;
 	self.padHandler->SetButtonState(self.code, true);
-    if (CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK))
-    {
-        switch(self.code)
-        {
-            case PS2::CControllerInfo::BUTTON::START:
-            case PS2::CControllerInfo::BUTTON::SELECT:
-            case PS2::CControllerInfo::BUTTON::SQUARE:
-            case PS2::CControllerInfo::BUTTON::TRIANGLE:
-            case PS2::CControllerInfo::BUTTON::CROSS:
-            case PS2::CControllerInfo::BUTTON::CIRCLE:
-            case PS2::CControllerInfo::BUTTON::L1:
-            case PS2::CControllerInfo::BUTTON::L2:
-            case PS2::CControllerInfo::BUTTON::L3:
-            case PS2::CControllerInfo::BUTTON::R1:
-            case PS2::CControllerInfo::BUTTON::R2:
-            case PS2::CControllerInfo::BUTTON::R3:
-                [self.impactFeedback impactOccurred];
-                break;
-                
-            default:
-                [self.selectionFeedback selectionChanged];
-                break;
-        }
-    }
+	if(CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK))
+	{
+		switch(self.code)
+		{
+		case PS2::CControllerInfo::BUTTON::START:
+		case PS2::CControllerInfo::BUTTON::SELECT:
+		case PS2::CControllerInfo::BUTTON::SQUARE:
+		case PS2::CControllerInfo::BUTTON::TRIANGLE:
+		case PS2::CControllerInfo::BUTTON::CROSS:
+		case PS2::CControllerInfo::BUTTON::CIRCLE:
+		case PS2::CControllerInfo::BUTTON::L1:
+		case PS2::CControllerInfo::BUTTON::L2:
+		case PS2::CControllerInfo::BUTTON::L3:
+		case PS2::CControllerInfo::BUTTON::R1:
+		case PS2::CControllerInfo::BUTTON::R2:
+		case PS2::CControllerInfo::BUTTON::R3:
+			[self.impactFeedback impactOccurred];
+			break;
+
+		default:
+			[self.selectionFeedback selectionChanged];
+			break;
+		}
+	}
 	[super onPointerDown:position];
 }
 

--- a/Source/ui_ios/VirtualPadView.mm
+++ b/Source/ui_ios/VirtualPadView.mm
@@ -1,3 +1,5 @@
+#import "../AppConfig.h"
+#import "PreferenceDefs.h"
 #import "VirtualPadView.h"
 #import "VirtualPadButton.h"
 #import "VirtualPadStick.h"
@@ -92,7 +94,8 @@
 			{
 				item.touch = touch;
 				[item onPointerDown:touchPos];
-				[self.selectionFeedback selectionChanged];
+                if (CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK))
+                    [self.selectionFeedback selectionChanged];
 				[self setNeedsDisplay];
 				break;
 			}

--- a/Source/ui_ios/VirtualPadView.mm
+++ b/Source/ui_ios/VirtualPadView.mm
@@ -3,6 +3,10 @@
 #import "VirtualPadStick.h"
 #include "../VirtualPad.h"
 
+@interface VirtualPadView ()
+@property (strong, nonatomic) UISelectionFeedbackGenerator* selectionFeedback;
+@end
+
 @implementation VirtualPadView
 
 - (id)initWithFrame:(CGRect)frame padHandler:(CPH_Generic*)padHandler
@@ -24,7 +28,7 @@
 		[itemImages setObject:[UIImage imageNamed:@"lr.png"] forKey:@"lr"];
 		[itemImages setObject:[UIImage imageNamed:@"analogstick.png"] forKey:@"analogStick"];
 		self.itemImages = itemImages;
-
+        _selectionFeedback = [[UISelectionFeedbackGenerator alloc] init];
 		self.opaque = NO;
 		self.multipleTouchEnabled = YES;
 		_padHandler = padHandler;
@@ -88,6 +92,7 @@
 			{
 				item.touch = touch;
 				[item onPointerDown:touchPos];
+                [self.selectionFeedback selectionChanged];
 				[self setNeedsDisplay];
 				break;
 			}

--- a/Source/ui_ios/VirtualPadView.mm
+++ b/Source/ui_ios/VirtualPadView.mm
@@ -94,8 +94,8 @@
 			{
 				item.touch = touch;
 				[item onPointerDown:touchPos];
-                if (CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK))
-                    [self.selectionFeedback selectionChanged];
+				if(CAppConfig::GetInstance().GetPreferenceBoolean(PREFERENCE_UI_VIRTUALPAD_HAPTICFEEDBACK))
+					[self.selectionFeedback selectionChanged];
 				[self setNeedsDisplay];
 				break;
 			}

--- a/Source/ui_ios/VirtualPadView.mm
+++ b/Source/ui_ios/VirtualPadView.mm
@@ -4,7 +4,7 @@
 #include "../VirtualPad.h"
 
 @interface VirtualPadView ()
-@property (strong, nonatomic) UISelectionFeedbackGenerator* selectionFeedback;
+@property(strong, nonatomic) UISelectionFeedbackGenerator* selectionFeedback;
 @end
 
 @implementation VirtualPadView
@@ -28,7 +28,7 @@
 		[itemImages setObject:[UIImage imageNamed:@"lr.png"] forKey:@"lr"];
 		[itemImages setObject:[UIImage imageNamed:@"analogstick.png"] forKey:@"analogStick"];
 		self.itemImages = itemImages;
-        _selectionFeedback = [[UISelectionFeedbackGenerator alloc] init];
+		_selectionFeedback = [[UISelectionFeedbackGenerator alloc] init];
 		self.opaque = NO;
 		self.multipleTouchEnabled = YES;
 		_padHandler = padHandler;
@@ -92,7 +92,7 @@
 			{
 				item.touch = touch;
 				[item onPointerDown:touchPos];
-                [self.selectionFeedback selectionChanged];
+				[self.selectionFeedback selectionChanged];
 				[self setNeedsDisplay];
 				break;
 			}


### PR DESCRIPTION
Some small improvements:
- Added preference for Virtual Pad opacity
- Added preference for hiding the virtual pad when a controller is connected
- Added a section for Virtual Pad in Settings
- Added haptic feedback for Virtual Pad and settings to enable it
- Add support for L3/R3 buttons for external controllers (requires iOS 12.1+)
- Add support for Select/Start buttons for external controllers (requires iOS 13+)

I can merge master after PR #1097 is merged (right now it has those diffs)