### PR TITLE
System 246 controller mapping improvement for driving and drum

### DIFF
--- a/Source/iop/namco_sys246/Iop_NamcoSys246.cpp
+++ b/Source/iop/namco_sys246/Iop_NamcoSys246.cpp
@@ -573,14 +573,14 @@ void CSys246::SetButtonState(unsigned int padNumber, PS2::CControllerInfo::BUTTO
 		uint16 buttonBit = m_jvsButtonBits[button];
 		if(m_jvsMode == JVS_MODE::DRIVE)
 		{
-			if(button == PS2::CControllerInfo::R1)         buttonBit = 0x0004;
-			else if(button == PS2::CControllerInfo::L1)    buttonBit = 0x0002;
+			if(button == PS2::CControllerInfo::R1) buttonBit = 0x0004;
+			else if(button == PS2::CControllerInfo::L1) buttonBit = 0x0002;
 			else if(button == PS2::CControllerInfo::DPAD_RIGHT) buttonBit = 0x0000;
-			else if(button == PS2::CControllerInfo::CROSS)      buttonBit = 0x0000;
+			else if(button == PS2::CControllerInfo::CROSS) buttonBit = 0x0000;
 		}
 
 		m_jvsButtonState[padNumber] &= ~m_jvsButtonBits[button]; // clear original bit
-		m_jvsButtonState[padNumber] &= ~buttonBit;               // clear remapped bit
+		m_jvsButtonState[padNumber] &= ~buttonBit; // clear remapped bit
 		m_jvsButtonState[padNumber] |= (pressed ? buttonBit : 0);
 
 		if(padNumber == 0)
@@ -598,9 +598,9 @@ void CSys246::SetButtonState(unsigned int padNumber, PS2::CControllerInfo::BUTTO
 			{
 				// Taiko no Tatsujin: DPAD_LEFT=Left Men, L2=Left Fuchi, CROSS=Right Men, R2=Right Fuchi
 				if(button == PS2::CControllerInfo::DPAD_LEFT) m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_DL] = pressed ? drumPressValue << 6 : 0;
-				if(button == PS2::CControllerInfo::L2)        m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_KL] = pressed ? drumPressValue << 6 : 0;
-				if(button == PS2::CControllerInfo::CROSS)     m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_DR] = pressed ? drumPressValue << 6 : 0;
-				if(button == PS2::CControllerInfo::R2)        m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_KR] = pressed ? drumPressValue << 6 : 0;
+				if(button == PS2::CControllerInfo::L2) m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_KL] = pressed ? drumPressValue << 6 : 0;
+				if(button == PS2::CControllerInfo::CROSS) m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_DR] = pressed ? drumPressValue << 6 : 0;
+				if(button == PS2::CControllerInfo::R2) m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_KR] = pressed ? drumPressValue << 6 : 0;
 			}
 		}
 		else if(padNumber == 1)
@@ -609,9 +609,9 @@ void CSys246::SetButtonState(unsigned int padNumber, PS2::CControllerInfo::BUTTO
 			{
 				// Taiko no Tatsujin: DPAD_LEFT=Left Men, L2=Left Fuchi, CROSS=Right Men, R2=Right Fuchi
 				if(button == PS2::CControllerInfo::DPAD_LEFT) m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_DL] = pressed ? drumPressValue << 6 : 0;
-				if(button == PS2::CControllerInfo::L2)        m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_KL] = pressed ? drumPressValue << 6 : 0;
-				if(button == PS2::CControllerInfo::CROSS)     m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_DR] = pressed ? drumPressValue << 6 : 0;
-				if(button == PS2::CControllerInfo::R2)        m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_KR] = pressed ? drumPressValue << 6 : 0;
+				if(button == PS2::CControllerInfo::L2) m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_KL] = pressed ? drumPressValue << 6 : 0;
+				if(button == PS2::CControllerInfo::CROSS) m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_DR] = pressed ? drumPressValue << 6 : 0;
+				if(button == PS2::CControllerInfo::R2) m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_KR] = pressed ? drumPressValue << 6 : 0;
 			}
 		}
 	}

--- a/Source/iop/namco_sys246/Iop_NamcoSys246.cpp
+++ b/Source/iop/namco_sys246/Iop_NamcoSys246.cpp
@@ -54,13 +54,13 @@ static const std::array<uint16, PS2::CControllerInfo::MAX_BUTTONS> g_defaultJvsB
 	0x0020, //DPAD_UP,
 	0x0010, //DPAD_DOWN,
 	0x0008, //DPAD_LEFT (Shutter Sensor Top),
-	0x0004, //DPAD_RIGHT (Shutter Sensor Down),
+	0x0800, //DPAD_RIGHT (Shift Up),
 	0x0040, //SELECT,
 	0x0080, //START,
 	0x4000, //SQUARE,
 	0x8000, //TRIANGLE,
 	0x0001, //CIRCLE (Motor Sensor),
-	0x0002, //CROSS,
+	0x0100, //CROSS (Shift Down),
 	0x0100, //L1,
 	0x0200, //L2,
 	0x0400, //L3,
@@ -563,8 +563,20 @@ void CSys246::SetButtonState(unsigned int padNumber, PS2::CControllerInfo::BUTTO
 	{
 		static const uint16 drumPressValue = 0x200;
 
-		m_jvsButtonState[padNumber] &= ~m_jvsButtonBits[button];
-		m_jvsButtonState[padNumber] |= (pressed ? m_jvsButtonBits[button] : 0);
+		// In DRIVE mode, remap R1 -> Shift Up (0x0004) and L1 -> Shift Down (0x0002)
+		// Disable original DPAD_RIGHT and CROSS for shift
+		uint16 buttonBit = m_jvsButtonBits[button];
+		if(m_jvsMode == JVS_MODE::DRIVE)
+		{
+			if(button == PS2::CControllerInfo::R1)         buttonBit = 0x0004;
+			else if(button == PS2::CControllerInfo::L1)    buttonBit = 0x0002;
+			else if(button == PS2::CControllerInfo::DPAD_RIGHT) buttonBit = 0x0000;
+			else if(button == PS2::CControllerInfo::CROSS)      buttonBit = 0x0000;
+		}
+
+		m_jvsButtonState[padNumber] &= ~m_jvsButtonBits[button]; // clear original bit
+		m_jvsButtonState[padNumber] &= ~buttonBit;               // clear remapped bit
+		m_jvsButtonState[padNumber] |= (pressed ? buttonBit : 0);
 
 		if(padNumber == 0)
 		{
@@ -645,25 +657,34 @@ void CSys246::SetButtonState(unsigned int padNumber, PS2::CControllerInfo::BUTTO
 
 void CSys246::SetAxisState(unsigned int padNumber, PS2::CControllerInfo::BUTTON button, uint8 axisValue, uint8* ram)
 {
-	switch(button)
+	if(m_jvsMode == JVS_MODE::DRIVE)
 	{
-	case PS2::CControllerInfo::BUTTON::ANALOG_LEFT_X:
-		if(axisValue >= 0 || axisValue < 128) m_jvsWheel = axisValue + 128;
-		if(axisValue > 128 || axisValue < 256) m_jvsWheel = axisValue - 128;
-		m_jvsWheel = axisValue;
-		break;
-	case PS2::CControllerInfo::BUTTON::ANALOG_LEFT_Y:
-		if(axisValue >= 128) axisValue = 127; // limit Left stick Y axis to Y+
-		m_jvsGaz = -axisValue + 127;
-		break;
-	case PS2::CControllerInfo::BUTTON::ANALOG_RIGHT_X:
-		if(axisValue < 128) axisValue = 128; // limit Right stick X axis to X+
-		m_jvsBrake = axisValue - 128;
-		break;
-	case PS2::CControllerInfo::BUTTON::ANALOG_RIGHT_Y:
-		break;
-	default:
-		break;
+		switch(button)
+		{
+		case PS2::CControllerInfo::BUTTON::ANALOG_LEFT_X:
+			if(axisValue >= 0 || axisValue < 128) m_jvsWheel = axisValue + 128;
+			if(axisValue > 128 || axisValue < 256) m_jvsWheel = axisValue - 128;
+			m_jvsWheel = axisValue;
+			break;
+		case PS2::CControllerInfo::BUTTON::ANALOG_LEFT_Y:
+			break;
+		case PS2::CControllerInfo::BUTTON::ANALOG_RIGHT_X:
+			break;
+		case PS2::CControllerInfo::BUTTON::ANALOG_RIGHT_Y:
+			// Right stick Y upper -> Gaz (Accelerator)
+			if(axisValue < 128)
+			{
+				m_jvsGaz = -axisValue + 127;
+			}
+			// Right stick Y lower -> Brake
+			else
+			{
+				m_jvsBrake = axisValue - 128;
+			}
+			break;
+		default:
+			break;
+		}
 	}
 }
 

--- a/Source/iop/namco_sys246/Iop_NamcoSys246.cpp
+++ b/Source/iop/namco_sys246/Iop_NamcoSys246.cpp
@@ -54,13 +54,13 @@ static const std::array<uint16, PS2::CControllerInfo::MAX_BUTTONS> g_defaultJvsB
 	0x0020, //DPAD_UP,
 	0x0010, //DPAD_DOWN,
 	0x0008, //DPAD_LEFT (Shutter Sensor Top),
-	0x0800, //DPAD_RIGHT (Shift Up),
+	0x0004, //DPAD_RIGHT (Shutter Sensor Down),
 	0x0040, //SELECT,
 	0x0080, //START,
 	0x4000, //SQUARE,
 	0x8000, //TRIANGLE,
 	0x0001, //CIRCLE (Motor Sensor),
-	0x0100, //CROSS (Shift Down),
+	0x0002, //CROSS,
 	0x0100, //L1,
 	0x0200, //L2,
 	0x0400, //L3,
@@ -573,14 +573,18 @@ void CSys246::SetButtonState(unsigned int padNumber, PS2::CControllerInfo::BUTTO
 		uint16 buttonBit = m_jvsButtonBits[button];
 		if(m_jvsMode == JVS_MODE::DRIVE)
 		{
-			if(button == PS2::CControllerInfo::R1) buttonBit = 0x0004;
-			else if(button == PS2::CControllerInfo::L1) buttonBit = 0x0002;
-			else if(button == PS2::CControllerInfo::DPAD_RIGHT) buttonBit = 0x0000;
-			else if(button == PS2::CControllerInfo::CROSS) buttonBit = 0x0000;
+			if(button == PS2::CControllerInfo::R1)
+				buttonBit = 0x0004;
+			else if(button == PS2::CControllerInfo::L1)
+				buttonBit = 0x0002;
+			else if(button == PS2::CControllerInfo::DPAD_RIGHT)
+				buttonBit = 0x0000;
+			else if(button == PS2::CControllerInfo::CROSS)
+				buttonBit = 0x0000;
 		}
 
 		m_jvsButtonState[padNumber] &= ~m_jvsButtonBits[button]; // clear original bit
-		m_jvsButtonState[padNumber] &= ~buttonBit; // clear remapped bit
+		m_jvsButtonState[padNumber] &= ~buttonBit;               // clear remapped bit
 		m_jvsButtonState[padNumber] |= (pressed ? buttonBit : 0);
 
 		if(padNumber == 0)
@@ -693,7 +697,6 @@ void CSys246::SetAxisState(unsigned int padNumber, PS2::CControllerInfo::BUTTON 
 			break;
 		}
 	}
-
 }
 
 void CSys246::SetScreenPosition(float x, float y)

--- a/Source/iop/namco_sys246/Iop_NamcoSys246.cpp
+++ b/Source/iop/namco_sys246/Iop_NamcoSys246.cpp
@@ -439,6 +439,11 @@ void CSys246::ProcessJvsPacket(const uint8* input, uint8* output)
 					(*output++) = static_cast<uint8>(m_jvsDrumChannels[i] >> 8);
 					(*output++) = static_cast<uint8>(m_jvsDrumChannels[i]);
 				}
+				// Reset drum channels after sending — drum inputs are pulses, not held states
+				for(int i = 0; i < JVS_DRUM_CHANNEL_MAX; i++)
+				{
+					m_jvsDrumChannels[i] = 0;
+				}
 			}
 			else if(m_jvsMode == JVS_MODE::DRIVE)
 			{
@@ -591,20 +596,22 @@ void CSys246::SetButtonState(unsigned int padNumber, PS2::CControllerInfo::BUTTO
 			}
 			else if(m_jvsMode == JVS_MODE::DRUM)
 			{
-				if(button == PS2::CControllerInfo::L1) m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_DL] = pressed ? drumPressValue << 6 : 0;
-				if(button == PS2::CControllerInfo::L2) m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_KL] = pressed ? drumPressValue << 6 : 0;
-				if(button == PS2::CControllerInfo::R1) m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_DR] = pressed ? drumPressValue << 6 : 0;
-				if(button == PS2::CControllerInfo::R2) m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_KR] = pressed ? drumPressValue << 6 : 0;
+				// Taiko no Tatsujin: DPAD_LEFT=Left Men, L2=Left Fuchi, CROSS=Right Men, R2=Right Fuchi
+				if(button == PS2::CControllerInfo::DPAD_LEFT) m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_DL] = pressed ? drumPressValue << 6 : 0;
+				if(button == PS2::CControllerInfo::L2)        m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_KL] = pressed ? drumPressValue << 6 : 0;
+				if(button == PS2::CControllerInfo::CROSS)     m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_DR] = pressed ? drumPressValue << 6 : 0;
+				if(button == PS2::CControllerInfo::R2)        m_jvsDrumChannels[JVS_DRUM_CHANNEL_1P_KR] = pressed ? drumPressValue << 6 : 0;
 			}
 		}
 		else if(padNumber == 1)
 		{
 			if(m_jvsMode == JVS_MODE::DRUM)
 			{
-				if(button == PS2::CControllerInfo::L1) m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_DL] = pressed ? drumPressValue << 6 : 0;
-				if(button == PS2::CControllerInfo::L2) m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_KL] = pressed ? drumPressValue << 6 : 0;
-				if(button == PS2::CControllerInfo::R1) m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_DR] = pressed ? drumPressValue << 6 : 0;
-				if(button == PS2::CControllerInfo::R2) m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_KR] = pressed ? drumPressValue << 6 : 0;
+				// Taiko no Tatsujin: DPAD_LEFT=Left Men, L2=Left Fuchi, CROSS=Right Men, R2=Right Fuchi
+				if(button == PS2::CControllerInfo::DPAD_LEFT) m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_DL] = pressed ? drumPressValue << 6 : 0;
+				if(button == PS2::CControllerInfo::L2)        m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_KL] = pressed ? drumPressValue << 6 : 0;
+				if(button == PS2::CControllerInfo::CROSS)     m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_DR] = pressed ? drumPressValue << 6 : 0;
+				if(button == PS2::CControllerInfo::R2)        m_jvsDrumChannels[JVS_DRUM_CHANNEL_2P_KR] = pressed ? drumPressValue << 6 : 0;
 			}
 		}
 	}
@@ -686,6 +693,7 @@ void CSys246::SetAxisState(unsigned int padNumber, PS2::CControllerInfo::BUTTON 
 			break;
 		}
 	}
+
 }
 
 void CSys246::SetScreenPosition(float x, float y)


### PR DESCRIPTION
For driving games such as Battle Gear 3
L1: Shift down
R1: Shift up
L stick: Steeling
R stick vertical: Accelerate and Brake 

For drum games
L2 R2: KA*
Dpad Left and Cross (A): DON
Codes are not optimized so that Right KA may be missed sometimes.