### PR TITLE
Fix a compilation error on some platforms.

### DIFF
--- a/Source/ee/PS2OS.cpp
+++ b/Source/ee/PS2OS.cpp
@@ -425,7 +425,7 @@ void CPS2OS::LoadELF(Framework::CStream* stream, const char* executablePath, con
 		    auto executableName = executablePath;
 		    for(const auto separator : separators)
 		    {
-			    if(auto sepPos = strrchr(executablePath, separator))
+			    if(const char* sepPos = strrchr(executablePath, separator))
 			    {
 				    executableName = std::max(executableName, sepPos + 1);
 			    }


### PR DESCRIPTION
std::max expects both arguments to be the same type (in this case const char *), while the C version of strrchr returns non-const char *, which results in a type error with some C libraries.