### PR TITLE
taiko11a.arcadedef added

### DIFF
--- a/arcadedefs/taiko11a.arcadedef
+++ b/arcadedefs/taiko11a.arcadedef
@@ -1,0 +1,19 @@
+{
+	"id": "taiko11a",
+	"name": "Taiko no Tatsujin 11 Asia Version",
+	"driver": "sys246",
+	"dongle":
+	{
+		"name": "t111004-na-a.ic002"
+	},
+	"cdvd":
+	{
+		"name": "t11100-4-na-dvd0-a.chd"
+	},
+	"inputMode": "drum",
+	"eeFrequencyScale": [4, 3],
+	"boot": "ac0:TEBLOAD",
+	"patches":
+	[
+	]
+}


### PR DESCRIPTION
[arcade] Taiko no tatsujin 11 Asia version added.
Asia version Rom will check system NVRAM region value. It is marked as not working now.