### PR TITLE
Qt6 compatibility

### DIFF
--- a/Source/ui_qt/DebugSupport/FrameDebugger/PixelBufferView.cpp
+++ b/Source/ui_qt/DebugSupport/FrameDebugger/PixelBufferView.cpp
@@ -157,7 +157,12 @@ void CPixelBufferView::OnMouseMoveEvent(QMouseEvent* event)
 void CPixelBufferView::OnMouseWheelEvent(QWheelEvent* event)
 {
 	float newZoom = 0;
-	auto z = event->delta();
+	auto z = 0;
+	auto delta = event->angleDelta();
+	if(!delta.isNull())
+	{
+		z = delta.y();
+	}
 	if(z <= -1)
 	{
 		newZoom = m_zoomFactor / 2;
@@ -170,7 +175,7 @@ void CPixelBufferView::OnMouseWheelEvent(QWheelEvent* event)
 	if(newZoom != 0)
 	{
 		auto clientRect = m_openglpanel->size();
-		auto mousePoint = event->posF();
+		auto mousePoint = event->position();
 		float relPosX = static_cast<float>(mousePoint.x()) / static_cast<float>(clientRect.width());
 		float relPosY = static_cast<float>(mousePoint.y()) / static_cast<float>(clientRect.height());
 		relPosX = std::max(relPosX, 0.f);

--- a/Source/ui_qt/DebugSupport/FrameDebugger/QtFramedebugger.cpp
+++ b/Source/ui_qt/DebugSupport/FrameDebugger/QtFramedebugger.cpp
@@ -18,6 +18,7 @@
 #include "gs/GSH_Vulkan/GSH_VulkanOffscreen.h"
 #endif
 
+#include <QActionGroup>
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QOffscreenSurface>

--- a/Source/ui_qt/DebugSupport/MemoryViewTable.cpp
+++ b/Source/ui_qt/DebugSupport/MemoryViewTable.cpp
@@ -1,4 +1,5 @@
 #include <QAction>
+#include <QActionGroup>
 #include <QApplication>
 #include <QInputDialog>
 #include <QMenu>

--- a/Source/ui_qt/Qt_ui/s3filebrowser.ui
+++ b/Source/ui_qt/Qt_ui/s3filebrowser.ui
@@ -104,53 +104,5 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>refreshButton</sender>
-   <signal>clicked()</signal>
-   <receiver>S3FileBrowser</receiver>
-   <slot>refreshButton_clicked()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>400</x>
-     <y>21</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>223</x>
-     <y>186</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>objectList</sender>
-   <signal>itemSelectionChanged()</signal>
-   <receiver>S3FileBrowser</receiver>
-   <slot>objectList_itemSelectionChanged()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>223</x>
-     <y>187</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>223</x>
-     <y>186</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>searchFilterEdit</sender>
-   <signal>textChanged(QString)</signal>
-   <receiver>S3FileBrowser</receiver>
-   <slot>searchFilterEdit_textChanged(QString)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>223</x>
-     <y>49</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>223</x>
-     <y>186</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>

--- a/Source/ui_qt/S3FileBrowser.cpp
+++ b/Source/ui_qt/S3FileBrowser.cpp
@@ -41,17 +41,17 @@ fs::path S3FileBrowser::GetSelectedPath() const
 	return m_selectedPath;
 }
 
-void S3FileBrowser::refreshButton_clicked()
+void S3FileBrowser::on_refreshButton_clicked()
 {
 	launchUpdate();
 }
 
-void S3FileBrowser::objectList_itemSelectionChanged()
+void S3FileBrowser::on_objectList_itemSelectionChanged()
 {
 	updateOkButtonState();
 }
 
-void S3FileBrowser::searchFilterEdit_textChanged(QString)
+void S3FileBrowser::on_searchFilterEdit_textChanged(QString)
 {
 	m_filterTimer->start(100);
 }

--- a/Source/ui_qt/S3FileBrowser.h
+++ b/Source/ui_qt/S3FileBrowser.h
@@ -24,9 +24,9 @@ public:
 	fs::path GetSelectedPath() const;
 
 private slots:
-	void refreshButton_clicked();
-	void objectList_itemSelectionChanged();
-	void searchFilterEdit_textChanged(QString);
+	void on_refreshButton_clicked();
+	void on_objectList_itemSelectionChanged();
+	void on_searchFilterEdit_textChanged(QString);
 	void updateFilter();
 
 private:

--- a/Source/ui_qt/memorycardmanagerdialog.cpp
+++ b/Source/ui_qt/memorycardmanagerdialog.cpp
@@ -117,7 +117,7 @@ void MemoryCardManagerDialog::on_savelistWidget_currentRowChanged(int currentRow
 	{
 		const CSave* save = m_pCurrentMemoryCard->GetSaveByIndex(saveIndex);
 		QDateTime* dt = new QDateTime;
-		dt->setTime_t(save->GetLastModificationTime());
+		dt->setSecsSinceEpoch(save->GetLastModificationTime());
 		QString datetime = dt->toUTC().toString("hh:mm - dd.MM.yyyy");
 
 		ui->label_name->setText(QString::fromWCharArray(save->GetName()));


### PR DESCRIPTION
few changes to allow forward compatability with Qt6.

though we probably dont want to move to it anytime soon, 32bit prebuilds has been dropped (though I dont believe official support is dropped, yet, so we can build from source (or wait until someone eventually does XD)).

to build with Qt6, you'd need to replace emu ui + debugger ui cmake `Qt5` & `QT5` replaces with `Qt6` & `QT6`