### PR TITLE
Add missing header

### DIFF
--- a/Source/ee/IPU.h
+++ b/Source/ee/IPU.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <functional>
 #include "Types.h"


### PR DESCRIPTION
Add missing header `algorithm` for `std::clamp`
```
/build/libretro-play/src/libretro-play/Source/ee/IPU.cpp: In member function ‘virtual bool CIPU::CCSCCommand::Execute()’:
/build/libretro-play/src/libretro-play/Source/ee/IPU.cpp:1965:51: error: ‘clamp’ is not a member of ‘std’
 1965 |                                         nR = std::clamp(nR, 0.f, 255.f);
      |                                                   ^~~~~
/build/libretro-play/src/libretro-play/Source/ee/IPU.cpp:1966:51: error: ‘clamp’ is not a member of ‘std’
 1966 |                                         nG = std::clamp(nG, 0.f, 255.f);
      |                                                   ^~~~~
/build/libretro-play/src/libretro-play/Source/ee/IPU.cpp:1967:51: error: ‘clamp’ is not a member of ‘std’
 1967 |                                         nB = std::clamp(nB, 0.f, 255.f);
      |                                                   ^~~~~
```