### PR TITLE
CI : update upload-artifact version

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -68,7 +68,7 @@ jobs:
         ANDROID_KEYSTORE_PASS: ${{ secrets.ANDROID_KEYSTORE_PASS }}
     - name: Upload a Build Artifact Android APK Signed
       if: ${{ matrix.build-type == 'apk' && env.ANDROID_KEYSTORE_PASS != null }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Play_Android_Signed
         path: Play-release.apk
@@ -76,13 +76,13 @@ jobs:
         ANDROID_KEYSTORE_PASS: ${{ secrets.ANDROID_KEYSTORE_PASS }}
     - name: Upload a Build Artifact Android APK Unsigned
       if: ${{ matrix.build-type == 'apk' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Play_Android_APK_Unsigned
         path: Play-release-unsigned.apk
     - name: Upload a Build Artifact Android libretro
       if: ${{ matrix.build-type == 'libretro' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Play_Android_libretro
         path: build_retro/play_libretro_*_android.so

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -52,7 +52,7 @@ jobs:
         cd installer_ios
         ./build_cydia.sh
     - name: Upload a Build Artifact ipa/deb/bz2
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Play_iOS
         path: |
@@ -60,7 +60,7 @@ jobs:
           installer_ios/Play.deb
           installer_ios/Packages.bz2
     - name: Upload a Build Artifact libretro
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Play_iOS_libretro
         path: build/Source/ui_libretro/Release-iphoneos/play_libretro_ios.dylib

--- a/.github/workflows/build-linux.yaml
+++ b/.github/workflows/build-linux.yaml
@@ -74,14 +74,14 @@ jobs:
       env:
         VERSION: ${{ steps.short_hash.outputs.VALUE }}
     - name: Upload a Build Artifact x86_64 AppImage
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Play_Linux_x86_64_AppImage
         path: build/Play!-${{ env.SHORT_HASH }}-x86_64.AppImage
       env:
         SHORT_HASH: ${{ steps.short_hash.outputs.VALUE }}
     - name: Upload a Build Artifact x86_64 Libretro
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Play_Linux_x86_64_libretro
         path: build/Source/ui_libretro/play_libretro.so

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -71,12 +71,12 @@ jobs:
         cd build
         appdmg ../installer_macos/spec.json Play.dmg
     - name: Upload a Build Artifact dmg
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Play_MacOS_dmg
         path: build/Play.dmg
     - name: Upload a Build Artifact libretro
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Play_MacOS_libretro
         path: build/Source/ui_libretro/Release/play_libretro.dylib

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -87,12 +87,12 @@ jobs:
         cd ..
         makensis.exe ./installer_win32/${{ matrix.installer-script}}
     - name: Upload a Build Artifact Installer
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Play_Windows_${{ matrix.target-platform }}_Installer
         path: installer_win32\*.exe
     - name: Upload a Build Artifact Libretro Core
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Play_Windows_${{ matrix.target-platform }}_libretro
         path: build\Source\ui_libretro\Release\play_libretro.dll


### PR DESCRIPTION
updates upload-artifact version to the lastest version (6) 

mainly a copy of teh pr i did in https://github.com/jpd002/Play-/pull/1437 just to the newer versions 

hopefully this dosent break anything , but it shouldn't

also would Recommend enabling [dependabot](https://github.blog/news-insights/product-news/keep-all-your-packages-up-to-date-with-dependabot/) because most of the action versions are out of date 