### PR TITLE
Removed the Baldur's Gate patch

### DIFF
--- a/patches.xml
+++ b/patches.xml
@@ -1,8 +1,4 @@
 <Patches>
-	<Executable Name="SLES_506.72;1" Title="Baldur's Gate: Dark Alliance" Region="EU">
-		<Patch Address="0x00300478" Value="0x00000001" Description="Enable libcdvd tracing."/>
-	</Executable>
-	
 	<Executable Name="SLES_501.76;1" Title="Oni" Region="EU">
 		<Patch Address="0x001cef7c" Value="0x00000000 // bc0f $001cef7c" Description="Fix hang by skip branch if copro 0 condition false." />
 	</Executable>


### PR DESCRIPTION
It was used for debugging purposes in the past, no longer needed to make the game work properly