### PR TITLE
Fix compile errors

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -444,6 +444,10 @@ set(COMMON_SRC_FILES
 	${AMAZON_S3_SRC}
 )
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	add_compile_options("-fbracket-depth=512")
+endif()
+
 if(TARGET_PLATFORM_WIN32)
 	set(PLATFORM_SPECIFIC_SRC_FILES VolumeStream.cpp)
 	list(APPEND PROJECT_LIBS winmm)

--- a/tools/VuTest/VuAssembler.h
+++ b/tools/VuTest/VuAssembler.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstddef>
 #include <map>
+
 #include "Types.h"
 
 class CVuAssembler


### PR DESCRIPTION
Modern versions of `gcc` and `clang` require these changes to compile.

see: https://reviews.llvm.org/D86936