### PR TITLE
Handle retrieving root file record via dot

### DIFF
--- a/Source/iop/ioman/OpticalMediaDevice.cpp
+++ b/Source/iop/ioman/OpticalMediaDevice.cpp
@@ -48,6 +48,8 @@ DirectoryIteratorPtr COpticalMediaDevice::GetDirectory(const char* devicePath)
 	if(!m_opticalMedia) return nullptr;
 	std::string fixedString(devicePath);
 	std::transform(fixedString.begin(), fixedString.end(), fixedString.begin(), &COpticalMediaDevice::FixSlashes);
+	fixedString.erase(fixedString.find_last_not_of('.') + 1); // Remove trailing dot, if there is any
+
 	auto fileSystem = m_opticalMedia->GetFileSystem();
 	auto directoryStream = fileSystem->OpenDirectory(fixedString.c_str());
 	if(directoryStream == nullptr)


### PR DESCRIPTION
Fixes Constantine not booting.

I'm not entirely sure if this is the most elegant solution, but it works. The alternative could be to store the root entry via "." instead of "", but maybe this could break other games?