### PR TITLE
CMake updates

### DIFF
--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../deps/Dependencies/cmake-modules

--- a/Source/app_shared/CMakeLists.txt
+++ b/Source/app_shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules

--- a/Source/discimages/ChdCdImageStream.cpp
+++ b/Source/discimages/ChdCdImageStream.cpp
@@ -20,7 +20,7 @@ void CChdCdImageStream::ReadMetadata()
 {
 	static const size_t bufferSize = 256;
 	char metadata[bufferSize];
-	UINT32 outlen = 0;
+	uint32_t outlen = 0;
 	if(chd_get_metadata(m_chd, CDROM_TRACK_METADATA2_TAG, 0, &metadata, sizeof(metadata), &outlen, nullptr, nullptr) == CHDERR_NONE)
 	{
 		assert(m_unitSize == 2448);

--- a/Source/discimages/ChdStreamSupport.cpp
+++ b/Source/discimages/ChdStreamSupport.cpp
@@ -10,14 +10,14 @@ static size_t stream_core_fread(void* buffer, size_t elemSize, size_t elemCount,
 	return stream->Read(buffer, elemSize * elemCount);
 }
 
-static int stream_core_fseek(core_file* file, INT64 position, int whence)
+static int stream_core_fseek(core_file* file, int64_t position, int whence)
 {
 	auto stream = reinterpret_cast<Framework::CStream*>(file->argp);
 	stream->Seek(position, static_cast<Framework::STREAM_SEEK_DIRECTION>(whence));
 	return 0;
 }
 
-static UINT64 stream_core_fsize(core_file* file)
+static uint64_t stream_core_fsize(core_file* file)
 {
 	auto stream = reinterpret_cast<Framework::CStream*>(file->argp);
 	auto currPos = stream->Tell();

--- a/Source/gs/GSH_Direct3D9/CMakeLists.txt
+++ b/Source/gs/GSH_Direct3D9/CMakeLists.txt
@@ -1,10 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
-set(CMAKE_MODULE_PATH
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../deps/Dependencies/cmake-modules
-	${CMAKE_MODULE_PATH}
-)
-
 include(Header)
 
 project(gsh_d3d9)

--- a/Source/gs/GSH_OpenGL/CMakeLists.txt
+++ b/Source/gs/GSH_OpenGL/CMakeLists.txt
@@ -1,10 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
-set(CMAKE_MODULE_PATH
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../deps/Dependencies/cmake-modules
-	${CMAKE_MODULE_PATH}
-)
-
 include(Header)
 
 project(GSH_OpenGL)

--- a/Source/gs/GSH_OpenGLWin32/CMakeLists.txt
+++ b/Source/gs/GSH_OpenGLWin32/CMakeLists.txt
@@ -1,10 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
-set(CMAKE_MODULE_PATH
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../deps/Dependencies/cmake-modules
-	${CMAKE_MODULE_PATH}
-)
-
 include(Header)
 
 project(GSH_OpenGLWin32)

--- a/Source/gs/GSH_Vulkan/CMakeLists.txt
+++ b/Source/gs/GSH_Vulkan/CMakeLists.txt
@@ -1,10 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
-set(CMAKE_MODULE_PATH
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../deps/Dependencies/cmake-modules
-	${CMAKE_MODULE_PATH}
-)
-
 include(Header)
 
 project(GSH_Vulkan)

--- a/Source/ui_android/CMakeLists.txt
+++ b/Source/ui_android/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules

--- a/Source/ui_ios/CMakeLists.txt
+++ b/Source/ui_ios/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules

--- a/Source/ui_js/CMakeLists.txt
+++ b/Source/ui_js/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../../deps/Dependencies/cmake-modules
+	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules
 	${CMAKE_MODULE_PATH}
 )
 include(Header)

--- a/Source/ui_libretro/CMakeLists.txt
+++ b/Source/ui_libretro/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../deps/Dependencies/cmake-modules
+	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules
 	${CMAKE_MODULE_PATH}
 )
 include(Header)

--- a/Source/ui_qt/CMakeLists.txt
+++ b/Source/ui_qt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules

--- a/Source/ui_qt/DebugSupport/CMakeLists.txt
+++ b/Source/ui_qt/DebugSupport/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
 project(PlayDebugSupport)
 set(PLAYDEBUGSUPPORT_LIBS)
 

--- a/Source/ui_shared/CMakeLists.txt
+++ b/Source/ui_shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules

--- a/tools/AutoTest/CMakeLists.txt
+++ b/tools/AutoTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules

--- a/tools/ElfView/CMakeLists.txt
+++ b/tools/ElfView/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules

--- a/tools/GsAreaTest/CMakeLists.txt
+++ b/tools/GsAreaTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules

--- a/tools/McServTest/CMakeLists.txt
+++ b/tools/McServTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules

--- a/tools/NamcoSys147NANDTools/CMakeLists.txt
+++ b/tools/NamcoSys147NANDTools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules

--- a/tools/PsfPlayer/CMakeLists.txt
+++ b/tools/PsfPlayer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules

--- a/tools/PsfPlayer/Source/CMakeLists.txt
+++ b/tools/PsfPlayer/Source/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../deps/Dependencies/cmake-modules

--- a/tools/PsfPlayer/Source/SH_OpenAL/CMakeLists.txt
+++ b/tools/PsfPlayer/Source/SH_OpenAL/CMakeLists.txt
@@ -1,10 +1,3 @@
-cmake_minimum_required(VERSION 3.5)
-
-set(CMAKE_MODULE_PATH
-	${CMAKE_CURRENT_SOURCE_DIR}/../../../deps/Dependencies/cmake-modules
-	${CMAKE_MODULE_PATH}
-)
-
 include(Header)
 
 project(SH_OpenAL)

--- a/tools/PsfPlayer/Source/ui_aot/CMakeLists.txt
+++ b/tools/PsfPlayer/Source/ui_aot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../../deps/Dependencies/cmake-modules

--- a/tools/PsfPlayer/Source/ui_ios/CMakeLists.txt
+++ b/tools/PsfPlayer/Source/ui_ios/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../../deps/Dependencies/cmake-modules

--- a/tools/PsfPlayer/Source/ui_js/CMakeLists.txt
+++ b/tools/PsfPlayer/Source/ui_js/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../../deps/Dependencies/cmake-modules

--- a/tools/PsfPlayer/Source/ui_qt/CMakeLists.txt
+++ b/tools/PsfPlayer/Source/ui_qt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../../deps/Dependencies/cmake-modules

--- a/tools/PsfPlayer/Source/ui_win32/CMakeLists.txt
+++ b/tools/PsfPlayer/Source/ui_win32/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../../../deps/Dependencies/cmake-modules

--- a/tools/SpuTest/CMakeLists.txt
+++ b/tools/SpuTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules

--- a/tools/VuTest/CMakeLists.txt
+++ b/tools/VuTest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 
 set(CMAKE_MODULE_PATH
 	${CMAKE_CURRENT_SOURCE_DIR}/../../deps/Dependencies/cmake-modules


### PR DESCRIPTION
"Requires" https://github.com/jpd002/Play--Framework/pull/46 & https://github.com/jpd002/Play-Dependencies/pull/37
(well, it doesnt actually "require" those, this can still be merged as a standalone PR, but for the cmake changes to be complete, its best to have those 2 PR merged 1st)

- Updated libchdr to upstream
  - to update cmake min requirement
  - includes required header fix
- Changed cmake min version to 3.18
- I removed references to  as much as possible references to `cmake_minimum_required` and `set(CMAKE_MODULE_PATH ...)`
  - we can probably go a step further and also remove the `include(Header)` in the same scripts, but its probably good to have as a basic assert (if path is not set, cmake generation will fail, which will indicate an issue in cmake hierarchy)
  - the reason those specific script had this removed, is because we dont expect those to ever be used as a standalone, and any callee should already have set `CMAKE_MODULE_PATH` (and even included `Header`) 
    - thats is also why I've kept the `ui_*/CMakeLists.txt`, since its valid to call `add_subdirectory(...)` on those (skipping the root cmake)