### PR TITLE
[WIP] Touchscreen Support

### DIFF
--- a/Source/AnalogueListener.h
+++ b/Source/AnalogueListener.h
@@ -1,0 +1,8 @@
+#pragma once
+
+class CAnalogueListener
+{
+public:
+	virtual ~CAnalogueListener() = default;
+	virtual void SetAnaloguePosition(float, float) = 0;
+};

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -241,7 +241,7 @@ set(COMMON_SRC_FILES
 	FrameDump.h
 	FrameLimiter.cpp
 	FrameLimiter.h
-	GunListener.h
+	AnalogueListener.h
 	InputConfig.cpp
 	InputConfig.h
 	GenericMipsExecutor.h

--- a/Source/GunListener.h
+++ b/Source/GunListener.h
@@ -1,8 +1,0 @@
-#pragma once
-
-class CGunListener
-{
-public:
-	virtual ~CGunListener() = default;
-	virtual void SetGunPosition(float, float) = 0;
-};

--- a/Source/PS2VM.cpp
+++ b/Source/PS2VM.cpp
@@ -128,21 +128,21 @@ CPadHandler* CPS2VM::GetPadHandler()
 	return m_pad;
 }
 
-bool CPS2VM::HasGunListener() const
+bool CPS2VM::HasAnalogueListener() const
 {
-	return m_gunListener != nullptr;
+	return m_analogueListener != nullptr;
 }
 
-void CPS2VM::SetGunListener(CGunListener* listener)
+void CPS2VM::SetAnalogueListener(CAnalogueListener* listener)
 {
-	m_gunListener = listener;
+	m_analogueListener = listener;
 }
 
-void CPS2VM::ReportGunPosition(float x, float y)
+void CPS2VM::ReportAnaloguePosition(float x, float y)
 {
-	if(m_gunListener)
+	if(m_analogueListener)
 	{
-		m_gunListener->SetGunPosition(x, y);
+		m_analogueListener->SetAnaloguePosition(x, y);
 	}
 }
 
@@ -493,7 +493,7 @@ void CPS2VM::ResetVM()
 	m_iop->m_spuCore1.SetDestinationSamplingRate(DST_SAMPLE_RATE);
 
 	RegisterModulesInPadHandler();
-	m_gunListener = nullptr;
+	m_analogueListener = nullptr;
 }
 
 void CPS2VM::DestroyVM()

--- a/Source/PS2VM.h
+++ b/Source/PS2VM.h
@@ -7,7 +7,7 @@
 #include "MIPS.h"
 #include "MailBox.h"
 #include "PadHandler.h"
-#include "GunListener.h"
+#include "AnalogueListener.h"
 #include "OpticalMedia.h"
 #include "VirtualMachine.h"
 #include "ee/Ee_SubSystem.h"
@@ -89,9 +89,9 @@ public:
 	void SaveDebugTags(const char*);
 #endif
 
-	void ReportGunPosition(float, float);
-	bool HasGunListener() const;
-	void SetGunListener(CGunListener*);
+	void ReportAnaloguePosition(float, float);
+	bool HasAnalogueListener() const;
+	void SetAnalogueListener(CAnalogueListener*);
 
 	OpticalMediaPtr m_cdrom0;
 	CPadHandler* m_pad = nullptr;
@@ -199,7 +199,7 @@ private:
 	int m_spuBlockCount = 0;
 	CSoundHandler* m_soundHandler = nullptr;
 
-	CGunListener* m_gunListener = nullptr;
+	CAnalogueListener* m_analogueListener = nullptr;
 
 	CProfiler::ZoneHandle m_eeProfilerZone = 0;
 	CProfiler::ZoneHandle m_iopProfilerZone = 0;

--- a/Source/iop/Iop_NamcoArcade.cpp
+++ b/Source/iop/Iop_NamcoArcade.cpp
@@ -243,6 +243,15 @@ void CNamcoArcade::ProcessJvsPacket(const uint8* input, uint8* output)
 
 				(*dstSize) += 8;
 			}
+			else if(m_jvsMode == JVS_MODE::TOUCHSCREEN)
+			{
+				(*output++) = 0x06; //Screen Pos Input
+				(*output++) = 0x10; //X pos bits
+				(*output++) = 0x10; //Y pos bits
+				(*output++) = 0x01; //channels
+
+				(*dstSize) += 4;
+			}
 			else if(m_jvsMode == JVS_MODE::DRUM)
 			{
 				(*output++) = 0x03;                 //Analog Input
@@ -393,10 +402,18 @@ void CNamcoArcade::ProcessJvsPacket(const uint8* input, uint8* output)
 			if(m_jvsMode == JVS_MODE::LIGHTGUN)
 			{
 				assert(channel == 2);
-				(*output++) = static_cast<uint8>(m_jvsGunPosX >> 8); //Pos X MSB
-				(*output++) = static_cast<uint8>(m_jvsGunPosX);      //Pos X LSB
-				(*output++) = static_cast<uint8>(m_jvsGunPosY >> 8); //Pos Y MSB
-				(*output++) = static_cast<uint8>(m_jvsGunPosY);      //Pos Y LSB
+				(*output++) = static_cast<uint8>(m_jvsAnlPosX >> 8); //Pos X MSB
+				(*output++) = static_cast<uint8>(m_jvsAnlPosX);      //Pos X LSB
+				(*output++) = static_cast<uint8>(m_jvsAnlPosY >> 8); //Pos Y MSB
+				(*output++) = static_cast<uint8>(m_jvsAnlPosY);      //Pos Y LSB
+			}
+			else if(m_jvsMode == JVS_MODE::TOUCHSCREEN)
+			{
+				assert(channel == 2);
+				(*output++) = static_cast<uint8>(m_jvsAnlPosX >> 8); //Pos X MSB
+				(*output++) = static_cast<uint8>(m_jvsAnlPosX);      //Pos X LSB
+				(*output++) = static_cast<uint8>(m_jvsAnlPosY >> 8); //Pos Y MSB
+				(*output++) = static_cast<uint8>(m_jvsAnlPosY);      //Pos Y LSB
 			}
 			else if(m_jvsMode == JVS_MODE::DRUM)
 			{
@@ -433,10 +450,10 @@ void CNamcoArcade::ProcessJvsPacket(const uint8* input, uint8* output)
 
 			(*output++) = 0x01; //Command success
 
-			(*output++) = static_cast<uint8>(m_jvsGunPosX >> 8); //Pos X MSB
-			(*output++) = static_cast<uint8>(m_jvsGunPosX);      //Pos X LSB
-			(*output++) = static_cast<uint8>(m_jvsGunPosY >> 8); //Pos Y MSB
-			(*output++) = static_cast<uint8>(m_jvsGunPosY);      //Pos Y LSB
+			(*output++) = static_cast<uint8>(m_jvsAnlPosX >> 8); //Pos X MSB
+			(*output++) = static_cast<uint8>(m_jvsAnlPosX);      //Pos X LSB
+			(*output++) = static_cast<uint8>(m_jvsAnlPosY >> 8); //Pos Y MSB
+			(*output++) = static_cast<uint8>(m_jvsAnlPosY);      //Pos Y LSB
 
 			(*dstSize) += 5;
 		}
@@ -476,9 +493,9 @@ void CNamcoArcade::SetButton(unsigned int buttonIndex, PS2::CControllerInfo::BUT
 	m_jvsButtonBits[buttonValue] = (1 << buttonIndex);
 }
 
-void CNamcoArcade::SetAnalogueXform(const std::array<float, 4>& lightGunXform)
+void CNamcoArcade::SetAnalogueXform(const std::array<float, 4>& analogueXform)
 {
-	m_lightGunXform = lightGunXform;
+	m_analogueXform = analogueXform;
 }
 
 void CNamcoArcade::SetButtonState(unsigned int padNumber, PS2::CControllerInfo::BUTTON button, bool pressed, uint8* ram)
@@ -596,10 +613,10 @@ void CNamcoArcade::SetAxisState(unsigned int padNumber, PS2::CControllerInfo::BU
 	}
 }
 
-void CNamcoArcade::SetGunPosition(float x, float y)
+void CNamcoArcade::SetAnaloguePosition(float x, float y)
 {
-	m_jvsGunPosX = static_cast<int16>((x * m_lightGunXform[0]) + m_lightGunXform[1]);
-	m_jvsGunPosY = static_cast<int16>((y * m_lightGunXform[2]) + m_lightGunXform[3]);
+	m_jvsAnlPosX = static_cast<int16>((x * m_analogueXform[0]) + m_analogueXform[1]);
+	m_jvsAnlPosY = static_cast<int16>((y * m_analogueXform[2]) + m_analogueXform[3]);
 }
 
 bool CNamcoArcade::Invoke001(uint32 method, uint32* args, uint32 argsSize, uint32* ret, uint32 retSize, uint8* ram)

--- a/Source/iop/Iop_NamcoArcade.cpp
+++ b/Source/iop/Iop_NamcoArcade.cpp
@@ -476,7 +476,7 @@ void CNamcoArcade::SetButton(unsigned int buttonIndex, PS2::CControllerInfo::BUT
 	m_jvsButtonBits[buttonValue] = (1 << buttonIndex);
 }
 
-void CNamcoArcade::SetLightGunXform(const std::array<float, 4>& lightGunXform)
+void CNamcoArcade::SetAnalogueXform(const std::array<float, 4>& lightGunXform)
 {
 	m_lightGunXform = lightGunXform;
 }

--- a/Source/iop/Iop_NamcoArcade.h
+++ b/Source/iop/Iop_NamcoArcade.h
@@ -5,7 +5,7 @@
 #include "Iop_SifMan.h"
 #include "../SifModuleAdapter.h"
 #include "../PadListener.h"
-#include "../GunListener.h"
+#include "../AnalogueListener.h"
 #include "filesystem_def.h"
 
 namespace Iop
@@ -17,13 +17,14 @@ namespace Iop
 		class CAcRam;
 	}
 
-	class CNamcoArcade : public CModule, public CPadListener, public CGunListener
+	class CNamcoArcade : public CModule, public CPadListener, public CAnalogueListener
 	{
 	public:
 		enum class JVS_MODE
 		{
 			DEFAULT,
 			LIGHTGUN,
+			TOUCHSCREEN,
 			DRUM,
 			DRIVE,
 		};
@@ -46,8 +47,8 @@ namespace Iop
 		void SetButtonState(unsigned int, PS2::CControllerInfo::BUTTON, bool, uint8*) override;
 		void SetAxisState(unsigned int, PS2::CControllerInfo::BUTTON, uint8, uint8*) override;
 
-		//CGunListener
-		void SetGunPosition(float, float) override;
+		//CAnalogueListener
+		void SetAnaloguePosition(float, float) override;
 
 	private:
 		enum MODULE_ID
@@ -117,13 +118,13 @@ namespace Iop
 		uint32 m_sendAddr = 0;
 
 		JVS_MODE m_jvsMode = JVS_MODE::DEFAULT;
-		std::array<float, 4> m_lightGunXform = {65535, 0, 65535, 0};
+		std::array<float, 4> m_analogueXform = {65535, 0, 65535, 0};
 
 		std::array<uint16, PS2::CControllerInfo::MAX_BUTTONS> m_jvsButtonBits = {};
 		uint16 m_jvsButtonState[JVS_PLAYER_COUNT] = {};
 		uint16 m_jvsSystemButtonState = 0;
-		uint16 m_jvsGunPosX = 0x7FFF;
-		uint16 m_jvsGunPosY = 0x7FFF;
+		uint16 m_jvsAnlPosX = 0x7FFF;
+		uint16 m_jvsAnlPosY = 0x7FFF;
 		uint16 m_jvsDrumChannels[JVS_DRUM_CHANNEL_MAX] = {};
 		uint16 m_jvsWheelChannels[JVS_WHEEL_CHANNEL_MAX] = {};
 		uint16 m_jvsWheel = 0x0;

--- a/Source/iop/Iop_NamcoArcade.h
+++ b/Source/iop/Iop_NamcoArcade.h
@@ -40,7 +40,7 @@ namespace Iop
 
 		void SetJvsMode(JVS_MODE);
 		void SetButton(unsigned int, PS2::CControllerInfo::BUTTON);
-		void SetLightGunXform(const std::array<float, 4>&);
+		void SetAnalogueXform(const std::array<float, 4>&);
 
 		//CPadListener
 		void SetButtonState(unsigned int, PS2::CControllerInfo::BUTTON, bool, uint8*) override;

--- a/Source/ui_qt/mainwindow.cpp
+++ b/Source/ui_qt/mainwindow.cpp
@@ -829,7 +829,7 @@ void MainWindow::focusInEvent(QFocusEvent* event)
 
 void MainWindow::outputWindow_doubleClickEvent(QMouseEvent* ev)
 {
-	if(!m_virtualMachine->HasGunListener() && (ev->button() == Qt::LeftButton))
+	if(!m_virtualMachine->HasAnalogueListener() && (ev->button() == Qt::LeftButton))
 	{
 		on_actionToggleFullscreen_triggered();
 	}
@@ -837,7 +837,7 @@ void MainWindow::outputWindow_doubleClickEvent(QMouseEvent* ev)
 
 void MainWindow::outputWindow_mouseMoveEvent(QMouseEvent* ev)
 {
-	if(m_virtualMachine->HasGunListener())
+	if(m_virtualMachine->HasAnalogueListener())
 	{
 		auto gsHandler = m_virtualMachine->GetGSHandler();
 		if(!gsHandler) return;
@@ -856,7 +856,7 @@ void MainWindow::outputWindow_mouseMoveEvent(QMouseEvent* ev)
 		mouseY -= vpOfsY;
 		mouseX = std::clamp<float>(mouseX, 0, vpWidth);
 		mouseY = std::clamp<float>(mouseY, 0, vpHeight);
-		m_virtualMachine->ReportGunPosition(
+		m_virtualMachine->ReportAnaloguePosition(
 		    static_cast<float>(mouseX) / static_cast<float>(vpWidth),
 		    static_cast<float>(mouseY) / static_cast<float>(vpHeight));
 	}
@@ -865,11 +865,23 @@ void MainWindow::outputWindow_mouseMoveEvent(QMouseEvent* ev)
 void MainWindow::outputWindow_mousePressEvent(QMouseEvent* ev)
 {
 	m_qtMouseInputProvider->OnMousePress(ev->button());
+	if(m_virtualMachine->HasAnalogueListener())
+	{
+		m_virtualMachine->ReportTouchPress(
+			// TODO: Set tap to true
+		)
+	}
 }
 
 void MainWindow::outputWindow_mouseReleaseEvent(QMouseEvent* ev)
 {
 	m_qtMouseInputProvider->OnMouseRelease(ev->button());
+	if(m_virtualMachine->HasAnalogueListener())
+	{
+		m_virtualMachine->ReportTouchRelease(
+			// TODO: Set tap to false
+		)
+	}
 }
 
 void MainWindow::on_actionToggleFullscreen_triggered()

--- a/Source/ui_shared/ArcadeUtils.cpp
+++ b/Source/ui_shared/ArcadeUtils.cpp
@@ -309,7 +309,7 @@ void PrepareArcadeEnvironment(CPS2VM* virtualMachine, const ARCADE_MACHINE_DEF& 
 			case ARCADE_MACHINE_DEF::INPUT_MODE::LIGHTGUN:
 				virtualMachine->SetGunListener(namcoArcadeModule.get());
 				namcoArcadeModule->SetJvsMode(Iop::CNamcoArcade::JVS_MODE::LIGHTGUN);
-				namcoArcadeModule->SetLightGunXform(def.lightGunXform);
+				namcoArcadeModule->SetAnalogueXform(def.lightGunXform);
 				break;
 			case ARCADE_MACHINE_DEF::INPUT_MODE::DRUM:
 				namcoArcadeModule->SetJvsMode(Iop::CNamcoArcade::JVS_MODE::DRUM);

--- a/arcadedefs/cobrata.arcadedef
+++ b/arcadedefs/cobrata.arcadedef
@@ -14,7 +14,7 @@
 		"3": "circle"
 	},
 	"inputMode": "lightgun",
-	"lightGunXform": [ -65535, 0, 65535, 0 ],
+	"analogueXform": [ -65535, 0, 65535, 0 ],
 	"eeFrequencyScale": [4, 3],
 	"boot": "ac0:CBRLOAD",
 	"patches":

--- a/arcadedefs/idolm.arcadedef
+++ b/arcadedefs/idolm.arcadedef
@@ -9,6 +9,8 @@
 	{
 		"name": "NM00022 IDM1-HA (HDD).chd"
 	},
+	"inputMode": "lightgun",
+	"analogueXform": [ 65535, 0, -65535, 0 ],
 	"eeFrequencyScale": [4, 3],
 	"boot": "ac0:IDLLOAD",
 	"patches":

--- a/arcadedefs/idolmtower.arcadedef
+++ b/arcadedefs/idolmtower.arcadedef
@@ -1,6 +1,6 @@
 {
-	"id": "idolmtower",
-	"name": "The iDOLM@STER/偶像大师 (Tower)",
+	"id": "idolm",
+	"name": "The iDOLM@STER/偶像大师",
 	"dongle":
 	{
 		"name": "NM00022 IDMT1, Ver.D a026061342184a [Tower] [Rebuilt].bin"
@@ -9,6 +9,8 @@
 	{
 		"name": "NM00022 IDM1-HA (HDD).chd"
 	},
+	"inputMode": "touchscreen",
+	"analogueXform": [ 65535, 0, -65535, 0 ],
 	"eeFrequencyScale": [4, 3],
 	"boot": "ac0:IDLLOAD",
 	"patches":

--- a/arcadedefs/timecrs3.arcadedef
+++ b/arcadedefs/timecrs3.arcadedef
@@ -10,7 +10,7 @@
 		"name": "tst1dvd0.chd"
 	},
 	"inputMode": "lightgun",
-	"lightGunXform": [ 660, 16053, 220, 16273 ],
+	"analogueXform": [ 660, 16053, 220, 16273 ],
 	"boot": "ac0:TC3LOAD",
 	"patches":
 	[

--- a/arcadedefs/timecrs3e.arcadedef
+++ b/arcadedefs/timecrs3e.arcadedef
@@ -11,7 +11,7 @@
 		"name": "tst1dvd0.chd"
 	},
 	"inputMode": "lightgun",
-	"lightGunXform": [ 660, 16053, 220, 16273 ],
+	"analogueXform": [ 660, 16053, 220, 16273 ],
 	"boot": "ac0:TC3LOAD",
 	"patches":
 	[

--- a/arcadedefs/timecrs3u.arcadedef
+++ b/arcadedefs/timecrs3u.arcadedef
@@ -11,7 +11,7 @@
 		"name": "tst1dvd0.chd"
 	},
 	"inputMode": "lightgun",
-	"lightGunXform": [ 660, 16053, 220, 16273 ],
+	"analogueXform": [ 660, 16053, 220, 16273 ],
 	"boot": "ac0:TC3LOAD",
 	"patches":
 	[

--- a/arcadedefs/timecrs4.arcadedef
+++ b/arcadedefs/timecrs4.arcadedef
@@ -14,7 +14,7 @@
 		"3": "circle"
 	},
 	"inputMode": "lightgun",
-	"lightGunXform": [ -65535, 0, 65535, 0 ],
+	"analogueXform": [ -65535, 0, 65535, 0 ],
 	"eeFrequencyScale": [3, 2],
 	"boot": "ac0:TC4LOAD",
 	"patches":

--- a/arcadedefs/vnight.arcadedef
+++ b/arcadedefs/vnight.arcadedef
@@ -10,7 +10,7 @@
 		"name": "vpn1cd0.chd"
 	},
 	"inputMode": "lightgun",
-	"lightGunXform": [ 53000, 7000, -48146, 50321 ],
+	"analogueXform": [ 53000, 7000, -48146, 50321 ],
 	"boot": "ac0:VPNGAME",
 	"patches":
 	[


### PR DESCRIPTION
Hi!
Here's a first pass at a touchscreen support implementation. This should work on the Touchscreens found on Idolm@ster (Namco 2X6) & Dragon Chronicle (Namco 2X6). I'll try to test the remainder two games Druaga Online: The Story of Aon & Minna de Kitaeru Zenno Training (this one should work because it seems to be a reutilization of the Idolm@ster's Tower unit).
The idea is that Gun & Touchscreen support derive from the same data: The JVS Analogue Controller, so there goes a little name change to some of the Listeners and Setters to reflect that and making it a little easier to follow up... also an initial creation of the functions needed for the implementation.

TO-DO: Now the [mouse is being followed by a barrage of taps](https://youtu.be/1GK6aECWw88). This is not the expected behaviour, as it should only work when the mouse click is being held down. This is necessary as one of the requirements to activate a [hidden code in Idolm@ster to activate Offline Mode](https://www.idolmaster.jp/imas/arcade/idolmaster_offline.pdf) is to press any spot of the touchscreen for at least 10 seconds.