### PR TITLE
Fix dipswitch documentation

### DIFF
--- a/Source/iop/Iop_NamcoArcade.cpp
+++ b/Source/iop/Iop_NamcoArcade.cpp
@@ -776,7 +776,7 @@ void CNamcoArcade::ProcessMemRequest(uint8* ram, uint32 infoPtr)
 			//0x80 -> Test Mode
 			//0x40 -> Output Level (Voltage) of Video Signal
 			//0x20 -> Monitor Sync Frequency (1: 31Khz or 0: 15Khz)
-			//0x10 -> Video Sync Signal (1: Composite Sync or 0: Separate Sync)
+			//0x10 -> Video Sync Signal (1: Separate Sync or 0: Composite Sync)
 			//ram[recvDataPtr + 0x30] = 0;
 
 			uint16 pktId = sendData[0x0C];


### PR DESCRIPTION
I'm not sure what manual https://www.arcade-projects.com/threads/yet-another-256-display-issue.2792/#post-37365 is from, but they appear to have gotten the setting for switch 4 wrong; OFF sets composite sync, and ON sets separate sync. The diagram above even correctly shows this, as all (or at least most) games shipped with all switches set to off for 15khz, and switches 2-4 are all meant to be flipped up for 31khz. Backed up against the F/UC operator's manual (link at https://www.arcade-projects.com/threads/fate-unlimited-codes-japanese-manual-pdf.7799/, direct link https://mega.nz/#!shwzSY5K!E1gzeJaA6oGHNqARNBvsmJB1LlsF6qO6Z9Ke4vLQJ_U in case it's taken down)
![fateswitch](https://github.com/jpd002/Play-/assets/50224630/9df074a8-1ae0-4108-b243-81d8cfa1d892)
