### PR TITLE
iOS: Update collection view layout for a better looking grid

### DIFF
--- a/Source/ui_ios/Base.lproj/Main.storyboard
+++ b/Source/ui_ios/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="VnE-Sh-vgR">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="VnE-Sh-vgR">
     <device id="retina6_1" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -31,9 +31,8 @@
                                     <rect key="frame" x="0.0" y="0.0" width="144" height="204"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="bottom" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KRt-E5-gbH">
-                                            <rect key="frame" x="8" y="116" width="128" height="80"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="bottom" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KRt-E5-gbH">
+                                            <rect key="frame" x="8" y="196" width="128" height="0.0"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
@@ -41,6 +40,11 @@
                                     </subviews>
                                 </view>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="KRt-E5-gbH" secondAttribute="bottom" constant="8" id="E8C-f7-irY"/>
+                                    <constraint firstItem="KRt-E5-gbH" firstAttribute="leading" secondItem="0I6-tW-IKA" secondAttribute="leading" constant="8" id="OOs-Mt-If5"/>
+                                    <constraint firstAttribute="trailing" secondItem="KRt-E5-gbH" secondAttribute="trailing" constant="8" id="o0I-9w-bRR"/>
+                                </constraints>
                                 <size key="customSize" width="144" height="204"/>
                                 <connections>
                                     <outlet property="nameLabel" destination="KRt-E5-gbH" id="XJm-ai-vMg"/>

--- a/Source/ui_ios/CoverViewController.mm
+++ b/Source/ui_ios/CoverViewController.mm
@@ -102,6 +102,7 @@ static NSString* const reuseIdentifier = @"coverCell";
 
 	[[AltServerJitService sharedAltServerJitService] startProcess];
 	[self buildCollectionWithForcedFullScan:NO];
+    self.collectionView.collectionViewLayout = [self createLayout];
 }
 
 - (void)viewDidUnload
@@ -128,6 +129,35 @@ static NSString* const reuseIdentifier = @"coverCell";
 	{
 		return NO;
 	}
+}
+
+#pragma mark <UICollectionViewLayout>
+
+-(UICollectionViewLayout*)createLayout
+{
+    UICollectionViewCompositionalLayout *layout = [[UICollectionViewCompositionalLayout alloc] initWithSectionProvider:^NSCollectionLayoutSection * _Nullable(NSInteger section, id<NSCollectionLayoutEnvironment> _Nonnull layoutEnvironment) {
+        NSInteger numColumns = [self columnCountForTraitCollection:layoutEnvironment.traitCollection];
+        NSCollectionLayoutSize *layoutSize = [NSCollectionLayoutSize sizeWithWidthDimension:[NSCollectionLayoutDimension fractionalWidthDimension:0.2] heightDimension:[NSCollectionLayoutDimension estimatedDimension:300]];
+        NSCollectionLayoutItem *item = [NSCollectionLayoutItem itemWithLayoutSize:layoutSize];
+        item.contentInsets = NSDirectionalEdgeInsetsMake(2, 2, 2, 2);
+        NSCollectionLayoutDimension *groupHeight = [NSCollectionLayoutDimension estimatedDimension:300];
+        NSCollectionLayoutSize *groupSize = [NSCollectionLayoutSize sizeWithWidthDimension:[NSCollectionLayoutDimension fractionalWidthDimension:1.0] heightDimension:groupHeight];
+        NSCollectionLayoutGroup *group = [NSCollectionLayoutGroup horizontalGroupWithLayoutSize:groupSize subitem:item count:numColumns];
+        return [NSCollectionLayoutSection sectionWithGroup:group];
+    }];
+    return layout;
+}
+
+-(NSInteger)columnCountForTraitCollection:(UITraitCollection*)traitCollection
+{
+    switch (traitCollection.horizontalSizeClass) {
+        case UIUserInterfaceSizeClassRegular:
+            return 4;
+            break;
+        default:
+            return 2;
+            break;
+    }
 }
 
 #pragma mark <UICollectionViewDataSource>
@@ -164,8 +194,6 @@ static NSString* const reuseIdentifier = @"coverCell";
 
 	return cell;
 }
-
-#pragma mark <UICollectionViewDelegate>
 
 - (void)prepareForSegue:(UIStoryboardSegue*)segue sender:(id)sender
 {


### PR DESCRIPTION
The Games list screen had some wasted space in the middle, where the items would be pinned to the leading and trailing edges of the collection view.

Updated to use the UICollectionView compositional layout API to better support a grid layout. This API however requires iOS 13. I'll add another PR for the dependencies repo for the deployment target update.

Also updated the collection view cell to use auto layout constraints for the label.

![IMG_A46E73920780-1](https://user-images.githubusercontent.com/564774/143764877-45edd74a-d5de-4218-a502-9ac1d1be2709.jpeg)


