### PR TITLE
cmake: Use GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ endif()
 
 project(Play)
 
+include(GNUInstallDirs)
+
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/deps/Dependencies/cmake-modules
 	${CMAKE_MODULE_PATH}

--- a/Source/ui_qt/CMakeLists.txt
+++ b/Source/ui_qt/CMakeLists.txt
@@ -306,11 +306,21 @@ elseif(TARGET_PLATFORM_WIN32)
 elseif(TARGET_PLATFORM_UNIX)
 	add_executable(Play ${QT_SOURCES} ${QT_MOC_SRCS} ${QT_RES_SOURCES} ${QT_UI_HEADERS})
 
-	install(TARGETS Play DESTINATION bin RENAME Play PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ)
-
-	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../icons/icon_base.png DESTINATION share/icons/hicolor/1024x1024/apps RENAME Play.png)
-	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../icons/icon.svg DESTINATION share/icons/hicolor/scalable/apps RENAME Play.svg)
-	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../installer_unix/Play.desktop DESTINATION share/applications)
+	install(TARGETS Play DESTINATION ${CMAKE_INSTALL_BINDIR}
+		PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
+		RENAME Play
+	)
+	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../icons/icon_base.png
+		DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/1024x1024/apps
+		RENAME Play.png
+	)
+	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../icons/icon.svg
+		DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps
+		RENAME Play.svg
+	)
+	install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../../installer_unix/Play.desktop
+		DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications
+	)
 else()
 	add_executable(Play ${QT_SOURCES} ${QT_MOC_SRCS} ${QT_RES_SOURCES} ${QT_UI_HEADERS})
 endif()


### PR DESCRIPTION
This is helpful for distros and anyone installing to a non-standard potentially arbitrary location. For example a distro may want `/usr/games/Play` rather than the default of `/usr/bin/Play` and can configure this with `-DCMAKE_INSTALL_BINDIR=game`.

Reference: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html

I also reformatted it for better readability.