### PR TITLE
Added idle skip patch for the game After... - Wasure Enu Kizuna

### DIFF
--- a/GameConfig.xml
+++ b/GameConfig.xml
@@ -26,7 +26,7 @@
 		<IdleLoopBlock Address="0x00292DE0" />
 	</GameConfig>
 	<GameConfig Executable="SLPM_654.81;1" Title="After... - Wasure Enu Kizuna">
-		<IdleLoopBlock Address="0x001407A0" />
+		<IdleLoopBlock Address="0x00106F18" />
 	</GameConfig>
 	<GameConfig Executable="SLUS_203.07;1" Title="Burnout">
 		<IdleLoopBlock Address="0x0021B980" />

--- a/GameConfig.xml
+++ b/GameConfig.xml
@@ -25,6 +25,9 @@
 	<GameConfig Executable="SLPS_204.20;1" Title="Ultraman Nexus">
 		<IdleLoopBlock Address="0x00292DE0" />
 	</GameConfig>
+	<GameConfig Executable="SLPM_654.81;1" Title="After... - Wasure Enu Kizuna">
+		<IdleLoopBlock Address="0x001407A0" />
+	</GameConfig>
 	<GameConfig Executable="SLUS_203.07;1" Title="Burnout">
 		<IdleLoopBlock Address="0x0021B980" />
 	</GameConfig>


### PR DESCRIPTION
Fixes high EE usage all the time. Improves performance around 1500%+
Note: patched address changed from 0x001407A0 to 0x00106F18, to avoid patching FlushCache (performance improvement remains the same)