### PR TITLE
Update on input

### DIFF
--- a/Source/input/InputBindingManager.h
+++ b/Source/input/InputBindingManager.h
@@ -13,6 +13,7 @@ class CInputBindingManager
 {
 public:
 	using ProviderPtr = std::shared_ptr<CInputProvider>;
+	using ProviderConnectionMap = std::map<uint32, CInputProvider::OnInputSignalConnection>;
 
 	enum
 	{
@@ -50,7 +51,7 @@ public:
 	bool HasBindings() const;
 
 	void RegisterInputProvider(const ProviderPtr&);
-	void OverrideInputEventHandler(const InputEventFunction&);
+	ProviderConnectionMap OverrideInputEventHandler(const InputEventFunction&);
 
 	std::string GetTargetDescription(const BINDINGTARGET&) const;
 
@@ -159,4 +160,5 @@ private:
 
 	std::unique_ptr<CInputConfig> m_config;
 	ProviderMap m_providers;
+	ProviderConnectionMap m_providersConnection;
 };

--- a/Source/input/InputBindingManager.h
+++ b/Source/input/InputBindingManager.h
@@ -12,7 +12,7 @@
 class CInputBindingManager
 {
 public:
-	typedef std::shared_ptr<CInputProvider> ProviderPtr;
+	using ProviderPtr = std::shared_ptr<CInputProvider>;
 
 	enum
 	{
@@ -147,8 +147,8 @@ private:
 		uint32 m_key2State = 0;
 	};
 
-	typedef std::shared_ptr<CBinding> BindingPtr;
-	typedef std::map<uint32, ProviderPtr> ProviderMap;
+	using BindingPtr = std::shared_ptr<CBinding>;
+	using ProviderMap = std::map<uint32, ProviderPtr>;
 
 	void OnInputEventReceived(const BINDINGTARGET&, uint32);
 

--- a/Source/input/InputProvider.h
+++ b/Source/input/InputProvider.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Types.h"
+#include "signal/Signal.h"
 #include <array>
 #include <functional>
 #include <string>
@@ -70,5 +71,7 @@ public:
 	virtual uint32 GetId() const = 0;
 	virtual std::string GetTargetDescription(const BINDINGTARGET&) const = 0;
 
-	InputEventFunction OnInput;
+	using OnInputSignal = Framework::CSignal<void(const BINDINGTARGET&, uint32)>;
+	using OnInputSignalConnection = OnInputSignal::Connection;
+	OnInputSignal OnInput;
 };

--- a/Source/ui_js/InputProviderEmscripten.cpp
+++ b/Source/ui_js/InputProviderEmscripten.cpp
@@ -104,12 +104,10 @@ BINDINGTARGET CInputProviderEmscripten::MakeBindingTarget(const EM_UTF8* code)
 
 void CInputProviderEmscripten::OnKeyDown(const EM_UTF8* code)
 {
-	if(!OnInput) return;
 	OnInput(MakeBindingTarget(code), 1);
 }
 
 void CInputProviderEmscripten::OnKeyUp(const EM_UTF8* code)
 {
-	if(!OnInput) return;
 	OnInput(MakeBindingTarget(code), 0);
 }

--- a/Source/ui_qt/ControllerConfig/inputeventselectiondialog.cpp
+++ b/Source/ui_qt/ControllerConfig/inputeventselectiondialog.cpp
@@ -24,7 +24,6 @@ InputEventSelectionDialog::InputEventSelectionDialog(QWidget* parent)
 
 InputEventSelectionDialog::~InputEventSelectionDialog()
 {
-	m_inputManager->OverrideInputEventHandler(InputEventFunction());
 	delete ui;
 }
 
@@ -38,7 +37,7 @@ void InputEventSelectionDialog::Setup(const char* text, CInputBindingManager* in
 	m_qtMouseInputProvider = qtMouseInputProvider;
 	ui->bindinglabel->setText(m_bindingText.arg(m_buttonName));
 
-	m_inputManager->OverrideInputEventHandler([this](auto target, auto value) { this->onInputEvent(target, value); });
+	m_providersOverrideConnection = m_inputManager->OverrideInputEventHandler([this](auto target, auto value) { this->onInputEvent(target, value); });
 	connect(this, SIGNAL(countdownComplete()), this, SLOT(confirmBinding()));
 }
 

--- a/Source/ui_qt/ControllerConfig/inputeventselectiondialog.h
+++ b/Source/ui_qt/ControllerConfig/inputeventselectiondialog.h
@@ -57,6 +57,8 @@ private:
 	CInputBindingManager::BINDINGTYPE m_bindingType = CInputBindingManager::BINDING_UNBOUND;
 	uint32 m_bindingValue = 0;
 
+	CInputBindingManager::ProviderConnectionMap m_providersOverrideConnection;
+
 	QString m_bindingText = QString("Select new binding for\n%1");
 	QString m_nextbindingText = QString("Select axis negative binding for\n%1");
 	QString m_countingText = QString("Press & Hold Button for %1 Seconds to assign key");

--- a/Source/ui_qt/InputProviderQtKey.cpp
+++ b/Source/ui_qt/InputProviderQtKey.cpp
@@ -24,12 +24,10 @@ BINDINGTARGET CInputProviderQtKey::MakeBindingTarget(int keyCode)
 
 void CInputProviderQtKey::OnKeyPress(int keyCode)
 {
-	if(!OnInput) return;
 	OnInput(MakeBindingTarget(keyCode), 1);
 }
 
 void CInputProviderQtKey::OnKeyRelease(int keyCode)
 {
-	if(!OnInput) return;
 	OnInput(MakeBindingTarget(keyCode), 0);
 }

--- a/Source/ui_qt/InputProviderQtMouse.cpp
+++ b/Source/ui_qt/InputProviderQtMouse.cpp
@@ -33,12 +33,10 @@ BINDINGTARGET CInputProviderQtMouse::MakeBindingTarget(Qt::MouseButton mouseButt
 
 void CInputProviderQtMouse::OnMousePress(Qt::MouseButton mouseButton)
 {
-	if(!OnInput) return;
 	OnInput(MakeBindingTarget(mouseButton), 1);
 }
 
 void CInputProviderQtMouse::OnMouseRelease(Qt::MouseButton mouseButton)
 {
-	if(!OnInput) return;
 	OnInput(MakeBindingTarget(mouseButton), 0);
 }

--- a/Source/ui_qt/macos/InputProviderMacOsHid.cpp
+++ b/Source/ui_qt/macos/InputProviderMacOsHid.cpp
@@ -129,18 +129,13 @@ void CInputProviderMacOsHid::OnDeviceMatched(IOReturn result, void* sender, IOHI
 	}
 	else
 	{
-		if(OnInput)
-		{
-			SetInitialBindValues(device);
-		}
+		SetInitialBindValues(device);
 		IOHIDDeviceRegisterInputValueCallback(device, &InputValueCallbackStub, &deviceInfo);
 	}
 }
 
 void CInputProviderMacOsHid::InputValueCallback(DEVICE_INFO* deviceInfo, IOReturn result, void* sender, IOHIDValueRef valueRef)
 {
-	if(!OnInput) return;
-
 	IOHIDElementRef elementRef = IOHIDValueGetElement(valueRef);
 	uint32 usagePage = IOHIDElementGetUsagePage(elementRef);
 	if(
@@ -181,42 +176,39 @@ void CInputProviderMacOsHid::InputReportCallback_DS3(DEVICE_INFO* deviceInfo, IO
 		OnInput(tgt, new_btn_state->btn);                                    \
 	}
 
-	if(OnInput)
-	{
-		deviceInfo->first_run = false;
+	deviceInfo->first_run = false;
 
-		checkbtnstate(prev_btn_state, new_btn_state, Select, 1, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, L3, 2, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, R3, 3, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, Start, 4, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, Select, 1, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, L3, 2, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, R3, 3, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, Start, 4, BINDINGTARGET::KEYTYPE::BUTTON);
 
-		checkbtnstate(prev_btn_state, new_btn_state, DPadU, 5, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, DPadR, 6, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, DPadD, 7, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, DPadL, 8, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, DPadU, 5, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, DPadR, 6, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, DPadD, 7, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, DPadL, 8, BINDINGTARGET::KEYTYPE::BUTTON);
 
-		checkbtnstate(prev_btn_state, new_btn_state, R2, 9, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, L2, 10, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, R1, 11, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, L1, 12, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, R2, 9, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, L2, 10, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, R1, 11, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, L1, 12, BINDINGTARGET::KEYTYPE::BUTTON);
 
-		checkbtnstate(prev_btn_state, new_btn_state, PSHome, 13, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, PSHome, 13, BINDINGTARGET::KEYTYPE::BUTTON);
 
-		checkbtnstate(prev_btn_state, new_btn_state, LX, 14, BINDINGTARGET::KEYTYPE::AXIS);
-		checkbtnstate(prev_btn_state, new_btn_state, LY, 15, BINDINGTARGET::KEYTYPE::AXIS);
-		checkbtnstate(prev_btn_state, new_btn_state, RX, 16, BINDINGTARGET::KEYTYPE::AXIS);
-		checkbtnstate(prev_btn_state, new_btn_state, RY, 17, BINDINGTARGET::KEYTYPE::AXIS);
+	checkbtnstate(prev_btn_state, new_btn_state, LX, 14, BINDINGTARGET::KEYTYPE::AXIS);
+	checkbtnstate(prev_btn_state, new_btn_state, LY, 15, BINDINGTARGET::KEYTYPE::AXIS);
+	checkbtnstate(prev_btn_state, new_btn_state, RX, 16, BINDINGTARGET::KEYTYPE::AXIS);
+	checkbtnstate(prev_btn_state, new_btn_state, RY, 17, BINDINGTARGET::KEYTYPE::AXIS);
 
-		//checkbtnstate(prev_btn_state, new_btn_state, L2T, 18, 3);
-		//checkbtnstate(prev_btn_state, new_btn_state, R2T, 19, 3);
-		//checkbtnstate(prev_btn_state, new_btn_state, L1T, 20, 3);
-		//checkbtnstate(prev_btn_state, new_btn_state, R1T, 21, 3);
+	//checkbtnstate(prev_btn_state, new_btn_state, L2T, 18, 3);
+	//checkbtnstate(prev_btn_state, new_btn_state, R2T, 19, 3);
+	//checkbtnstate(prev_btn_state, new_btn_state, L1T, 20, 3);
+	//checkbtnstate(prev_btn_state, new_btn_state, R1T, 21, 3);
 
-		checkbtnstate(prev_btn_state, new_btn_state, Triangle, 22, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, Circle, 23, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, Cross, 24, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, Square, 25, BINDINGTARGET::KEYTYPE::BUTTON);
-	}
+	checkbtnstate(prev_btn_state, new_btn_state, Triangle, 22, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, Circle, 23, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, Cross, 24, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, Square, 25, BINDINGTARGET::KEYTYPE::BUTTON);
 #undef checkbtnstate
 
 	if(is_change > 0)
@@ -245,36 +237,34 @@ void CInputProviderMacOsHid::InputReportCallback_DS4(DEVICE_INFO* deviceInfo, IO
 		OnInput(tgt, new_btn_state->btn);                                    \
 	}
 
-	if(OnInput)
-	{
-		deviceInfo->first_run = false;
+	deviceInfo->first_run = false;
 
-		checkbtnstate(prev_btn_state, new_btn_state, LX, 1, BINDINGTARGET::KEYTYPE::AXIS);
-		checkbtnstate(prev_btn_state, new_btn_state, LY, 2, BINDINGTARGET::KEYTYPE::AXIS);
-		checkbtnstate(prev_btn_state, new_btn_state, RX, 3, BINDINGTARGET::KEYTYPE::AXIS);
-		checkbtnstate(prev_btn_state, new_btn_state, RY, 4, BINDINGTARGET::KEYTYPE::AXIS);
+	checkbtnstate(prev_btn_state, new_btn_state, LX, 1, BINDINGTARGET::KEYTYPE::AXIS);
+	checkbtnstate(prev_btn_state, new_btn_state, LY, 2, BINDINGTARGET::KEYTYPE::AXIS);
+	checkbtnstate(prev_btn_state, new_btn_state, RX, 3, BINDINGTARGET::KEYTYPE::AXIS);
+	checkbtnstate(prev_btn_state, new_btn_state, RY, 4, BINDINGTARGET::KEYTYPE::AXIS);
 
-		checkbtnstate(prev_btn_state, new_btn_state, DPad, 5, BINDINGTARGET::KEYTYPE::POVHAT);
-		checkbtnstate(prev_btn_state, new_btn_state, Triangle, 6, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, Circle, 7, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, Cross, 8, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, Square, 9, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, DPad, 5, BINDINGTARGET::KEYTYPE::POVHAT);
+	checkbtnstate(prev_btn_state, new_btn_state, Triangle, 6, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, Circle, 7, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, Cross, 8, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, Square, 9, BINDINGTARGET::KEYTYPE::BUTTON);
 
-		checkbtnstate(prev_btn_state, new_btn_state, L1, 10, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, R1, 11, BINDINGTARGET::KEYTYPE::BUTTON);
-		//checkbtnstate(prev_btn_state, new_btn_state, L2, 12, 1);
-		//checkbtnstate(prev_btn_state, new_btn_state, R2, 13, 1);
+	checkbtnstate(prev_btn_state, new_btn_state, L1, 10, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, R1, 11, BINDINGTARGET::KEYTYPE::BUTTON);
+	//checkbtnstate(prev_btn_state, new_btn_state, L2, 12, 1);
+	//checkbtnstate(prev_btn_state, new_btn_state, R2, 13, 1);
 
-		checkbtnstate(prev_btn_state, new_btn_state, Share, 14, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, Option, 15, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, L3, 16, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, R3, 17, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, Share, 14, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, Option, 15, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, L3, 16, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, R3, 17, BINDINGTARGET::KEYTYPE::BUTTON);
 
-		checkbtnstate(prev_btn_state, new_btn_state, PSHome, 18, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, TouchPad, 19, BINDINGTARGET::KEYTYPE::BUTTON);
-		checkbtnstate(prev_btn_state, new_btn_state, LT, 20, BINDINGTARGET::KEYTYPE::AXIS);
-		checkbtnstate(prev_btn_state, new_btn_state, RT, 21, BINDINGTARGET::KEYTYPE::AXIS);
-	}
+	checkbtnstate(prev_btn_state, new_btn_state, PSHome, 18, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, TouchPad, 19, BINDINGTARGET::KEYTYPE::BUTTON);
+	checkbtnstate(prev_btn_state, new_btn_state, LT, 20, BINDINGTARGET::KEYTYPE::AXIS);
+	checkbtnstate(prev_btn_state, new_btn_state, RT, 21, BINDINGTARGET::KEYTYPE::AXIS);
+
 #undef checkbtnstate
 
 	if(is_change > 0)

--- a/Source/ui_qt/unix/InputProviderEvDev.cpp
+++ b/Source/ui_qt/unix/InputProviderEvDev.cpp
@@ -21,7 +21,6 @@ std::string CInputProviderEvDev::GetTargetDescription(const BINDINGTARGET& targe
 
 void CInputProviderEvDev::OnEvDevInputEvent(GamePadDeviceId deviceId, int code, int value, int type, const input_absinfo* abs)
 {
-	if(!OnInput) return;
 	BINDINGTARGET tgt;
 	tgt.providerId = PROVIDER_ID;
 	tgt.deviceId = deviceId;


### PR DESCRIPTION
Change `OnInput` from a functional pointer to signal, for our use case, signals are better, since they're mutex protected (thread safe), thus reduce race chance, they simplify the code (no (explicit) guarding required), and allows multiple targets to request input.

In Framework, we also added a new call `CSignal<>::ConnectOverride(...)`, which can be used to temporarly redirect events (e.g when configuring gamepads).

Requires: https://github.com/jpd002/Play--Framework/pull/40 (would need to rebase once that is merged)

Notes: tested on Windows only (changes are simple that if it compiles, we should be fine)