### PR TITLE
reduce GPIO output threshold for recoil events to accomodate both I/O board types

### DIFF
--- a/Source/iop/namco_sys246/Iop_NamcoSys246.cpp
+++ b/Source/iop/namco_sys246/Iop_NamcoSys246.cpp
@@ -492,7 +492,7 @@ void CSys246::ProcessJvsPacket(const uint8* input, uint8* output)
 				if(i == 1)
 				{
 					// value1 0xC0 indicates P1 recoil triggered
-					int p1Recoil = (gpvalue >= 0x80) ? 1 : 0;
+					int p1Recoil = (gpvalue >= 0x50) ? 1 : 0;
 					if(p1Recoil != m_p1RecoilLast)
 					{
 						m_p1RecoilLast = p1Recoil;


### PR DESCRIPTION
Unfortunately, https://github.com/jpd002/Play-/pull/1516 broke recoil for TC3, as the recoil output signal has a lower value for whatever reason (0x50 rather than 0xC0) when using the MIU type I/O board. This sets the threshold lower for writing a recoil event via the network output and fixes recoil in TC3.