### PR TITLE
Fix Mailbox potential race condition

### DIFF
--- a/Source/MailBox.cpp
+++ b/Source/MailBox.cpp
@@ -77,6 +77,6 @@ void CMailBox::ReceiveCall()
 	{
 		std::lock_guard<std::mutex> waitLock(m_callMutex);
 		m_callDone = true;
-		m_callFinished.notify_all();
+		m_callFinished.notify_one();
 	}
 }


### PR DESCRIPTION
This might have some performance ramifications, since previously all waits got released once a single call finished.

having said that, I do think emu thread is the only thread that calls on GS, so if its waiting, calling all or once is all the same and will have no impact or notable change at that.