### PR TITLE
Added idle skip patch for the game Simpsons Road Rage

### DIFF
--- a/GameConfig.xml
+++ b/GameConfig.xml
@@ -28,6 +28,9 @@
 	<GameConfig Executable="SLPM_654.81;1" Title="After... - Wasure Enu Kizuna">
 		<IdleLoopBlock Address="0x00106F18" />
 	</GameConfig>
+	<GameConfig Executable="SLUS_203.05;1" Title="Simpsons Road Rage">
+		<IdleLoopBlock Address="0x0027C708" />
+	</GameConfig>
 	<GameConfig Executable="SLUS_203.07;1" Title="Burnout">
 		<IdleLoopBlock Address="0x0021B980" />
 	</GameConfig>


### PR DESCRIPTION
Fixes high EE usage all the time in the game. Gives around a 100% framerate improvement