### PR TITLE
[codex] Fix directory and cover edge cases

### DIFF
--- a/Source/ISO9660/DirectoryRecord.cpp
+++ b/Source/ISO9660/DirectoryRecord.cpp
@@ -11,6 +11,10 @@ CDirectoryRecord::CDirectoryRecord()
 CDirectoryRecord::CDirectoryRecord(Framework::CStream* stream)
 {
 	m_length = stream->Read8();
+	if(m_length == 0)
+	{
+		return;
+	}
 	m_exLength = stream->Read8();
 	m_position = stream->Read32();
 	stream->Seek(4, Framework::STREAM_SEEK_CUR);

--- a/Source/iop/Iop_Ioman.cpp
+++ b/Source/iop/Iop_Ioman.cpp
@@ -398,6 +398,10 @@ int32 CIoman::Dopen(const char* path)
 			throw std::runtime_error("Device not found.");
 		}
 		auto directory = deviceIterator->second->GetDirectory(pathInfo.devicePath.c_str());
+		if(!directory)
+		{
+			throw std::runtime_error("Directory not found.");
+		}
 		handle = m_nextFileHandle++;
 		m_directories[handle] = std::move(directory);
 	}
@@ -435,6 +439,10 @@ int32 CIoman::Dread(uint32 handle, Ioman::DIRENTRY* dirEntry)
 	}
 
 	auto& directory = directoryIterator->second;
+	if(!directory)
+	{
+		return -1;
+	}
 	if(directory->IsDone())
 	{
 		return 0;

--- a/Source/iop/ioman/HardDiskDumpDevice.cpp
+++ b/Source/iop/ioman/HardDiskDumpDevice.cpp
@@ -111,6 +111,10 @@ Framework::CStream* CHardDiskDumpPartitionDevice::GetFile(uint32 accessType, con
 DirectoryIteratorPtr CHardDiskDumpPartitionDevice::GetDirectory(const char* path)
 {
 	auto reader = m_pfsReader.GetDirectoryReader(path);
+	if(!reader)
+	{
+		return DirectoryIteratorPtr();
+	}
 	return std::make_unique<CHardDiskDumpPartitionDirectoryIterator>(reader);
 }
 
@@ -131,6 +135,7 @@ void CHardDiskDumpPartitionDirectoryIterator::ReadEntry(DIRENTRY* entry)
 	m_reader->ReadEntry(entryName, entryInode);
 	*entry = {};
 	strncpy(entry->name, entryName.c_str(), DIRENTRY::NAME_SIZE);
+	entry->name[DIRENTRY::NAME_SIZE - 1] = 0;
 	entry->stat.mode = entryInode.mode;
 	entry->stat.loSize = entryInode.size;
 	entry->stat.attr = entryInode.attr;

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -36,7 +36,7 @@ public class GameInfo
 		NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
 		if(mMobile != null && mWifi != null)
 		{
-			return mMobile.isAvailable() || mWifi.isAvailable();
+			return mMobile.isConnected() || mWifi.isConnected();
 		}
 		return activeNetworkInfo != null && activeNetworkInfo.isConnected();
 	}
@@ -105,13 +105,17 @@ public class GameInfo
 
 	public void saveImage(String key, String custom, Bitmap image)
 	{
+		if(image == null)
+		{
+			return;
+		}
 		addBitmapToMemoryCache(key, image);
 		String path = mContext.getExternalFilesDir(null) + "/covers/";
 		OutputStream fOut = null;
 		File file = new File(path, key + custom + ".jpg"); // the File to save to
 		if(!file.getParentFile().exists())
 		{
-			file.getParentFile().mkdir();
+			file.getParentFile().mkdirs();
 		}
 		try
 		{
@@ -127,7 +131,10 @@ public class GameInfo
 		{
 			try
 			{
-				fOut.close();
+				if(fOut != null)
+				{
+					fOut.close();
+				}
 			}
 			catch(IOException ignored)
 			{
@@ -223,14 +230,7 @@ public class GameInfo
 						return null;
 					}
 
-					if(boxart.startsWith("https://cdn.thegamesdb.net/images/original/"))
-					{
-						api = "https://cdn.thegamesdb.net/images/original/" + boxart;
-					}
-					else
-					{
-						api = boxart;
-					}
+					api = boxart;
 					InputStream im = null;
 					try
 					{
@@ -239,6 +239,10 @@ public class GameInfo
 
 						im = conn1.getInputStream();
 						Bitmap bitmap = ImageUtils.getSampledImage(mContext, im);
+						if(bitmap == null)
+						{
+							return null;
+						}
 
 						saveImage(key, bitmap);
 						return bitmap;


### PR DESCRIPTION
## Summary

This PR fixes a small set of defensive edge cases found during a static bug-hunt pass. The changes are intentionally narrow and limited to directory iteration/parsing paths plus Android cover-image loading.

## Fixes

- Avoid registering a null directory iterator in `CIoman::Dopen`. Some devices explicitly return a null directory iterator for unsupported directory listing; previously `Dopen` still returned a valid handle, and a later `Dread` could dereference it.
- Add a defensive null check in `CIoman::Dread` before using a stored directory iterator.
- Stop ISO9660 directory-record parsing immediately when a zero-length record is encountered. A zero-length record marks the end/padding area, so continuing to read the remaining fields consumes bytes that do not belong to a directory record.
- Return no directory iterator when `CHardDiskDumpPartitionDevice::GetDirectory` cannot resolve a PFS path instead of constructing an iterator around a null reader.
- Ensure HDD dump partition directory entry names are null-terminated before callers use them as C strings.
- Fix Android cover handling so failed bitmap decoding does not flow into `saveImage`, failed `FileOutputStream` creation does not cause a null close, parent cover directories are created recursively, and network availability checks require an actually connected network.
- Simplify Android cover URL selection to use the supplied URL directly, avoiding the previous duplicate CDN-prefix construction.

## Why

The affected paths are mostly error and malformed-input handling. The previous behavior could turn unsupported directory listing, missing HDD/PFS paths, malformed ISO directory padding, or cover download/decode failures into crashes or incorrect network/file behavior.

## Contribution rules checked

I reviewed `CONTRIBUTING.md` and `.github/workflows/check-format.yaml` before opening this PR:

- C++ indentation uses tabs and Allman braces.
- C++ changes are minimal and do not introduce new class members, constructors/destructors, or override declarations.
- The repository format workflow runs clang-format 16 over C/C++/ObjC files in `Source` and `tools`; the C++ edits are simple guard blocks following the existing style.
- Java is not covered by that clang-format workflow, so the Android changes preserve the local indentation/style of the surrounding file.

## Validation

- Ran `git -c core.whitespace=cr-at-eol diff --check` locally.
- Reviewed the diff manually for scope and style.

I did not run the full native build locally because this checkout was originally cloned without initialized submodules, while the CI workflows use `submodules: recursive`.