### PR TITLE
Change Xcode debugging note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ https://spidy123222.github.io/iOS-Debugging-JIT-Guides/
 
 Play! implements automatic JIT activation through AltServer, which requires AltServer to be running on the same network as your iOS device. This can be enabled in the Settings menu of the emulator.
 
-You can also build the emulator yourself and launch it through Xcode's debugger.
+You can also build the emulator yourself and launch it through Xcode's debugger. This will require installing the iOS SDK. If you want to not be tethered to xcode. You will have to use the "Detach" button in the "Debug" section after attaching the debugger to the app proccess. After you Detach the debugger. The debug process well stay on the app until the app's process ends.
 
 **If you try to play a game without JIT enabled, you will experience a crash when you launch the game.**
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ https://spidy123222.github.io/iOS-Debugging-JIT-Guides/
 
 Play! implements automatic JIT activation through AltServer, which requires AltServer to be running on the same network as your iOS device. This can be enabled in the Settings menu of the emulator.
 
-You can also build the emulator yourself and launch it through Xcode's debugger. This will require installing the iOS SDK. If you want to not be tethered to xcode. You will have to use the "Detach" button in the "Debug" section after attaching the debugger to the app proccess. After you Detach the debugger. The debug process well stay on the app until the app's process ends.
+You can also build the emulator yourself and launch it through Xcode's debugger to enable JIT. This will require installing the iOS SDK. If you don't want to be tethered to Xcode, you can use the "Detach" button in the "Debug" section after attaching the debugger to the app proccess. After you detach the debugger, the debug process will stay on the app until the app's process ends.
 
 **If you try to play a game without JIT enabled, you will experience a crash when you launch the game.**
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ https://spidy123222.github.io/iOS-Debugging-JIT-Guides/
 
 Play! implements automatic JIT activation through AltServer, which requires AltServer to be running on the same network as your iOS device. This can be enabled in the Settings menu of the emulator.
 
-You can also build the emulator yourself and launch it through Xcode's debugger, but you will need to be tethered to your Mac while playing. You will also need a paid developer license to do that.
+You can also build the emulator yourself and launch it through Xcode's debugger.
 
 **If you try to play a game without JIT enabled, you will experience a crash when you launch the game.**
 


### PR DESCRIPTION
Noticing from reading the readme. I saw that it mentioned needing a paid developer account for debugging the app. You do not need one at the moment. I’m not sure even if there was a time that you needed one for debugging the app. You also don’t need a paid dev account for using the app or compiling it.

I changed these to reflect how using Xcode is currently. It also describes detaching the debugger to act like how the jit enablers do it which is just the detach button.