### PR TITLE
Update addresses in batlgr3j.arcadedef

### DIFF
--- a/arcadedefs/batlgr3j.arcadedef
+++ b/arcadedefs/batlgr3j.arcadedef
@@ -20,12 +20,12 @@
 			"description": "Fixes hang on white screen."
 		},
 		{
-			"address": "0x0017E52C",
+			"address": "0x0017E574",
 			"value": "0x0",
 			"description": "Removes T1_COUNT read that throws off idle detector."
 		},
 		{
-			"address": "0x0017E6B4",
+			"address": "0x0017E6FC",
 			"value": "0x0",
 			"description": "Removes T1_COUNT read that throws off idle detector (Race Mode)."
 		}


### PR DESCRIPTION
previous address is wrong and typo.
Updated for 2.10j revision.

Conversation started in #1586 PR, for reference.
