### PR TITLE
Add missing include <cstring> in NamcoSys147-NANDReader.cpp

### DIFF
--- a/Source/iop/namco_sys147/NamcoSys147NANDReader.cpp
+++ b/Source/iop/namco_sys147/NamcoSys147NANDReader.cpp
@@ -2,6 +2,7 @@
 #include <cassert>
 #include "maybe_unused.h"
 #include "PtrStream.h"
+#include <cstring>
 
 using namespace Namco;
 


### PR DESCRIPTION
Hi, the patch solve this error found while compiling from the latest commit

This is happening on Arch Linux with GCC 14.2

```
[ 59%] Building CXX object Source/ui_qt/Source/CMakeFiles/PlayCore.dir/iop/namco_sys147/Iop_NamcoSys147.cpp.o
[ 59%] Building CXX object Source/ui_qt/Source/CMakeFiles/PlayCore.dir/iop/namco_sys246/Iop_NamcoAcCdvd.cpp.o
In file included from /usr/include/c++/14.2.1/cassert:44,
                 from /home/fabio/Dev/Github/PKGBUILD-AUR_fix/p/play-emu-git/src/play-emu/Source/iop/namco_sys147/NamcoSys147NANDReader.cpp:2:
/home/fabio/Dev/Github/PKGBUILD-AUR_fix/p/play-emu-git/src/play-emu/Source/iop/namco_sys147/NamcoSys147NANDReader.cpp: In member function 'Namco::CSys147NANDReader::Directory Namco::CSys147NANDReader::ReadDirectory(uint32)':
/home/fabio/Dev/Github/PKGBUILD-AUR_fix/p/play-emu-git/src/play-emu/Source/iop/namco_sys147/NamcoSys147NANDReader.cpp:30:17: error: 'strcmp' was not declared in this scope
   30 |         assert(!strcmp(header.signature, "S147ROM"));
      |                 ^~~~~~
/home/fabio/Dev/Github/PKGBUILD-AUR_fix/p/play-emu-git/src/play-emu/Source/iop/namco_sys147/NamcoSys147NANDReader.cpp:5:1: note: 'strcmp' is defined in header '<cstring>'; this is probably fixable by adding '#include <cstring>'
    4 | #include "PtrStream.h"
  +++ |+#include <cstring>
    5 | 
[ 59%] Building CXX object Source/ui_qt/Source/CMakeFiles/PlayCore.dir/iop/namco_sys246/Iop_NamcoAcRam.cpp.o
make[2]: *** [Source/ui_qt/Source/CMakeFiles/PlayCore.dir/build.make:1465: Source/ui_qt/Source/CMakeFiles/PlayCore.dir/iop/namco_sys147/NamcoSys147NANDReader.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /home/fabio/Dev/Github/PKGBUILD-AUR_fix/p/play-emu-git/src/play-emu/Source/iop/namco_sys147/Iop_NamcoSys147.cpp:2:
/home/fabio/Dev/Github/PKGBUILD-AUR_fix/p/play-emu-git/src/play-emu/Source/iop/namco_sys147/Iop_NamcoSys147.h:95:54: warning: conversion from 'unsigned int' to 'uint16' {aka 'short unsigned int'} changes value from '4294967295' to '65535' [-Woverflow]
   95 |                         uint16 m_systemSwitchState = ~0U;
      |                                                      ^~~
/home/fabio/Dev/Github/PKGBUILD-AUR_fix/p/play-emu-git/src/play-emu/Source/iop/namco_sys147/Iop_NamcoSys147.h:96:54: warning: conversion from 'unsigned int' to 'uint16' {aka 'short unsigned int'} changes value from '4294967295' to '65535' [-Woverflow]
   96 |                         uint16 m_playerSwitchState = ~0U;
      |                                                      ^~~
make[1]: *** [CMakeFiles/Makefile2:830: Source/ui_qt/Source/CMakeFiles/PlayCore.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 59%] Built target CodeGenTestSuite
make: *** [Makefile:166: all] Error 2
==> ERROR: A failure occurred in build().
```

