### PR TITLE
Qt : allow filtering bootable list (though path, title and disc id)

### DIFF
--- a/Source/ui_qt/BootableModel.cpp
+++ b/Source/ui_qt/BootableModel.cpp
@@ -31,7 +31,7 @@ QVariant BootableModel::data(const QModelIndex& index, int role) const
 	{
 		int pos = index.row() + index.column();
 		auto bootable = m_bootables.at(static_cast<unsigned int>(pos));
-		return QVariant::fromValue(BootableCoverQVarient(bootable.discId, bootable.title));
+		return QVariant::fromValue(BootableCoverQVarient(bootable.discId, bootable.title, bootable.path.string()));
 	}
 	return QVariant();
 }
@@ -69,9 +69,10 @@ void BootableModel::SetWidth(int width)
 }
 
 /* start of BootImageItemDelegate */
-BootableCoverQVarient::BootableCoverQVarient(std::string key, std::string title)
+BootableCoverQVarient::BootableCoverQVarient(std::string key, std::string title, std::string path)
     : m_key(key)
     , m_title(title)
+    , m_path(path)
 {
 }
 
@@ -141,6 +142,11 @@ std::string BootableCoverQVarient::GetKey()
 std::string BootableCoverQVarient::GetTitle()
 {
 	return m_title;
+}
+
+std::string BootableCoverQVarient::GetPath()
+{
+	return m_path;
 }
 
 /* start of BootImageItemDelegate */

--- a/Source/ui_qt/BootableModel.cpp
+++ b/Source/ui_qt/BootableModel.cpp
@@ -133,6 +133,16 @@ QSize BootableCoverQVarient::sizeHint() const
 	return size;
 }
 
+std::string BootableCoverQVarient::GetKey()
+{
+	return m_key;
+}
+
+std::string BootableCoverQVarient::GetTitle()
+{
+	return m_title;
+}
+
 /* start of BootImageItemDelegate */
 BootImageItemDelegate::BootImageItemDelegate(QWidget* parent)
     : QStyledItemDelegate(parent)

--- a/Source/ui_qt/BootableModel.h
+++ b/Source/ui_qt/BootableModel.h
@@ -29,7 +29,7 @@ class BootableCoverQVarient
 {
 
 public:
-	explicit BootableCoverQVarient(std::string = "PH", std::string = "");
+	explicit BootableCoverQVarient(std::string = "PH", std::string = "", std::string = "");
 	~BootableCoverQVarient() = default;
 
 	void paint(QPainter* painter, const QRect& rect, const QPalette& palette, int mode) const;
@@ -37,11 +37,13 @@ public:
 
 	std::string GetKey();
 	std::string GetTitle();
+	std::string GetPath();
 
 private:
 	int GetPadding() const;
 	std::string m_key;
 	std::string m_title;
+	std::string m_path;
 };
 
 Q_DECLARE_METATYPE(BootableCoverQVarient)

--- a/Source/ui_qt/BootableModel.h
+++ b/Source/ui_qt/BootableModel.h
@@ -35,6 +35,8 @@ public:
 	void paint(QPainter* painter, const QRect& rect, const QPalette& palette, int mode) const;
 	QSize sizeHint() const;
 
+	std::string GetKey();
+	std::string GetTitle();
 private:
 	int GetPadding() const;
 	std::string m_key;

--- a/Source/ui_qt/BootableModel.h
+++ b/Source/ui_qt/BootableModel.h
@@ -37,6 +37,7 @@ public:
 
 	std::string GetKey();
 	std::string GetTitle();
+
 private:
 	int GetPadding() const;
 	std::string m_key;

--- a/Source/ui_qt/BootableModelProxy.cpp
+++ b/Source/ui_qt/BootableModelProxy.cpp
@@ -1,0 +1,25 @@
+#include "BootableModelProxy.h"
+#include "BootableModel.h"
+#include <regex>
+BootableModelProxy::BootableModelProxy(QObject* parent)
+	: QSortFilterProxyModel(parent)
+{
+}
+
+bool BootableModelProxy::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
+{
+	QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
+
+	QVariant data = sourceModel()->data(index);
+	if(data.canConvert<BootableCoverQVarient>())
+	{
+		BootableCoverQVarient bootablecover = qvariant_cast<BootableCoverQVarient>(data);
+		QString key = QString::fromStdString(bootablecover.GetKey());
+		QString title = QString::fromStdString(bootablecover.GetTitle());
+		QRegularExpression regex = filterRegularExpression();
+		regex.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
+
+		return  key.contains(regex) ||  title.contains(regex);
+	}
+	return false;
+}

--- a/Source/ui_qt/BootableModelProxy.cpp
+++ b/Source/ui_qt/BootableModelProxy.cpp
@@ -17,8 +17,15 @@ bool BootableModelProxy::filterAcceptsRow(int sourceRow, const QModelIndex& sour
 		QString key = QString::fromStdString(bootablecover.GetKey());
 		QString title = QString::fromStdString(bootablecover.GetTitle());
 		QString path = QString::fromStdString(bootablecover.GetPath());
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 		QRegularExpression regex = filterRegularExpression();
 		regex.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
+#else
+		// QRegExp is deprecated in Qt6, while QRegularExpression is recommended over QRegExp since Qt5
+		// however QRegularExpression is producing incorrect results in Qt5
+		QRegExp regex = filterRegExp();
+		regex.setCaseSensitivity(Qt::CaseInsensitive);
+#endif
 
 		return key.contains(regex) || title.contains(regex) || path.contains(regex);
 	}

--- a/Source/ui_qt/BootableModelProxy.cpp
+++ b/Source/ui_qt/BootableModelProxy.cpp
@@ -2,11 +2,11 @@
 #include "BootableModel.h"
 #include <regex>
 BootableModelProxy::BootableModelProxy(QObject* parent)
-	: QSortFilterProxyModel(parent)
+    : QSortFilterProxyModel(parent)
 {
 }
 
-bool BootableModelProxy::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
+bool BootableModelProxy::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const
 {
 	QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
 
@@ -19,7 +19,7 @@ bool BootableModelProxy::filterAcceptsRow(int sourceRow, const QModelIndex &sour
 		QRegularExpression regex = filterRegularExpression();
 		regex.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
 
-		return  key.contains(regex) ||  title.contains(regex);
+		return key.contains(regex) || title.contains(regex);
 	}
 	return false;
 }

--- a/Source/ui_qt/BootableModelProxy.cpp
+++ b/Source/ui_qt/BootableModelProxy.cpp
@@ -16,10 +16,11 @@ bool BootableModelProxy::filterAcceptsRow(int sourceRow, const QModelIndex& sour
 		BootableCoverQVarient bootablecover = qvariant_cast<BootableCoverQVarient>(data);
 		QString key = QString::fromStdString(bootablecover.GetKey());
 		QString title = QString::fromStdString(bootablecover.GetTitle());
+		QString path = QString::fromStdString(bootablecover.GetPath());
 		QRegularExpression regex = filterRegularExpression();
 		regex.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
 
-		return key.contains(regex) || title.contains(regex);
+		return key.contains(regex) || title.contains(regex) || path.contains(regex);
 	}
 	return false;
 }

--- a/Source/ui_qt/BootableModelProxy.h
+++ b/Source/ui_qt/BootableModelProxy.h
@@ -1,0 +1,12 @@
+#include <QSortFilterProxyModel>
+
+class BootableModelProxy : public QSortFilterProxyModel
+{
+	Q_OBJECT
+
+public:
+	BootableModelProxy(QObject* parent);
+
+protected:
+	bool filterAcceptsRow(int, const QModelIndex&) const override;
+};

--- a/Source/ui_qt/CMakeLists.txt
+++ b/Source/ui_qt/CMakeLists.txt
@@ -92,6 +92,8 @@ set(QT_SOURCES
 	bootablelistdialog.h
 	BootableModel.cpp
 	BootableModel.h
+	BootableModelProxy.cpp
+	BootableModelProxy.h
 	ControllerConfig/controllerconfigdialog.cpp
 	ControllerConfig/controllerconfigdialog.h
 	ControllerConfig/inputbindingmodel.cpp
@@ -204,6 +206,7 @@ endif()
 set(QT_MOC_HEADERS
 	bootablelistdialog.h
 	BootableModel.h
+	BootableModelProxy.h
 	ControllerConfig/controllerconfigdialog.h
 	ControllerConfig/inputbindingmodel.h
 	ControllerConfig/inputeventselectiondialog.h

--- a/Source/ui_qt/Qt_ui/bootablelistdialog.ui
+++ b/Source/ui_qt/Qt_ui/bootablelistdialog.ui
@@ -42,6 +42,26 @@
     <number>0</number>
    </property>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="leftMargin">
+      <number>9</number>
+     </property>
+     <property name="rightMargin">
+      <number>9</number>
+     </property>
+     <item>
+      <widget class="QLineEdit" name="filterLineEdit"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="reset_filter_button">
+       <property name="text">
+        <string>Reset Filter</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QListView" name="listView">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">

--- a/Source/ui_qt/Qt_ui/bootablelistdialog.ui
+++ b/Source/ui_qt/Qt_ui/bootablelistdialog.ui
@@ -49,6 +49,13 @@
      <property name="rightMargin">
       <number>9</number>
      </property>
+     <item row="2" column="0">
+      <widget class="QLabel" name="filterlabel">
+       <property name="text">
+        <string>Filter:</string>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QLineEdit" name="filterLineEdit"/>
      </item>

--- a/Source/ui_qt/bootablelistdialog.cpp
+++ b/Source/ui_qt/bootablelistdialog.cpp
@@ -316,3 +316,8 @@ void BootableListDialog::DisplayWarningMessage()
 	                     "Can't close dialog while background operation in progress.",
 	                     QMessageBox::Ok, QMessageBox::Ok);
 }
+
+void BootableListDialog::on_reset_filter_button_clicked()
+{
+	ui->filterLineEdit->clear();
+}

--- a/Source/ui_qt/bootablelistdialog.cpp
+++ b/Source/ui_qt/bootablelistdialog.cpp
@@ -104,7 +104,10 @@ void BootableListDialog::resetModel(bool repopulateBootables)
 		m_bootables = BootablesDb::CClient::GetInstance().GetBootables(m_sortingMethod);
 
 	model = new BootableModel(this, m_bootables);
-	ui->listView->setModel(model);
+	auto proxyModel = new BootableModelProxy(this);
+	proxyModel->setSourceModel(model);
+	ui->listView->setModel(proxyModel);
+	connect(ui->filterLineEdit, &QLineEdit::textChanged, proxyModel, &QSortFilterProxyModel::setFilterFixedString);
 	connect(ui->listView->selectionModel(), &QItemSelectionModel::currentChanged, this, &BootableListDialog::SelectionChange);
 
 	if(!m_thread_running)

--- a/Source/ui_qt/bootablelistdialog.h
+++ b/Source/ui_qt/bootablelistdialog.h
@@ -16,8 +16,7 @@ namespace Ui
 	class BootableListDialog;
 }
 
-class
-    BootableListDialog : public QDialog
+class BootableListDialog : public QDialog
 {
 	Q_OBJECT
 
@@ -48,14 +47,14 @@ private:
 	QStatusBar* m_statusBar = nullptr;
 	ElidedLabel* m_msgLabel = nullptr;
 
-	BootablesDb::Bootable bootable;
+	BootablesDb::Bootable m_bootable;
 	std::vector<BootablesDb::Bootable> m_bootables;
-	BootableModel* model = nullptr;
-	BootableModelProxy* m_proxy_model = nullptr;
+	BootableModel* m_model = nullptr;
+	BootableModelProxy* m_proxyModel = nullptr;
 	int m_sortingMethod = 2;
-	std::thread cover_loader;
-	std::atomic<bool> m_thread_running;
-	std::atomic<bool> m_s3_processing;
+	std::thread m_coverLoader;
+	std::atomic<bool> m_threadRunning;
+	std::atomic<bool> m_s3Processing;
 	CContinuationChecker* m_continuationChecker = nullptr;
 
 	void SelectionChange(const QModelIndex&);

--- a/Source/ui_qt/bootablelistdialog.h
+++ b/Source/ui_qt/bootablelistdialog.h
@@ -61,6 +61,7 @@ private:
 	void SelectionChange(const QModelIndex&);
 	void SetupStatusBar();
 	void DisplayWarningMessage();
+	void BootBootables(const QModelIndex&);
 
 Q_SIGNALS:
 	void AsyncResetModel(bool);

--- a/Source/ui_qt/bootablelistdialog.h
+++ b/Source/ui_qt/bootablelistdialog.h
@@ -39,6 +39,8 @@ private slots:
 
 	void resetModel(bool = true);
 
+	void on_reset_filter_button_clicked();
+
 private:
 	Ui::BootableListDialog* ui;
 

--- a/Source/ui_qt/bootablelistdialog.h
+++ b/Source/ui_qt/bootablelistdialog.h
@@ -7,6 +7,7 @@
 #include <thread>
 #include <atomic>
 #include "BootableModel.h"
+#include "BootableModelProxy.h"
 #include "ContinuationChecker.h"
 #include "ElidedLabel.h"
 
@@ -50,6 +51,7 @@ private:
 	BootablesDb::Bootable bootable;
 	std::vector<BootablesDb::Bootable> m_bootables;
 	BootableModel* model = nullptr;
+	BootableModelProxy* m_proxy_model = nullptr;
 	int m_sortingMethod = 2;
 	std::thread cover_loader;
 	std::atomic<bool> m_thread_running;


### PR DESCRIPTION
I'm debating using the model proxy to also sort the list,
as that will make the overall code simplier (no need to destory and repopulate `m_bootables` or `m_model`),
but it will mean we will have 2 different sorting codes, one Qt specific and the current (sqlite) one.