### PR TITLE
Don't scan /private/var/mobile

### DIFF
--- a/Source/ui_ios/CoverViewController.mm
+++ b/Source/ui_ios/CoverViewController.mm
@@ -56,14 +56,14 @@ static NSString* const reuseIdentifier = @"coverCell";
 	dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	dispatch_async(queue, ^{
 	  auto activeDirs = GetActiveBootableDirectories();
-	  if(forceFullDeviceScan || activeDirs.empty())
+	  if(forceFullDeviceScan)
 	  {
 		  dispatch_async(dispatch_get_main_queue(), ^{
 			alert.message = @"Scanning games on filesystem...";
 		  });
 		  ScanBootables("/private/var/mobile");
 	  }
-	  else
+	  else if(!activeDirs.empty())
 	  {
 		  dispatch_async(dispatch_get_main_queue(), ^{
 			alert.message = @"Scanning games in active directories...";


### PR DESCRIPTION
Results in large loading times on jailbroken devices and causes some devices to hang.
Probably something that shouldn't be done on launch, maybe have this as a manual button/toggle inside the app?
Fixes https://github.com/jpd002/Play-/issues/1227