### PR TITLE
N246 additions

### DIFF
--- a/Source/iop/Iop_NamcoArcade.cpp
+++ b/Source/iop/Iop_NamcoArcade.cpp
@@ -327,8 +327,6 @@ void CNamcoArcade::ProcessJvsPacket(const uint8* input, uint8* output)
 
 			(*output++) = 0x01; //Command success
 
-			//(*output++) = 0x00; //Coin 1 MSB
-			//(*output++) = 0x00; //Coin 1 LSB
 			(*output++) = static_cast<uint8>(((m_coin1 >> 8) & 0x3f) | (slot1Condition << 6)); //Coin 1 MSB + slot1condition
 			(*output++) = static_cast<uint8>(m_coin1 & 0x00ff);                                //Coin 1 LSB
 
@@ -336,8 +334,6 @@ void CNamcoArcade::ProcessJvsPacket(const uint8* input, uint8* output)
 
 			if(slotCount == 2)
 			{
-				//(*output++) = 0x00; //Coin 2 MSB
-				//(*output++) = 0x00; //Coin 2 LSB
 				(*output++) = static_cast<uint8>(((m_coin2 >> 8) & 0x3f) | (slot2Condition << 6)); //Coin 2 MSB + slot2condition
 				(*output++) = static_cast<uint8>(m_coin2 & 0x00ff);                                //Coin 2 LSB
 
@@ -580,20 +576,20 @@ void CNamcoArcade::SetAxisState(unsigned int padNumber, PS2::CControllerInfo::BU
 {
 	switch(button)
 	{
-	case 0:
+	case PS2::CControllerInfo::BUTTON::ANALOG_LEFT_X:
 		if(axisValue >= 0 || axisValue < 128) m_jvsWheel = axisValue + 128;
 		if(axisValue > 128 || axisValue < 256) m_jvsWheel = axisValue - 128;
 		m_jvsWheel = axisValue;
 		break;
-	case 1:
+	case PS2::CControllerInfo::BUTTON::ANALOG_LEFT_Y:
 		if(axisValue >= 128) axisValue = 127; // limit Left stick Y axis to Y+
 		m_jvsGaz = -axisValue + 127;
 		break;
-	case 2:
+	case PS2::CControllerInfo::BUTTON::ANALOG_RIGHT_X:
 		if(axisValue < 128) axisValue = 128; // limit Right stick X axis to X+
 		m_jvsBrake = axisValue - 128;
 		break;
-	case 3:
+	case PS2::CControllerInfo::BUTTON::ANALOG_RIGHT_Y:
 		break;
 	default:
 		break;

--- a/Source/iop/Iop_NamcoArcade.cpp
+++ b/Source/iop/Iop_NamcoArcade.cpp
@@ -281,16 +281,16 @@ void CNamcoArcade::ProcessJvsPacket(const uint8* input, uint8* output)
 			inWorkChecksum += playerCount;
 			inWorkChecksum += byteCount;
 			inSize -= 2;
-			
+
 			(*output++) = 0x01; //Command success
 
 			m_counter++;
-			if(m_testButtonState == 0 && m_jvsSystemButtonState == 0x03 && m_counter>16)
+			if(m_testButtonState == 0 && m_jvsSystemButtonState == 0x03 && m_counter > 16)
 			{
 				m_testButtonState = 0x80;
 				m_counter = 0;
 			}
-			else if(m_testButtonState == 0x80 && m_jvsSystemButtonState == 0x03 && m_counter>16)
+			else if(m_testButtonState == 0x80 && m_jvsSystemButtonState == 0x03 && m_counter > 16)
 			{
 				m_testButtonState = 0;
 				m_counter = 0;
@@ -341,7 +341,7 @@ void CNamcoArcade::ProcessJvsPacket(const uint8* input, uint8* output)
 			}
 		}
 		break;
-		case JVS_CMD_COININC:	// actually never received this jvs cmd
+		case JVS_CMD_COININC: // actually never received this jvs cmd
 		{
 			assert(inSize != 3);
 			uint8 slotCount = (*input++);
@@ -361,7 +361,7 @@ void CNamcoArcade::ProcessJvsPacket(const uint8* input, uint8* output)
 			(*dstSize) += 1;
 		}
 		break;
-		case JVS_CMD_COINDEC:	// actually never received this jvs cmd
+		case JVS_CMD_COINDEC: // actually never received this jvs cmd
 		{
 			assert(inSize != 3);
 			uint8 slotCount = (*input++);

--- a/Source/iop/Iop_NamcoArcade.h
+++ b/Source/iop/Iop_NamcoArcade.h
@@ -25,6 +25,7 @@ namespace Iop
 			DEFAULT,
 			LIGHTGUN,
 			DRUM,
+			DRIVE,
 		};
 
 		CNamcoArcade(CSifMan&, CSifCmd&, Namco::CAcRam&, const std::string&);
@@ -84,6 +85,14 @@ namespace Iop
 			JVS_DRUM_CHANNEL_MAX,
 		};
 
+		enum JVS_WHEEL_CHANNELS
+		{
+			JVS_WHEEL_CHANNEL_WHEEL,
+			JVS_WHEEL_CHANNEL_GAZ,
+			JVS_WHEEL_CHANNEL_BRAKE,
+			JVS_WHEEL_CHANNEL_MAX,
+		};
+
 		bool Invoke001(uint32, uint32*, uint32, uint32*, uint32, uint8*);
 		bool Invoke003(uint32, uint32*, uint32, uint32*, uint32, uint8*);
 		bool Invoke004(uint32, uint32*, uint32, uint32*, uint32, uint8*);
@@ -116,5 +125,13 @@ namespace Iop
 		uint16 m_jvsGunPosX = 0x7FFF;
 		uint16 m_jvsGunPosY = 0x7FFF;
 		uint16 m_jvsDrumChannels[JVS_DRUM_CHANNEL_MAX] = {};
+		uint16 m_jvsWheelChannels[JVS_WHEEL_CHANNEL_MAX] = {};
+		uint16 m_jvsWheel = 0x0;
+		uint16 m_jvsGaz = 0x0;
+		uint16 m_jvsBrake = 0x0;
+		uint16 m_coin1;
+		uint16 m_coin2;
+		uint8 m_testButtonState = 0;
+		uint8 m_counter = 0;
 	};
 }

--- a/Source/ui_shared/ArcadeUtils.cpp
+++ b/Source/ui_shared/ArcadeUtils.cpp
@@ -24,6 +24,7 @@ struct ARCADE_MACHINE_DEF
 		DEFAULT,
 		LIGHTGUN,
 		DRUM,
+		DRIVE,
 	};
 
 	struct PATCH
@@ -73,6 +74,7 @@ static const std::pair<const char*, ARCADE_MACHINE_DEF::INPUT_MODE> g_inputModeV
 	{ "default", ARCADE_MACHINE_DEF::INPUT_MODE::DEFAULT },
 	{ "lightgun", ARCADE_MACHINE_DEF::INPUT_MODE::LIGHTGUN },
 	{ "drum", ARCADE_MACHINE_DEF::INPUT_MODE::DRUM },
+	{ "drive", ARCADE_MACHINE_DEF::INPUT_MODE::DRIVE },
 };
 // clang-format on
 
@@ -299,6 +301,9 @@ void PrepareArcadeEnvironment(CPS2VM* virtualMachine, const ARCADE_MACHINE_DEF& 
 				break;
 			case ARCADE_MACHINE_DEF::INPUT_MODE::DRUM:
 				namcoArcadeModule->SetJvsMode(Iop::CNamcoArcade::JVS_MODE::DRUM);
+				break;
+			case ARCADE_MACHINE_DEF::INPUT_MODE::DRIVE:
+				namcoArcadeModule->SetJvsMode(Iop::CNamcoArcade::JVS_MODE::DRIVE);
 				break;
 			default:
 				break;

--- a/arcadedefs/acedriv3.arcadedef
+++ b/arcadedefs/acedriv3.arcadedef
@@ -1,0 +1,18 @@
+{
+	"id": "acedriv3",
+	"name": "Ace Driver 3: Final Turn",
+	"dongle":
+	{
+		"name": "adt1005-na-a.ic002"
+	},
+	"hdd":
+	{
+		"name": "adt1005-na-hdd0a.chd"
+	},
+	"inputMode": "drive",
+	"boot": "mc0:NRALOAD",
+        "eeFrequencyScale": [4, 3],
+	"patches":
+	[
+	]
+}

--- a/arcadedefs/motogp.arcadedef
+++ b/arcadedefs/motogp.arcadedef
@@ -9,6 +9,7 @@
 	{
 		"name": "mgp1004-na-hdd0-a.chd"
 	},
+	"inputMode": "drive",
 	"boot": "ac0:MGPLOAD",
 	"patches":
 	[

--- a/arcadedefs/rrvac.arcadedef
+++ b/arcadedefs/rrvac.arcadedef
@@ -9,6 +9,7 @@
 	{
 		"name": "rrv1-a.chd"
 	},
+	"inputMode": "drive",
 	"boot": "ac0:START",
 	"patches":
 	[

--- a/arcadedefs/wanganmd.arcadedef
+++ b/arcadedefs/wanganmd.arcadedef
@@ -9,6 +9,7 @@
 	{
 		"name": "wmn1-a.chd"
 	},
+	"inputMode": "drive",
 	"boot": "ac0:WGNLOAD",
 	"patches":
 	[

--- a/arcadedefs/wanganmr.arcadedef
+++ b/arcadedefs/wanganmr.arcadedef
@@ -9,6 +9,7 @@
 	{
 		"name": "wmr1-a.chd"
 	},
+	"inputMode": "drive",
 	"boot": "ac0:AL3LOAD",
 	"patches":
 	[


### PR DESCRIPTION
Add drive inputmode.
Add jvs analog for drive inputmode (limiting to LSY+ for accel and to RSX+ for brake).
Add jvs coin managment despite never receiving jvs coin inc/dec cmd.
Resolve missing button4 (tekken) (located on R3).
Latching test button.
Just added acedriver3 arcadedef file (not my work).
