### PR TITLE
Moderanise Mailbox to use promises and futures

### DIFF
--- a/Source/MailBox.h
+++ b/Source/MailBox.h
@@ -4,6 +4,7 @@
 #include <deque>
 #include <mutex>
 #include <condition_variable>
+#include <future>
 
 class CMailBox
 {
@@ -33,14 +34,12 @@ private:
 		MESSAGE& operator=(const MESSAGE&) = delete;
 
 		FunctionType function;
-		bool sync = false;
+		std::promise<void> promise;
 	};
 
 	typedef std::deque<MESSAGE> FunctionCallQueue;
 
 	FunctionCallQueue m_calls;
 	std::mutex m_callMutex;
-	std::condition_variable m_callFinished;
 	std::condition_variable m_waitCondition;
-	bool m_callDone = false;
 };


### PR DESCRIPTION
1) remove `m_callFinished`/`m_callDone`
    * future will now handle the waiting
 2) `sync` replaced with `promise`
    * simplify sync logic
       * delegating the logic to the future (if was created)