### PR TITLE
Added idle skip patch for the games Mutsu-boshi Kirari - Hoshifuru Miyako and Ultraman Nexus

### DIFF
--- a/GameConfig.xml
+++ b/GameConfig.xml
@@ -19,6 +19,9 @@
 	<GameConfig Executable="SLUS_206.98;1" Title="SD Gundam Force - Showdown!">
 		<IdleLoopBlock Address="0x001F8BB0" />
 	</GameConfig>
+	<GameConfig Executable="SLPM_663.59;1" Title="Mutsu-boshi Kirari - Hoshifuru Miyako">
+		<IdleLoopBlock Address="0x001009E4" />
+	</GameConfig>
 	<GameConfig Executable="SLUS_203.07;1" Title="Burnout">
 		<IdleLoopBlock Address="0x0021B980" />
 	</GameConfig>

--- a/GameConfig.xml
+++ b/GameConfig.xml
@@ -22,6 +22,9 @@
 	<GameConfig Executable="SLPM_663.59;1" Title="Mutsu-boshi Kirari - Hoshifuru Miyako">
 		<IdleLoopBlock Address="0x001009E4" />
 	</GameConfig>
+	<GameConfig Executable="SLPS_204.20;1" Title="Ultraman Nexus">
+		<IdleLoopBlock Address="0x00292DE0" />
+	</GameConfig>
 	<GameConfig Executable="SLUS_203.07;1" Title="Burnout">
 		<IdleLoopBlock Address="0x0021B980" />
 	</GameConfig>


### PR DESCRIPTION
Fixes high EE usage on both games, giving a nice performance boost:
- Mutsu-boshi Kirari - Hoshifuru Miyako: 700%+ improvement
- Ultraman Nexus: 100% improvement