### PR TITLE
Port T1_COUNT patches to other battle gear 3 arcadedefs and fix hang in race mode caused by another T1_COUNT read

### DIFF
--- a/arcadedefs/batlgr3.arcadedef
+++ b/arcadedefs/batlgr3.arcadedef
@@ -23,6 +23,11 @@
 			"address": "0x00181064",
 			"value": "0x0",
 			"description": "Removes T1_COUNT read that throws off idle detector."
+		},
+		{
+			"address": "0x001811EC",
+			"value": "0x0",
+			"description": "Removes T1_COUNT read that throws off idle detector (Race Mode)."
 		}
 	]
 }

--- a/arcadedefs/batlgr37.arcadedef
+++ b/arcadedefs/batlgr37.arcadedef
@@ -23,6 +23,11 @@
 			"address": "0x0017E274",
 			"value": "0x0",
 			"description": "Removes T1_COUNT read that throws off idle detector."
+		},
+		{
+			"address": "0x0017E3FC",
+			"value": "0x0",
+			"description": "Removes T1_COUNT read that throws off idle detector (Race Mode)."
 		}
 	]
 }

--- a/arcadedefs/batlgr37.arcadedef
+++ b/arcadedefs/batlgr37.arcadedef
@@ -18,6 +18,11 @@
 			"address": "0x001008EC",
 			"value": "0x0",
 			"description": "Fixes hang on white screen."
+		},
+		{
+			"address": "0x0017E274",
+			"value": "0x0",
+			"description": "Removes T1_COUNT read that throws off idle detector."
 		}
 	]
 }

--- a/arcadedefs/batlgr38.arcadedef
+++ b/arcadedefs/batlgr38.arcadedef
@@ -13,7 +13,7 @@
 	"inputMode": "drive",
 	"boot": "ac0:BGRLOAD",
 	"patches":
-	[	
+	[
 		{
 			"address": "0x001008EC",
 			"value": "0x0",

--- a/arcadedefs/batlgr38.arcadedef
+++ b/arcadedefs/batlgr38.arcadedef
@@ -13,11 +13,16 @@
 	"inputMode": "drive",
 	"boot": "ac0:BGRLOAD",
 	"patches":
-	[
+	[	
 		{
 			"address": "0x001008EC",
 			"value": "0x0",
 			"description": "Fixes hang on white screen."
+		},
+		{
+			"address": "0x0017E52C",
+			"value": "0x0",
+			"description": "Removes T1_COUNT read that throws off idle detector."
 		}
 	]
 }

--- a/arcadedefs/batlgr38.arcadedef
+++ b/arcadedefs/batlgr38.arcadedef
@@ -23,6 +23,11 @@
 			"address": "0x0017E52C",
 			"value": "0x0",
 			"description": "Removes T1_COUNT read that throws off idle detector."
+		},
+		{
+			"address": "0x0017E6B4",
+			"value": "0x0",
+			"description": "Removes T1_COUNT read that throws off idle detector (Race Mode)."
 		}
 	]
 }

--- a/arcadedefs/batlgr3t.arcadedef
+++ b/arcadedefs/batlgr3t.arcadedef
@@ -28,6 +28,11 @@
 			"address": "0x0019F8CC",
 			"value": "0x0",
 			"description": "Removes T1_COUNT read that throws off idle detector."
+		},
+		{
+			"address": "0x0019FA54",
+			"value": "0x0",
+			"description": "Removes T1_COUNT read that throws off idle detector (Race Mode)."
 		}
 	]
 }

--- a/arcadedefs/batlgr3t.arcadedef
+++ b/arcadedefs/batlgr3t.arcadedef
@@ -18,11 +18,16 @@
 			"address": "0x0010090C",
 			"value": "0x0",
 			"description": "Fixes hang on white screen."
-		},		
+		},
 		{
 			"address": "0x00160D58",
 			"value": "0x10000011",
 			"description": "Fixes rack error message."
+		},
+		{
+			"address": "0x0019F8CC",
+			"value": "0x0",
+			"description": "Removes T1_COUNT read that throws off idle detector."
 		}
 	]
 }


### PR DESCRIPTION
As the title suggests, I noticed in PR #1491 that the T1 count patch was implemented for battle gear 3 2.01A but not the other games. I have quickly ported these to the other arcadedefs and raised another PR (hopefully this is okay).

Have tested and works perfectly my end :)