### PR TITLE
cmake: Better git handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,22 @@ if(BUILD_TESTS)
 	enable_testing()
 endif()
 
-execute_process(COMMAND git describe RESULT_VARIABLE GIT_DESCRIBE_RESULT OUTPUT_VARIABLE GIT_TAG OUTPUT_STRIP_TRAILING_WHITESPACE)
-if(GIT_DESCRIBE_RESULT EQUAL 0)
-	message("Building for ${GIT_TAG}.")
-	set(PROJECT_Version ${GIT_TAG})
+find_package(Git)
+if(GIT_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git/")
+	execute_process(COMMAND ${GIT_EXECUTABLE} describe --always
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+		RESULT_VARIABLE GIT_DESCRIBE_RESULT
+		OUTPUT_VARIABLE GIT_TAG
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+	if(GIT_DESCRIBE_RESULT EQUAL 0)
+		message("Building for ${GIT_TAG}.")
+		set(PROJECT_Version ${GIT_TAG})
+	else()
+		message("Warning: Failed to obtain Git tag.")
+	endif()
 else()
-	message("Warning: Failed to obtain Git tag.")
+	message("Warning: Not a git repo or git not found.")
 endif()
 
 add_definitions(-DPLAY_VERSION="${PROJECT_Version}")


### PR DESCRIPTION
This fixes some problems.

* `git describe` without `--always` can fail in shallow clones.
* git will end up working in the wrong directory when doing an out of tree build.
* git may not actually be installed
* The `.git` directory may not be present, for example the user can download a source archive from any github branch, tag or commit where the git history will not be included.