### PR TITLE
Added idle skip patch for the game SD Gundam Force - Showdown!

### DIFF
--- a/GameConfig.xml
+++ b/GameConfig.xml
@@ -16,6 +16,9 @@
 	<GameConfig Executable="SLUS_201.60;1" Title="WinBack: Covert Operations">
 		<IdleLoopBlock Address="0x00234E58" />
 	</GameConfig>
+	<GameConfig Executable="SLUS_206.98;1" Title="SD Gundam Force - Showdown!">
+		<IdleLoopBlock Address="0x001F8BB0" />
+	</GameConfig>
 	<GameConfig Executable="SLUS_203.07;1" Title="Burnout">
 		<IdleLoopBlock Address="0x0021B980" />
 	</GameConfig>


### PR DESCRIPTION
Fixes high EE usage on the game SD Gundam Force - Showdown!. Performance should be at least 2x the previous framerate on avg (fully tested by playing the entire game)