### PR TITLE
Gauntlet 7 sorrows

### DIFF
--- a/Source/MIPS.h
+++ b/Source/MIPS.h
@@ -116,6 +116,14 @@ struct MIPSSTATE
 
 	uint32 savedIntReg;
 	uint32 savedIntRegTemp;
+
+	// In the case that the final delay slot includes an integer altering instruction
+	// save the register number here along with the value it has assuming the first
+	// instruction of the next block is a conditional branch on the same register.
+	uint32 savedNextBlockIntRegIdx;
+	uint32 savedNextBlockIntRegVal;
+	uint32 savedNextBlockIntRegValTemp;
+
 	uint32 xgkickAddress;
 
 	enum

--- a/Source/ee/Vpu.cpp
+++ b/Source/ee/Vpu.cpp
@@ -171,6 +171,7 @@ void CVpu::ExecuteMicroProgram(uint32 nAddress)
 	m_ctx->m_State.pipeFmacWrite[0] = {};
 	m_ctx->m_State.pipeFmacWrite[1] = {};
 	m_ctx->m_State.pipeFmacWrite[2] = {};
+	m_ctx->m_State.savedNextBlockIntRegIdx = 0;
 	m_ctx->m_State.nHasException = 0;
 
 #ifdef DEBUGGER_INCLUDED

--- a/Source/ee/VuBasicBlock.cpp
+++ b/Source/ee/VuBasicBlock.cpp
@@ -442,9 +442,9 @@ CVuBasicBlock::INTEGER_BRANCH_DELAY_INFO CVuBasicBlock::ComputeTrailingIntegerBr
 	uint32 fmacDelayOnBranch = fmacStallDelays[fmacStallDelays.size() - 2];
 	if((endLoOps.writeI != 0) && !endLoOps.branchValue && (fmacDelayOnBranch == 0))
 	{
-		// we need to use the value of intReg 3 steps prior or use initial value.
+		// we need to save the value of the integer register before the instruction is executed
 		result.regIndex = endLoOps.writeI;
-		result.saveRegAddress = std::max<int32>(adjustedEnd - 5 * 8, m_begin);
+		result.saveRegAddress = adjustedEnd;
 	}
 	return result;
 }

--- a/Source/ee/VuBasicBlock.h
+++ b/Source/ee/VuBasicBlock.h
@@ -38,6 +38,7 @@ private:
 	};
 
 	INTEGER_BRANCH_DELAY_INFO ComputeIntegerBranchDelayInfo(const std::vector<uint32>&) const;
+	INTEGER_BRANCH_DELAY_INFO ComputeTrailingIntegerBranchDelayInfo(const std::vector<uint32>&) const;
 	bool CheckIsSpecialIntegerLoop(unsigned int) const;
 	void ComputeSkipFlagsHints(const std::vector<uint32>&, std::vector<uint32>&) const;
 	BlockFmacPipelineInfo ComputeFmacStallDelays(uint32, uint32) const;

--- a/tools/VuTest/CMakeLists.txt
+++ b/tools/VuTest/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(VuTest
 	FlagsTest4.cpp
 	IntBranchDelayTest.cpp
 	IntBranchDelayTest2.cpp
+	IntBranchDelayTest3.cpp
 	Main.cpp
 	MinMaxFlagsTest.cpp
 	MinMaxTest.cpp
@@ -51,6 +52,7 @@ add_executable(VuTest
 	FlagsTest4.h
 	IntBranchDelayTest.h
 	IntBranchDelayTest2.h
+	IntBranchDelayTest3.h
 	MinMaxFlagsTest.h
 	MinMaxTest.h
 	StallTest.h

--- a/tools/VuTest/IntBranchDelayTest3.cpp
+++ b/tools/VuTest/IntBranchDelayTest3.cpp
@@ -1,0 +1,125 @@
+#include "IntBranchDelayTest3.h"
+#include "VuAssembler.h"
+
+void CIntBranchDelayTest3::Execute(CTestVm& virtualMachine)
+{
+	virtualMachine.Reset();
+
+	auto microMem = reinterpret_cast<uint32*>(virtualMachine.m_microMem);
+
+	//Inspired by Gauntlet: Seven Sorrows
+	//Game decrements and tests a value in a sequence. We need to properly track
+	//the actual tested value across basic blocks
+
+	{
+		CVuAssembler assembler(microMem);
+
+		auto firstDecLabel = assembler.CreateLabel();
+		auto secondDecLabel = assembler.CreateLabel();
+		auto thirdDecLabel = assembler.CreateLabel();
+		auto doneLabel = assembler.CreateLabel();
+
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::ISUBIU(CVuAssembler::VI10, CVuAssembler::VI10, 1));
+
+		//This should test value of initVI10
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::IBEQ(CVuAssembler::VI0, CVuAssembler::VI10, firstDecLabel));
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::ISUBIU(CVuAssembler::VI10, CVuAssembler::VI10, 1));
+
+		//This should test value of (initVI10 - 1)
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::IBEQ(CVuAssembler::VI0, CVuAssembler::VI10, secondDecLabel));
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::ISUBIU(CVuAssembler::VI10, CVuAssembler::VI10, 1));
+
+		//This should test value of (initVI10 - 2)
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::IBEQ(CVuAssembler::VI0, CVuAssembler::VI10, thirdDecLabel));
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::ISUBIU(CVuAssembler::VI10, CVuAssembler::VI10, 1));
+
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::B(doneLabel));
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::IADDIU(CVuAssembler::VI6, CVuAssembler::VI0, 0x00));
+
+		assembler.MarkLabel(firstDecLabel);
+
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::B(doneLabel));
+
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::IADDIU(CVuAssembler::VI6, CVuAssembler::VI0, 0x0F));
+
+		assembler.MarkLabel(secondDecLabel);
+
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::B(doneLabel));
+
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::IADDIU(CVuAssembler::VI6, CVuAssembler::VI0, 0xF0));
+
+		assembler.MarkLabel(thirdDecLabel);
+
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::B(doneLabel));
+
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::IADDIU(CVuAssembler::VI6, CVuAssembler::VI0, 0xFF));
+
+		assembler.MarkLabel(doneLabel);
+
+		assembler.Write(
+		    CVuAssembler::Upper::NOP() | CVuAssembler::Upper::E_BIT,
+		    CVuAssembler::Lower::NOP());
+
+		assembler.Write(
+		    CVuAssembler::Upper::NOP(),
+		    CVuAssembler::Lower::NOP());
+	}
+
+	//Test Case 1
+	{
+		virtualMachine.m_cpu.m_State.nCOP2VI[10] = 0;
+		virtualMachine.ExecuteTest(0);
+		TEST_VERIFY(virtualMachine.m_cpu.m_State.nCOP2VI[6] == 0x0F);
+	}
+
+	//Test Case 2
+	{
+		virtualMachine.m_cpu.m_State.nCOP2VI[10] = 1;
+		virtualMachine.ExecuteTest(0);
+		TEST_VERIFY(virtualMachine.m_cpu.m_State.nCOP2VI[6] == 0xF0);
+	}
+
+	//Test Case 3
+	{
+		virtualMachine.m_cpu.m_State.nCOP2VI[10] = 2;
+		virtualMachine.ExecuteTest(0);
+		TEST_VERIFY(virtualMachine.m_cpu.m_State.nCOP2VI[6] == 0xFF);
+	}
+
+	//Test Case 4
+	{
+		virtualMachine.m_cpu.m_State.nCOP2VI[10] = 3;
+		virtualMachine.ExecuteTest(0);
+		TEST_VERIFY(virtualMachine.m_cpu.m_State.nCOP2VI[6] == 0);
+	}
+}

--- a/tools/VuTest/IntBranchDelayTest3.h
+++ b/tools/VuTest/IntBranchDelayTest3.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "Test.h"
+
+class CIntBranchDelayTest3 : public CTest
+{
+public:
+	void Execute(CTestVm&) override;
+};

--- a/tools/VuTest/Main.cpp
+++ b/tools/VuTest/Main.cpp
@@ -13,6 +13,7 @@
 #include "FlagsTest4.h"
 #include "IntBranchDelayTest.h"
 #include "IntBranchDelayTest2.h"
+#include "IntBranchDelayTest3.h"
 #include "MinMaxTest.h"
 #include "MinMaxFlagsTest.h"
 #include "StallTest.h"
@@ -39,6 +40,7 @@ static const TestFactoryFunction s_factories[] =
 	[]() { return new CFlagsTest4(); },
 	[]() { return new CIntBranchDelayTest(); },
 	[]() { return new CIntBranchDelayTest2(); },
+	[]() { return new CIntBranchDelayTest3(); },
 	[]() { return new CMinMaxTest(); },
 	[]() { return new CMinMaxFlagsTest(); },
 	[]() { return new CStallTest(); },


### PR DESCRIPTION
implements the VU edge case where an integer altering instruction is in the delay slot of a conditional branch and the first instruction following it is another conditional branch based on that integer register.
The original code will take the value of the integer register at that time assuming a pipeline shortcut but that is wrong because having an integer altering instruction directly before a conditional branch on that same integer register causes the pipeline to fail and we need to use the value most recently written to memory.

Can potentially break a lot of games so needs quite a bit of testing.
