### PR TITLE
CMakeLists updated for VS2026 / Qt6 / MacOS 26 / Xcode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 
 # macOS deployment target needs to be set before 'project' to work
 if(APPLE AND NOT TARGET_IOS)
-	set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
+	set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum OS X deployment version")
 endif()
 
 project(Play)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,8 +3,8 @@
     "configurePresets": [
         {
             "name": "VS",
-            "displayName": "Visual Studio 17 2022",
-            "generator": "Visual Studio 17 2022",
+            "displayName": "Visual Studio 18 2026",
+            "generator": "Visual Studio 18 2026",
             "binaryDir": "${sourceDir}/build_cmake/build/${presetName}",
             "hidden": true
         },
@@ -42,6 +42,10 @@
                 "BUILD_PSFPLAYER": {
                     "type": "BOOL",
                     "value": "ON"
+                },
+                "CMAKE_PREFIX_PATH": {
+                    "type": "PATH",
+                    "value": "C:/Qt/6.11.1/msvc2022_64"
                 }
             },
             "hidden": true

--- a/README.md
+++ b/README.md
@@ -151,16 +151,20 @@ To build for Windows you will need to have CMake installed on your system.
  ```
  ```
  # Not specifying -G will automatically generate 32-bit projects.
- cmake .. -G "Visual Studio 18 2026 Win64" -DCMAKE_PREFIX_PATH="C:\Qt\6.10.2\msvc2022_64"
+ cmake .. -G "Visual Studio 18 2026" -DCMAKE_PREFIX_PATH="C:\Qt\6.xx.x\msvc2022_64"
  ```
-
-For Visual Studio 2026 solution, just double click on `Play.slnx` in "build" folder and follow GUI instructions.
 
 You can now build the project by opening the generated Visual Studio Solution or continue through cmdline:
  ```cmd
  cmake --build . --config Release
  ```
 Note: `--config` can be `Release`, `Debug`, or `RelWithDebInfo`.
+
+### For Visual Studio 2026 solution ###
+* Make sure you have installed msvc2022 plugin in `C:\QT\6.xx\msvc2022_64` and remember your Qt6 version.
+* Open `CMakePresets.json` and overwrite your Qt6 version in "CMAKE_PREFIX_PATH" (line 48).
+* After VS2026 configured and loaded cmake, `Play.slnx` automatically generated.
+* Select `Play.exe` and follow GUI instructions.
 
 ### Building for macOS & iOS ###
 If you don't have CMake installed, you can install it using [Homebrew](https://brew.sh) with the following command:

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ First you'll need to clone this repo which contains the emulator source code, al
  git clone --recurse-submodules https://github.com/jpd002/Play-.git
  cd Play-
  ```
+Update all submodule before build to avoid any compatibility issues.
+
+```
+git submodule update --init --recursive
+```
+
 
 ### Building for Windows ###
 The easiest way to build the project on Windows is to open Qt Creator and direct it to the CMake file in `/project/dir/Play-/CMakeLists.txt`.
@@ -180,6 +186,10 @@ There are two ways to generate a build for macOS. Either by using Makefiles, or 
  ```
  # Not specifying -G will automatically pick Makefiles
  cmake .. -G Xcode -DCMAKE_PREFIX_PATH=~/Qt/5.1.0/clang_64/
+ cmake --build . --config Release
+ # OR
+ cd build_cmake/build/macos-xcode
+ cmake --preset macos-xcode -DCMAKE_PREFIX_PATH=~/Qt/6.11.1/macos/
  cmake --build . --config Release
  # OR
  cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=~/Qt/5.1.0/clang_64/

--- a/Source/ui_qt/CMakeLists.txt
+++ b/Source/ui_qt/CMakeLists.txt
@@ -381,3 +381,7 @@ if(TARGET_PLATFORM_WIN32)
 									 "$<TARGET_FILE:Play>"
 	)
 endif()
+
+if(TARGET_PLATFORM_MACOS)
+    target_link_libraries(Play "-framework QuartzCore" "-framework Metal")
+endif()


### PR DESCRIPTION
Minor CMakeLists version adjustment for the latest build environment like VS2026, Qt6.
Also for M1-M5 MacOS, some codes are dated and cause error. 
Now re-optimized for MacOS 26.

I think this will no affects to Qt5 users but if any problems, need to double check.