### PR TITLE
Add Idolm@ster arcadedefs

### DIFF
--- a/arcadedefs/idolm.arcadedef
+++ b/arcadedefs/idolm.arcadedef
@@ -1,0 +1,17 @@
+{
+	"id": "idolm",
+	"name": "The iDOLM@STER/偶像大师",
+	"dongle":
+	{
+		"name": "NM00022 IDMT1, Ver.D a026061342184a [Tower] [Rebuilt].bin"
+	},
+	"hdd":
+	{
+		"name": "NM00022 IDM1-HA (HDD).chd"
+	},
+	"eeFrequencyScale": [4, 3],
+	"boot": "ac0:IDLLOAD",
+	"patches":
+	[
+	]
+}

--- a/arcadedefs/idolm.arcadedef
+++ b/arcadedefs/idolm.arcadedef
@@ -3,7 +3,7 @@
 	"name": "The iDOLM@STER/偶像大师",
 	"dongle":
 	{
-		"name": "NM00022 IDMT1, Ver.D a026061342184a [Tower] [Rebuilt].bin"
+		"name": "NM00022 IDMS1, Ver.D a026061343464a [Station].bin"
 	},
 	"hdd":
 	{

--- a/arcadedefs/idolmtower.arcadedef
+++ b/arcadedefs/idolmtower.arcadedef
@@ -1,0 +1,17 @@
+{
+	"id": "idolm",
+	"name": "The iDOLM@STER/偶像大师",
+	"dongle":
+	{
+		"name": "NM00022 IDMT1, Ver.D a026061342184a [Tower] [Rebuilt].bin"
+	},
+	"hdd":
+	{
+		"name": "NM00022 IDM1-HA (HDD).chd"
+	},
+	"eeFrequencyScale": [4, 3],
+	"boot": "ac0:IDLLOAD",
+	"patches":
+	[
+	]
+}


### PR DESCRIPTION
Added the arcadedefs that are working right now for Idolm@ster. It shares the same HDD with the two types of cabinet of the game, as the dongle is the responsible for deciding which version will it run (Tower or Station).

The main game happens in the Station cabinet, while the Tower shows the nationwide rankings runs a permanent Attract Mode.

As it goes, the Tower functions even without the implementation of Touchscreen support, while the Station still needs the Card RW module and Touchscreen support to be played.